### PR TITLE
Lock EOL to "lf" to avoid warnings on windows platform

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -9,7 +9,9 @@
 
     <!-- Checks whether files end with a new line.                        -->
     <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
-    <module name="NewlineAtEndOfFile"/>
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf" />
+    </module>
 
     <!-- Checks that property files contain the same keys.         -->
     <!-- See http://checkstyle.sf.net/config_misc.html#Translation -->


### PR DESCRIPTION
It is need to lock EOL to "lf" because there is false warning about absent EOL at the end of file on windows  platform.