### PR TITLE
Added smoke test for JNDI context initialisation, in pom.xml jetty version is in property now

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,10 @@
     <name>traccar</name>
     <url>https://www.traccar.org</url>
 
+    <properties>
+        <jetty.version>9.2.13.v20150730</jetty.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -71,22 +75,22 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.2.13.v20150730</version>
+            <version>${jetty.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>9.2.13.v20150730</version>
+            <version>${jetty.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
-            <version>9.2.13.v20150730</version>
+            <version>${jetty.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-jndi</artifactId>
-            <version>9.2.13.v20150730</version>
+            <version>${jetty.version}</version>
         </dependency>
     </dependencies>
 

--- a/test/org/traccar/web/WebServerInitialContextTest.java
+++ b/test/org/traccar/web/WebServerInitialContextTest.java
@@ -1,0 +1,27 @@
+package org.traccar.web;
+
+import org.junit.Test;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.sql.DataSource;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+public class WebServerInitialContextTest {
+    @Test
+    public void smokeTest() throws NamingException {
+        DataSource mockDataSource = (DataSource) Proxy.newProxyInstance(getClass().getClassLoader(),
+                new Class[]{DataSource.class}, new InvocationHandler() {
+                    @Override
+                    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+                        return null;
+                    }
+                });
+
+        Context context = new InitialContext();
+        context.bind("java:/DefaultDS", mockDataSource);
+    }
+}


### PR DESCRIPTION
As we discussed yesterday in #1377 I have added a simple smoke test, which will fail if it won't be able to initialise the JNDI context.

Also I have added `jetty.version` property which is re-used in all jetty dependencies definition since now there are four such records in `pom.xml` file.