### PR TITLE
Added jetty-jndi dependency to make old GWT based web UI working

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,11 @@
             <artifactId>jetty-webapp</artifactId>
             <version>9.2.13.v20150730</version>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-jndi</artifactId>
+            <version>9.2.13.v20150730</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Current version 3.1 was failing to start JNDI context with following error:

    WARN: Need to specify class name in environment or system property, or as an applet parameter, or in an application resource file:  java.naming.factory.initial - NoInitialContextException (... < WebServer.java:55 < Context.java:125 < Main.java:26 < ...)

This was because of missing JNDI implementation of jetty. In previous version `jetty-all` version was included, which had this implementation included and that's why it was working fine.

Please include it into your codebase to make it compatible with old version of web UI (and my mod in particular).