### PR TITLE
Add new OpenGTS protocol for Android mendhak/gpslogger client

### DIFF
--- a/src/org/traccar/protocol/OpenGTSProtocol.java
+++ b/src/org/traccar/protocol/OpenGTSProtocol.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 Anton Tananaev (anton.tananaev@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.protocol;
+
+import org.jboss.netty.bootstrap.ConnectionlessBootstrap;
+import org.jboss.netty.channel.ChannelPipeline;
+import org.jboss.netty.handler.codec.frame.LineBasedFrameDecoder;
+import org.jboss.netty.handler.codec.string.StringDecoder;
+import org.jboss.netty.handler.codec.string.StringEncoder;
+import org.traccar.BaseProtocol;
+import org.traccar.TrackerServer;
+
+import java.util.List;
+
+public class OpenGTSProtocol extends BaseProtocol {
+
+    public OpenGTSProtocol() {
+        super("opengts");
+    }
+
+    @Override
+    public void initTrackerServers(List<TrackerServer> serverList) {
+        serverList.add(new TrackerServer(new ConnectionlessBootstrap(), this.getName()) {
+            @Override
+            protected void addSpecificHandlers(ChannelPipeline pipeline) {
+                pipeline.addLast("stringEncoder", new StringEncoder());
+                pipeline.addLast("stringDecoder", new StringDecoder());
+                pipeline.addLast("objectDecoder", new OpenGTSProtocolDecoder(OpenGTSProtocol.this));
+            }
+        });
+    }
+}

--- a/src/org/traccar/protocol/OpenGTSProtocolDecoder.java
+++ b/src/org/traccar/protocol/OpenGTSProtocolDecoder.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2012 - 2015 Anton Tananaev (anton.tananaev@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.protocol;
+
+import java.net.SocketAddress;
+import java.util.Date;
+import java.util.regex.Pattern;
+import org.jboss.netty.channel.Channel;
+import org.traccar.BaseProtocolDecoder;
+import org.traccar.helper.DateBuilder;
+import org.traccar.helper.Parser;
+import org.traccar.helper.PatternBuilder;
+import org.traccar.model.Event;
+import org.traccar.model.Position;
+
+public class OpenGTSProtocolDecoder extends BaseProtocolDecoder {
+
+    public OpenGTSProtocolDecoder(OpenGTSProtocol protocol) {
+        super(protocol);
+    }
+
+    private static final Pattern PATTERN = new PatternBuilder()
+            .expression("([^/])*/")
+//          .number("(d+)/")                     // user
+            .number("(d+)/")                     // id
+            .text("$GPRMC,")
+            .number("(dd)(dd)(dd).?d*,")         // time
+            .expression("([AV]),")               // validity
+            .number("(dd)(dd.d+),")              // latitude
+            .expression("([NS]),")
+            .number("(d{2,3})(dd.d+),")          // longitude
+            .expression("([EW]),")
+            .number("(d+.?d*)?,")                // speed
+            .number("(d+.?d*)?,")                // course
+            .number("(dd)(dd)(dd),")             // date
+            .text(",")
+            .text("*").number("xx")
+            .any()
+            .compile();
+
+    @Override
+    protected Object decode(
+            Channel channel, SocketAddress remoteAddress, Object msg) throws Exception {
+
+        Parser parser = new Parser(PATTERN, (String) msg);
+        if (!parser.matches()) {
+            return null;
+        }
+
+        Position position = new Position();
+        position.setProtocol(getProtocolName());
+
+        parser.next();
+        if (!identify(parser.next(), channel, remoteAddress)) {
+            return null;
+        }
+        position.setDeviceId(getDeviceId());
+
+        DateBuilder dateBuilder = new DateBuilder()
+                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
+
+        position.setValid(parser.next().equals("A"));
+        position.setLatitude(parser.nextCoordinate());
+        position.setLongitude(parser.nextCoordinate());
+        position.setSpeed(parser.nextDouble());
+        position.setCourse(parser.nextDouble());
+
+        dateBuilder.setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt());
+        position.setTime(dateBuilder.getDate());
+
+        return position;
+    }
+}

--- a/test/org/traccar/protocol/OpenGTSProtocolDecoderTest.java
+++ b/test/org/traccar/protocol/OpenGTSProtocolDecoderTest.java
@@ -1,0 +1,17 @@
+package org.traccar.protocol;
+
+import org.junit.Test;
+import org.traccar.ProtocolTest;
+
+public class OpenGTSProtocolDecoderTest extends ProtocolTest {
+
+    @Test
+    public void testDecode() throws Exception {
+
+        OpenGTSProtocolDecoder decoder = new OpenGTSProtocolDecoder(new OpenGTSProtocol());
+
+        verifyPosition(decoder, text(
+                "4711/022789000688081/$GPRMC,133343,A,5308.56325,N,1029.12850,E,0.000000,0.000000,290316,,*2A"));
+    }
+
+}


### PR DESCRIPTION
I created an additional one:
- because t55 is already pretty bloated with various variants
- because mendhak/gpslogger does not terminate the message with a newline, thus no seperator
- because I prefer udp over tcp/http

No need to merge, this is just for information. I can understand if you would like to keep protocol inflation down...