### PR TITLE
Update GotopProtocolDecoder.java

### DIFF
--- a/src/org/traccar/protocol/GotopProtocolDecoder.java
+++ b/src/org/traccar/protocol/GotopProtocolDecoder.java
@@ -46,7 +46,7 @@ public class GotopProtocolDecoder extends BaseProtocolDecoder {
             "LOT:(\\d+.\\d+)([EW])," +          // Longitude
             "Speed:(\\d+.\\d+)," +              // Speed
             "([^,]+)," +                        // Status
-            "(\\d+)?" +                         // Course
+            "(\\d+)," +                         // Course
             ".*");
 
     @Override


### PR DESCRIPTION
I tried with Gotop TL206 and it doesn't work properly. I think I found an error in line 49 of the GotopProtocolDecoder.java. There should be also an comma instead a questionmark. 
Here is the code:#013949008891817,CMD-F,A,DATE:150225,TIME:175441,LAT:50.xxxxxxN,LOT:008.xxxxxxE,Speed:085.9,0-0-0-0-52-31,000,26201-1073-1DF5#