### PR TITLE
Handle OPTIONS preflight for CORS, FIX issue 1751

### DIFF
--- a/src/org/traccar/api/CorsResponseFilter.java
+++ b/src/org/traccar/api/CorsResponseFilter.java
@@ -37,7 +37,7 @@ public class CorsResponseFilter implements ContainerResponseFilter {
     public static final String ACCESS_CONTROL_ALLOW_CREDENTIALS_VALUE = "true";
 
     public static final String ACCESS_CONTROL_ALLOW_METHODS_KEY = "Access-Control-Allow-Methods";
-    public static final String ACCESS_CONTROL_ALLOW_METHODS_VALUE = "GET, POST, PUT, DELETE";
+    public static final String ACCESS_CONTROL_ALLOW_METHODS_VALUE = "GET, POST, PUT, DELETE, OPTIONS";
 
     @Override
     public void filter(ContainerRequestContext request, ContainerResponseContext response) throws IOException {
@@ -54,11 +54,9 @@ public class CorsResponseFilter implements ContainerResponseFilter {
         if (!response.getHeaders().containsKey(ACCESS_CONTROL_ALLOW_ORIGIN_KEY)) {
             String origin = request.getHeaderString(HttpHeaders.Names.ORIGIN);
             String allowed = Context.getConfig().getString("web.origin");
-            if (allowed == null) {
-                response.getHeaders().add(ACCESS_CONTROL_ALLOW_ORIGIN_KEY, ACCESS_CONTROL_ALLOW_ORIGIN_VALUE);
-            } else if (allowed.contains(origin)) {
-                String originSafe = URLEncoder.encode(origin, StandardCharsets.UTF_8.name());
-                response.getHeaders().add(ACCESS_CONTROL_ALLOW_ORIGIN_KEY, originSafe);
+            if (allowed == null || allowed == ACCESS_CONTROL_ALLOW_ORIGIN_VALUE || allowed.contains(origin)) {
+                String originResponse = origin == null ? ACCESS_CONTROL_ALLOW_ORIGIN_VALUE : origin;
+                response.getHeaders().add(ACCESS_CONTROL_ALLOW_ORIGIN_KEY, originResponse);
             }
         }
     }

--- a/src/org/traccar/api/SecurityRequestFilter.java
+++ b/src/org/traccar/api/SecurityRequestFilter.java
@@ -55,6 +55,11 @@ public class SecurityRequestFilter implements ContainerRequestFilter {
 
     @Override
     public void filter(ContainerRequestContext requestContext) {
+
+        if (requestContext.getMethod() == "OPTIONS") {
+            throw new WebApplicationException(Response.status(Response.Status.OK).entity("").build());
+        }
+
         SecurityContext securityContext = null;
 
         String authHeader = requestContext.getHeaderString(AUTHORIZATION_HEADER);


### PR DESCRIPTION
* Change to CORS handling to handle pre-flight OPTIONS requests.
* Fix to return origin correctly in the "Access-Control-Allow-Origin" header.
* Returns the origin rather than "*" to allow basic auth to function. This behavior can be disabled by setting "web.origin" to any value which will never match a hostname sent by the browser. e.g. "<entry key='web.origin'>DISABLED</entry>"
