### PR TITLE
Commands sending integration

### DIFF
--- a/src/org/traccar/Context.java
+++ b/src/org/traccar/Context.java
@@ -168,10 +168,7 @@ public final class Context {
         }
 
         if (config.getBoolean("web.enable")) {
-            if (config.getString("web.type", "new").equals("new")
-                    || config.getString("web.type", "new").equals("api")) {
-                permissionsManager = new PermissionsManager(dataManager);
-            }
+            permissionsManager = new PermissionsManager(dataManager);
             webServer = new WebServer(config, dataManager.getDataSource());
         }
 

--- a/src/org/traccar/web/WebServer.java
+++ b/src/org/traccar/web/WebServer.java
@@ -24,9 +24,11 @@ import javax.sql.DataSource;
 
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.SessionManager;
 import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
+import org.eclipse.jetty.server.session.HashSessionManager;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.webapp.WebAppContext;
@@ -53,6 +55,7 @@ public class WebServer {
     private final Config config;
     private final DataSource dataSource;
     private final HandlerList handlers = new HandlerList();
+    private final SessionManager sessionManager = new HashSessionManager();
 
     private void initServer() {
 
@@ -119,6 +122,7 @@ public class WebServer {
 
         WebAppContext app = new WebAppContext();
         app.setContextPath("/");
+        app.getSessionHandler().setSessionManager(sessionManager);
         app.setWar(config.getString("web.application"));
         handlers.addHandler(app);
     }
@@ -126,6 +130,7 @@ public class WebServer {
     private void initApi() {
         ServletContextHandler servletHandler = new ServletContextHandler(ServletContextHandler.SESSIONS);
         servletHandler.setContextPath("/api");
+        servletHandler.getSessionHandler().setSessionManager(sessionManager);
 
         servletHandler.addServlet(new ServletHolder(new AsyncSocketServlet()), "/socket");
 
@@ -144,6 +149,8 @@ public class WebServer {
     private void initOldApi() {
         ServletContextHandler servletHandler = new ServletContextHandler(ServletContextHandler.SESSIONS);
         servletHandler.setContextPath("/api");
+        servletHandler.getSessionHandler().setSessionManager(sessionManager);
+        
         servletHandler.addServlet(new ServletHolder(new AsyncServlet()), "/async/*");
         servletHandler.addServlet(new ServletHolder(new ServerServlet()), "/server/*");
         servletHandler.addServlet(new ServletHolder(new UserServlet()), "/user/*");


### PR DESCRIPTION
I want to implement a possibility to send commands from my Traccar Web UI mod. Some time ago I have already sent a pull request that allows to run both `traccar-web.war` and original traccar API for the same purpose. However, during implementation I have faced following issues:

* HTTP sessions are not shared between API and web app deployed from `traccar-web.war`. I suggest to share them.
* permissions manager object is required to validate permissions on the API side. However, it is not being initialized in 'old' web app mode. So it should be initialized if any web app is going to be started.
* the key used to look up for a user identifier in HTTP session changed from 3.2 (from `user` to `userId`). For the compatibility purpose I think that, if possible, we can stick with the `userId` attribute name and don't change it in future and if the storage format will change then leave the attribute name, and introduce new one as needed.

What do you think? I can submit a pull request with the changes. Actually they are very small, say "cosmetic" changes.