### PR TITLE
Update SkypatrolProtocolDecoder.java

### DIFF
--- a/src/org/traccar/protocol/SkypatrolProtocolDecoder.java
+++ b/src/org/traccar/protocol/SkypatrolProtocolDecoder.java
@@ -47,9 +47,12 @@ public class SkypatrolProtocolDecoder extends BaseProtocolDecoder {
             sign = -1;
             coordinate = 0xffffffffl - coordinate;
         }
-
-        double degrees = coordinate / 1000000;
-        degrees += (coordinate % 1000000) / 600000.0;
+        
+        double coordinateDouble = coordinate;
+        double degrees = coordinateDouble / 1000000;
+        
+        //TODO REMOVE THIS LINE
+        //degrees += (coordinate % 1000000) / 600000.0;
 
         return sign * degrees;
     }


### PR DESCRIPTION
The method convertCoordinate is inaccurate when obtaining the right side of the decimal dot, assigning coordinate variable to a double variable and then applying the divide by 1000000 operation solves the problem.