### PR TITLE
Update ServerManager.java

### DIFF
--- a/src/org/traccar/ServerManager.java
+++ b/src/org/traccar/ServerManager.java
@@ -239,6 +239,17 @@ public class ServerManager {
                     pipeline.addLast("objectDecoder", new Gl200ProtocolDecoder(protocol));
                 }
             });
+            
+            serverList.add(new TrackerServer(new ConnectionlessBootstrap(), protocol) {
+                @Override
+                protected void addSpecificHandlers(ChannelPipeline pipeline) {
+                    
+                    pipeline.addLast("frameDecoder",new CharacterDelimiterFrameDecoder(1024, "$", "\0"));
+                    pipeline.addLast("stringDecoder", new StringDecoder());
+                    pipeline.addLast("stringEncoder", new StringEncoder());
+                    pipeline.addLast("objectDecoder", new Gl200ProtocolDecoder(protocol));
+                }
+            });
         }
     }
 

--- a/src/org/traccar/ServerManager.java
+++ b/src/org/traccar/ServerManager.java
@@ -244,7 +244,6 @@ public class ServerManager {
                 @Override
                 protected void addSpecificHandlers(ChannelPipeline pipeline) {
                     
-                    pipeline.addLast("frameDecoder",new CharacterDelimiterFrameDecoder(1024, "$", "\0"));
                     pipeline.addLast("stringDecoder", new StringDecoder());
                     pipeline.addLast("stringEncoder", new StringEncoder());
                     pipeline.addLast("objectDecoder", new Gl200ProtocolDecoder(protocol));


### PR DESCRIPTION
Please allow the Queclink GL200 to support UDP as well as TCP connections.  GL300 model devices (compatible with GL200 protocol, it seems) support UDP mode as well as TCP.  UDP uses less battery though, so may allow the device to run a little bit longer on a charge.