### PR TITLE
Change initialisation order

### DIFF
--- a/src/org/traccar/Context.java
+++ b/src/org/traccar/Context.java
@@ -106,8 +106,6 @@ public class Context {
         }
         identityManager = dataManager;
 
-        connectionManager = new ConnectionManager(dataManager);
-
         if (config.getBoolean("geocoder.enable")) {
             String type = config.getString("geocoder.type", "google");
             String url = config.getString("geocoder.url");
@@ -130,6 +128,8 @@ public class Context {
             }
             webServer = new WebServer(config, dataManager.getDataSource());
         }
+
+        connectionManager = new ConnectionManager(dataManager);
 
         serverManager = new ServerManager();
     }


### PR DESCRIPTION
Right now in `Context.init` method the `connectionManager` initialisation happens before the initialisation of the web application. In the original version it is fine, but in old version (and in my web UI mod) the necessary tables are created by hibernate during web application initialisation. This causes following errors on the first start:

    2015-08-31 17:03:44 WARN: Table ‘traccar.positions’ doesn’t exist - MySQLSyntaxErrorException (… < QueryBuilder.java:289 < DataManager.java:349 < ConnectionManager.java:41 < …)

or

    2015-08-31 16:48:10  WARN: Table "POSITIONS" not found; SQL statement:
    SELECT * FROM positions WHERE id IN (SELECT latestPosition_id FROM devices); [42102-187] - JdbcSQLException (... < QueryBuilder.java:62 < *:132 < DataManager.java:349 < ConnectionManager.java:41 < ...)

Then it requires a second restart to make the application fully working. To avoid this I suggest to change initialisation order so the `connectionManager` will be initialised after the web application initialises and creates database schema. From my understanding this should not break the original application. Please let me know what do you think. Then I can submit a pull request with necessary changes, which are quite simple, just re-order lines in `Context` class.