### PR TITLE
Update DataManager.java

### DIFF
--- a/src/org/traccar/database/DataManager.java
+++ b/src/org/traccar/database/DataManager.java
@@ -73,7 +73,7 @@ public class DataManager {
 
         String jndiName = properties.getProperty("database.jndi");
         
-        if(jndi != null) {
+        if(jndiName != null) {
             try {
             DataSource ds = (DataSource) new InitialContext().lookup(jndiName);
             dataSource = ds;

--- a/src/org/traccar/database/DataManager.java
+++ b/src/org/traccar/database/DataManager.java
@@ -94,6 +94,7 @@ public class DataManager {
                 DriverManager.registerDriver(new DriverDelegate(d));
             } else {
                 Class.forName(driver);
+                
             }
         }
         

--- a/src/org/traccar/database/DataManager.java
+++ b/src/org/traccar/database/DataManager.java
@@ -27,6 +27,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.text.ParseException;
 import java.util.*;
+import javax.naming.InitialContext;
 import javax.sql.DataSource;
 
 import org.traccar.Context;
@@ -70,6 +71,17 @@ public class DataManager {
         
         useNewDatabase = Boolean.valueOf(properties.getProperty("http.new"));
 
+        String jndiName = properties.getProperty("database.jndi");
+        
+        if(jndi != null) {
+            try {
+            DataSource ds = (DataSource) new InitialContext().lookup(jndiName);
+            dataSource = ds;
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        } else {
         // Load driver
         String driver = properties.getProperty("database.driver");
         if (driver != null) {
@@ -94,7 +106,7 @@ public class DataManager {
         ds.setIdleConnectionTestPeriod(600);
         ds.setTestConnectionOnCheckin(true);
         dataSource = ds;
-
+        }
         // Load statements from configuration
         String query;
 

--- a/src/org/traccar/database/DataManager.java
+++ b/src/org/traccar/database/DataManager.java
@@ -75,39 +75,40 @@ public class DataManager {
         
         if(jndiName != null) {
             try {
-            DataSource ds = (DataSource) new InitialContext().lookup(jndiName);
-            dataSource = ds;
-
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        } else {
-        // Load driver
-        String driver = properties.getProperty("database.driver");
-        if (driver != null) {
-            String driverFile = properties.getProperty("database.driverFile");
-
-            if (driverFile != null) {
-                URL url = new URL("jar:file:" + new File(driverFile).getAbsolutePath() + "!/");
-                URLClassLoader cl = new URLClassLoader(new URL[]{url});
-                Driver d = (Driver) Class.forName(driver, true, cl).newInstance();
-                DriverManager.registerDriver(new DriverDelegate(d));
-            } else {
-                Class.forName(driver);
-                
+                DataSource ds = (DataSource) new InitialContext().lookup(jndiName);
+                dataSource = ds;
+            } catch (Exception e) {
+                e.printStackTrace();
+                throw e;
             }
+        } else {
+            // Load driver
+            String driver = properties.getProperty("database.driver");
+            
+            if (driver != null) {
+                String driverFile = properties.getProperty("database.driverFile");
+
+                if (driverFile != null) {
+                    URL url = new URL("jar:file:" + new File(driverFile).getAbsolutePath() + "!/");
+                    URLClassLoader cl = new URLClassLoader(new URL[]{url});
+                    Driver d = (Driver) Class.forName(driver, true, cl).newInstance();
+                    DriverManager.registerDriver(new DriverDelegate(d));
+                } else {
+                    Class.forName(driver);
+                }
+            }
+        
+            // Initialize data source
+            ComboPooledDataSource ds = new ComboPooledDataSource();
+            ds.setDriverClass(properties.getProperty("database.driver"));
+            ds.setJdbcUrl(properties.getProperty("database.url"));
+            ds.setUser(properties.getProperty("database.user"));
+            ds.setPassword(properties.getProperty("database.password"));
+            ds.setIdleConnectionTestPeriod(600);
+            ds.setTestConnectionOnCheckin(true);
+            dataSource = ds;
         }
         
-        // Initialize data source
-        ComboPooledDataSource ds = new ComboPooledDataSource();
-        ds.setDriverClass(properties.getProperty("database.driver"));
-        ds.setJdbcUrl(properties.getProperty("database.url"));
-        ds.setUser(properties.getProperty("database.user"));
-        ds.setPassword(properties.getProperty("database.password"));
-        ds.setIdleConnectionTestPeriod(600);
-        ds.setTestConnectionOnCheckin(true);
-        dataSource = ds;
-        }
         // Load statements from configuration
         String query;
 


### PR DESCRIPTION
allow DataManager to use a container provided datasource, as would be the case when being used with Glassfish, where the jdbc datasource is configured in the container, and available via jndi lookup from the InitialContext.