### PR TITLE
Another version of GlobalSat protocol

### DIFF
--- a/src/org/traccar/protocol/GlobalSatProtocolDecoder.java
+++ b/src/org/traccar/protocol/GlobalSatProtocolDecoder.java
@@ -190,7 +190,7 @@ public class GlobalSatProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+.?d*),")                 // altitude
             .number("(d+.?d*),")                 // speed
             .number("(d+.?d*)?,")                // course
-            .number("(d+)[,\\*]")                  // satellites
+            .number("(d+)[,*]")                  // satellites
             .number("(d+.?d*)")                  // hdop
             .compile();
 

--- a/src/org/traccar/protocol/GlobalSatProtocolDecoder.java
+++ b/src/org/traccar/protocol/GlobalSatProtocolDecoder.java
@@ -180,7 +180,7 @@ public class GlobalSatProtocolDecoder extends BaseProtocolDecoder {
             .text("$")
             .number("(d+),")                     // imei
             .number("d+,")                       // mode
-            .number("(d+),")                      // fix
+            .number("(d+),")                     // fix
             .number("(dd)(dd)(dd),")             // date (ddmmyy)
             .number("(dd)(dd)(dd),")             // time (hhmmss)
             .expression("([EW])")
@@ -189,8 +189,8 @@ public class GlobalSatProtocolDecoder extends BaseProtocolDecoder {
             .number("(dd)(dd.d+),")              // latitude (ddmm.mmmm)
             .number("(d+.?d*),")                 // altitude
             .number("(d+.?d*),")                 // speed
-            .number("(d*.?d*),")                 // course
-            .number("(d+)[,\\\\*]")              // satellites
+            .number("(d+.?d*)?,")                // course
+            .number("(d+)[,\\*]")                  // satellites
             .number("(d+.?d*)")                  // hdop
             .compile();
 
@@ -220,8 +220,7 @@ public class GlobalSatProtocolDecoder extends BaseProtocolDecoder {
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN));
         position.setAltitude(parser.nextDouble());
         position.setSpeed(parser.nextDouble());
-        String course = parser.next();
-        position.setCourse(course.isEmpty() ? 0d : Double.parseDouble(course));
+        position.setCourse(parser.nextDouble());
 
         position.set(Event.KEY_SATELLITES, parser.nextInt());
         position.set(Event.KEY_HDOP, parser.next());

--- a/src/org/traccar/protocol/GlobalSatProtocolDecoder.java
+++ b/src/org/traccar/protocol/GlobalSatProtocolDecoder.java
@@ -180,7 +180,7 @@ public class GlobalSatProtocolDecoder extends BaseProtocolDecoder {
             .text("$")
             .number("(d+),")                     // imei
             .number("d+,")                       // mode
-            .number("(d),")                      // fix
+            .number("(d+),")                      // fix
             .number("(dd)(dd)(dd),")             // date (ddmmyy)
             .number("(dd)(dd)(dd),")             // time (hhmmss)
             .expression("([EW])")
@@ -189,8 +189,8 @@ public class GlobalSatProtocolDecoder extends BaseProtocolDecoder {
             .number("(dd)(dd.d+),")              // latitude (ddmm.mmmm)
             .number("(d+.?d*),")                 // altitude
             .number("(d+.?d*),")                 // speed
-            .number("(d+.?d*),")                 // course
-            .number("(d+),")                     // satellites
+            .number("(d*.?d*),")                 // course
+            .number("(d+)[,\\\\*]")              // satellites
             .number("(d+.?d*)")                  // hdop
             .compile();
 
@@ -209,7 +209,7 @@ public class GlobalSatProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(getDeviceId());
 
-        position.setValid(parser.next().equals("1"));
+        position.setValid(!parser.next().equals("1"));
 
         DateBuilder dateBuilder = new DateBuilder()
                 .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt())
@@ -220,7 +220,8 @@ public class GlobalSatProtocolDecoder extends BaseProtocolDecoder {
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN));
         position.setAltitude(parser.nextDouble());
         position.setSpeed(parser.nextDouble());
-        position.setCourse(parser.nextDouble());
+        String course = parser.next();
+        position.setCourse(course.isEmpty() ? 0d : Double.parseDouble(course));
 
         position.set(Event.KEY_SATELLITES, parser.nextInt());
         position.set(Event.KEY_HDOP, parser.next());

--- a/test/org/traccar/protocol/GlobalSatProtocolDecoderTest.java
+++ b/test/org/traccar/protocol/GlobalSatProtocolDecoderTest.java
@@ -2,6 +2,9 @@ package org.traccar.protocol;
 
 import org.junit.Test;
 import org.traccar.ProtocolDecoderTest;
+import org.traccar.helper.PatternBuilder;
+
+import java.util.regex.Pattern;
 
 public class GlobalSatProtocolDecoderTest extends ProtocolDecoderTest {
 
@@ -46,6 +49,13 @@ public class GlobalSatProtocolDecoderTest extends ProtocolDecoderTest {
         verifyPosition(decoder, text(
                 "GSr,GTR-128,013227006963064,0080,1,a080,3,190615,163816,W07407.7134,N0440.8601,2579,0.01,130,12,0.7,11540mV,0,77,14,\"732,123,0744,2fc1,41,23\",\"732,123,0744,2dfe,05,28\",\"732,123,0744,272a,15,21\",\"732,123,0744,2f02,27,23\"*3b!"));
 
+        verifyPosition(decoder, text(
+                "$80050377796567,0,13,281015,173437,E08513.28616,N5232.85432,222.3,0.526,,07*37"
+        ), position("2015-10-28 17:34:37.000", true, 52.54757, 85.22144));
+
+        verifyPosition(decoder, text(
+                "$80050377796567,0,18,281015,191919,E08513.93290,N5232.42141,193.4,37.647,305.40,07*37"
+        ), position("2015-10-28 19:19:19.000", true, 52.54036, 85.23222));
     }
 
 }

--- a/test/org/traccar/protocol/GlobalSatProtocolDecoderTest.java
+++ b/test/org/traccar/protocol/GlobalSatProtocolDecoderTest.java
@@ -2,9 +2,6 @@ package org.traccar.protocol;
 
 import org.junit.Test;
 import org.traccar.ProtocolDecoderTest;
-import org.traccar.helper.PatternBuilder;
-
-import java.util.regex.Pattern;
 
 public class GlobalSatProtocolDecoderTest extends ProtocolDecoderTest {
 


### PR DESCRIPTION
I have a weird device [euspro sf-400](http://eus.com.ua/gps-monitoring/gps-tracker-sf400.html), which I want to connect with traccar. Unfortunately it does not have a protocol documentation, so I decided to break bad and just write to some port and read messages. Fortunately (I hope) the protocol has text format. Here are couple of message examples:

    $80050377796567,0,13,281015,173437,E08513.28616,N5232.85432,222.3,0.526,,07*37!

    $80050377796567,0,18,281015,191919,E08513.93290,N5232.42141,193.4,37.647,305.40,07*37!

(_I have replaced real IMEI and lon/lat numbers, but other fields were left untouched_)

The message format looks very close to the "alternative" version of `globalsat` protocol. However, there are couple of differences:

1) `fix` has something different (two digits number, `13` and `18` in these cases) and I don't think it should be used for identification whether received position or not.

2) `course` may be missing like in first message

3) I am not sure about last parameter `07*37`, but it looks like it is the number of satellites and the [HDOP](http://www.globalsat.ru/faq/gps_trekery_globalsat_tr-151_faq/tr_151_i_hdop) parameter separated with asterisk.

Here is my updated pattern of `globalsat` alternative for this protocol:

````java
    private static final Pattern PATTERN = new PatternBuilder()
            .txt("$")
            .num("(d+),")                        // imei
            .num("d+,")                          // mode
            .num("(d+),")                         // fix
            .num("(dd)(dd)(dd),")                // date (ddmmyy)
            .num("(dd)(dd)(dd),")                // time (hhmmss)
            .xpr("([EW])")
            .num("(ddd)(dd.d+),")                // longitude (dddmm.mmmm)
            .xpr("([NS])")
            .num("(dd)(dd.d+),")                 // latitude (ddmm.mmmm)
            .num("(d+.?d*),")                    // altitude
            .num("(d+.?d*),")                    // speed
            .num("(d*.?d*),")                    // course
            .num("(d+)[,\\*]")                   // satellites
            .num("(d+.?d*)")                     // hdop
            .compile();
````

So, what should I do? Update the pattern of the `globalsat` protocol or add the new one? Please advise.