### PR TITLE
Fix "Requests to this API must be over SSL" when use API Key

### DIFF
--- a/src/org/traccar/geocode/GoogleReverseGeocoder.java
+++ b/src/org/traccar/geocode/GoogleReverseGeocoder.java
@@ -30,7 +30,7 @@ public class GoogleReverseGeocoder extends JsonReverseGeocoder {
     }
 
     public GoogleReverseGeocoder(String key, int cacheSize) {
-        super("http://maps.googleapis.com/maps/api/geocode/json?latlng=%f,%f&key=" + key, cacheSize);
+        super("https://maps.googleapis.com/maps/api/geocode/json?latlng=%f,%f&key=" + key, cacheSize);
     }
 
     @Override


### PR DESCRIPTION
When is set geocoder google and `geocoder.key` , the API response is:

```json
{
   "error_message" : "Requests to this API must be over SSL. Load the API with \"https://\" instead of \"http://\".",
   "results" : [],
   "status" : "REQUEST_DENIED"
}
```