### PR TITLE
Fix invalid (My)SQL syntax when quoting reserved keywords

### DIFF
--- a/setup/unix/traccar.xml
+++ b/setup/unix/traccar.xml
@@ -31,7 +31,7 @@
     </entry>
 
     <entry key='database.createSchema'>
-        CREATE TABLE "user" (
+        CREATE TABLE `user` (
         id INT PRIMARY KEY AUTO_INCREMENT,
         name VARCHAR(128) NOT NULL,
         email VARCHAR(128) NOT NULL UNIQUE,
@@ -59,9 +59,9 @@
         CREATE TABLE user_device (
         userId INT NOT NULL,
         deviceId INT NOT NULL,
-        "read" BIT DEFAULT 1 NOT NULL,
-        "write" BIT DEFAULT 1 NOT NULL,
-        FOREIGN KEY (userId) REFERENCES "user" (id) ON DELETE CASCADE,
+        `read` BIT DEFAULT 1 NOT NULL,
+        `write` BIT DEFAULT 1 NOT NULL,
+        FOREIGN KEY (userId) REFERENCES `user` (id) ON DELETE CASCADE,
         FOREIGN KEY (deviceId) REFERENCES device (id) ON DELETE CASCADE);
 
         CREATE INDEX user_device_userId ON user_device(userId);
@@ -140,26 +140,26 @@
     </entry>
 
     <entry key='database.loginUser'>
-        SELECT * FROM "user"
+        SELECT * FROM `user`
         WHERE email = :email;
     </entry>
 
     <entry key='database.selectUser'>
-        SELECT * FROM "user"
+        SELECT * FROM `user`
         WHERE id = :id;
     </entry>
 
     <entry key='database.selectUsersAll'>
-        SELECT * FROM "user";
+        SELECT * FROM `user`;
     </entry>
 
     <entry key='database.insertUser'>
-        INSERT INTO "user" (name, email, hashedPassword, salt, admin)
+        INSERT INTO `user` (name, email, hashedPassword, salt, admin)
         VALUES (:name, :email, :hashedPassword, :salt, :admin);
     </entry>
 
     <entry key='database.updateUser'>
-        UPDATE "user" SET
+        UPDATE `user` SET
         name = :name,
         email = :email,
         admin = :admin,
@@ -174,11 +174,11 @@
     </entry>
 
     <entry key='database.updateUserPassword'>
-        UPDATE "user" SET hashedPassword = :hashedPassword, salt = :salt WHERE id = :id;
+        UPDATE `user` SET hashedPassword = :hashedPassword, salt = :salt WHERE id = :id;
     </entry>
     
     <entry key='database.deleteUser'>
-        DELETE FROM "user" WHERE id = :id;
+        DELETE FROM `user` WHERE id = :id;
     </entry>
 
     <entry key='database.getPermissionsAll'>


### PR DESCRIPTION
Hi folks,

I'm quite irritated by the SQL used to create the traccar database. Obviously there has gone some effort into quoting reserved keywords (though not all, for example, in MySQL, "status" in the device table would be another reserved keyword that is left unquoted) but the wrong delimiter for reserved keywords has been used - " instead of `.

Let me be clear on this: I gather the SQL in the file does currently work with the database driver used in traccar (that maybe fixes this on-the-fly, because my initial database has been created), but in itself, this is no valid MySQL (this is fixed by this commit). I don't know, whether there may be another delimiter for MSSQL or ORACLE, but as stated in 

> https://dev.mysql.com/doc/refman/5.5/en/keywords.html

the ` character is the one to turn to when using reserved keywords in MySQL.

This may be a bigger issue and other database folks (like MSSQL or ORACLE) might want to get involved.

Cheers
Thomas