### PR TITLE
Initialise API for old interface, added possibility to expose only API

### DIFF
--- a/src/org/traccar/Context.java
+++ b/src/org/traccar/Context.java
@@ -125,12 +125,10 @@ public class Context {
         }
 
         if (config.getBoolean("web.enable")) {
-            if (!config.getBoolean("web.old")) {
+            if (config.getString("web.type", "NEW").equals("NEW") || config.getString("web.type", "NEW").equals("API")) {
                 permissionsManager = new PermissionsManager(dataManager);
-                webServer = new WebServer(config);
-            } else {
-                webServer = new WebServer(config, dataManager.getDataSource());
             }
+            webServer = new WebServer(config, dataManager.getDataSource());
         }
 
         serverManager = new ServerManager();

--- a/src/org/traccar/Context.java
+++ b/src/org/traccar/Context.java
@@ -125,7 +125,7 @@ public class Context {
         }
 
         if (config.getBoolean("web.enable")) {
-            if (config.getString("web.type", "NEW").equals("NEW") || config.getString("web.type", "NEW").equals("API")) {
+            if (config.getString("web.type", "new").equals("new") || config.getString("web.type", "new").equals("api")) {
                 permissionsManager = new PermissionsManager(dataManager);
             }
             webServer = new WebServer(config, dataManager.getDataSource());

--- a/src/org/traccar/database/DataManager.java
+++ b/src/org/traccar/database/DataManager.java
@@ -143,7 +143,7 @@ public class DataManager implements IdentityManager {
 
     private void initDatabaseSchema() throws SQLException {
 
-        if (!config.getBoolean("web.old")) {
+        if (config.getString("web.type", "NEW").equals("NEW") || config.getString("web.type", "NEW").equals("API")) {
 
             Connection connection = dataSource.getConnection();
             ResultSet result = connection.getMetaData().getTables(

--- a/src/org/traccar/database/DataManager.java
+++ b/src/org/traccar/database/DataManager.java
@@ -143,7 +143,7 @@ public class DataManager implements IdentityManager {
 
     private void initDatabaseSchema() throws SQLException {
 
-        if (config.getString("web.type", "NEW").equals("NEW") || config.getString("web.type", "NEW").equals("API")) {
+        if (config.getString("web.type", "new").equals("new") || config.getString("web.type", "new").equals("api")) {
 
             Connection connection = dataSource.getConnection();
             ResultSet result = connection.getMetaData().getTables(

--- a/src/org/traccar/web/WebServer.java
+++ b/src/org/traccar/web/WebServer.java
@@ -53,15 +53,15 @@ public class WebServer {
         this.dataSource = dataSource;
 
         initServer();
-        switch (config.getString("web.type", "NEW")) {
-            case "API":
+        switch (config.getString("web.type", "new")) {
+            case "api":
                 initApi();
                 break;
-            case "NEW":
+            case "new":
                 initApi();
                 initWebApp();
                 break;
-            case "OLD":
+            case "old":
                 initApi();
                 initOldWebApp();
                 break;


### PR DESCRIPTION
Implemented three ways to initialise web server as discussed in #1395:

* with new web application ("web.type" = "NEW")
* with old web application ("web.type" = "OLD")
* only api ("web.type" = "API")

Please check and let me know if you have any questions.