### PR TITLE
Store command result to position for wondex

### DIFF
--- a/src/org/traccar/MainEventHandler.java
+++ b/src/org/traccar/MainEventHandler.java
@@ -51,7 +51,7 @@ public class MainEventHandler extends IdleStateAwareChannelHandler {
             s.append("speed: ").append(String.format("%.1f", position.getSpeed())).append(", ");
             s.append("course: ").append(String.format("%.1f", position.getCourse()));
             if ((position.getAttributes().get(Event.KEY_RESULT) != null)) {
-                s.append(", result:").append(position.getAttributes().get(Event.KEY_RESULT));
+                s.append(", result: ").append(position.getAttributes().get(Event.KEY_RESULT));
             }
             Log.info(s.toString());
 

--- a/src/org/traccar/MainEventHandler.java
+++ b/src/org/traccar/MainEventHandler.java
@@ -50,8 +50,9 @@ public class MainEventHandler extends IdleStateAwareChannelHandler {
             s.append("lon: ").append(String.format("%.5f", position.getLongitude())).append(", ");
             s.append("speed: ").append(String.format("%.1f", position.getSpeed())).append(", ");
             s.append("course: ").append(String.format("%.1f", position.getCourse()));
-            if ((position.getAttributes().get(Event.KEY_RESULT) != null)) {
-                s.append(", result: ").append(position.getAttributes().get(Event.KEY_RESULT));
+            Object cmdResult = position.getAttributes().get(Event.KEY_RESULT);
+            if (cmdResult != null) {
+                s.append(", result: ").append(cmdResult);
             }
             Log.info(s.toString());
 

--- a/src/org/traccar/MainEventHandler.java
+++ b/src/org/traccar/MainEventHandler.java
@@ -24,6 +24,7 @@ import org.jboss.netty.channel.socket.DatagramChannel;
 import org.jboss.netty.handler.timeout.IdleStateAwareChannelHandler;
 import org.jboss.netty.handler.timeout.IdleStateEvent;
 import org.traccar.helper.Log;
+import org.traccar.model.Event;
 import org.traccar.model.Position;
 
 import java.text.SimpleDateFormat;
@@ -49,6 +50,9 @@ public class MainEventHandler extends IdleStateAwareChannelHandler {
             s.append("lon: ").append(String.format("%.5f", position.getLongitude())).append(", ");
             s.append("speed: ").append(String.format("%.1f", position.getSpeed())).append(", ");
             s.append("course: ").append(String.format("%.1f", position.getCourse()));
+            if ((position.getAttributes().get(Event.KEY_RESULT) != null)) {
+                s.append(", result:").append(position.getAttributes().get(Event.KEY_RESULT));
+            }
             Log.info(s.toString());
 
             Position lastPosition = Context.getConnectionManager().getLastPosition(position.getDeviceId());

--- a/src/org/traccar/model/Event.java
+++ b/src/org/traccar/model/Event.java
@@ -58,6 +58,8 @@ public abstract class Event extends Extensible {
     public static final String KEY_OBD_SPEED = "obd-speed";
     public static final String KEY_OBD_ODOMETER = "obd-odometer";
 
+    public static final String KEY_RESULT = "result";
+
     // Starts with 1 not 0
     public static final String PREFIX_TEMP = "temp";
     public static final String PREFIX_ADC = "adc";

--- a/src/org/traccar/protocol/WondexFrameDecoder.java
+++ b/src/org/traccar/protocol/WondexFrameDecoder.java
@@ -15,7 +15,9 @@
  */
 package org.traccar.protocol;
 
+import java.nio.charset.StandardCharsets;
 import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.ChannelBuffers;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.handler.codec.frame.FrameDecoder;
@@ -40,6 +42,9 @@ public class WondexFrameDecoder extends FrameDecoder {
             if (channel != null) {
                 channel.write(frame);
             }
+            // Pass deviceId to protocol decoder
+            long deviceId = ((Long.reverseBytes((frame.getLong(0)))) >> 32) & 0xFFFFFFFFL;
+            return ChannelBuffers.copiedBuffer("$ID:"+String.valueOf(deviceId), StandardCharsets.US_ASCII);
 
         } else {
 

--- a/src/org/traccar/protocol/WondexFrameDecoder.java
+++ b/src/org/traccar/protocol/WondexFrameDecoder.java
@@ -15,9 +15,7 @@
  */
 package org.traccar.protocol;
 
-import java.nio.charset.StandardCharsets;
 import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.buffer.ChannelBuffers;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.handler.codec.frame.FrameDecoder;
@@ -42,9 +40,7 @@ public class WondexFrameDecoder extends FrameDecoder {
             if (channel != null) {
                 channel.write(frame);
             }
-            // Pass deviceId to protocol decoder
-            long deviceId = ((Long.reverseBytes((frame.getLong(0)))) >> 32) & 0xFFFFFFFFL;
-            return ChannelBuffers.copiedBuffer("$ID:" + String.valueOf(deviceId), StandardCharsets.US_ASCII);
+            return frame;
 
         } else {
 

--- a/src/org/traccar/protocol/WondexFrameDecoder.java
+++ b/src/org/traccar/protocol/WondexFrameDecoder.java
@@ -44,7 +44,7 @@ public class WondexFrameDecoder extends FrameDecoder {
             }
             // Pass deviceId to protocol decoder
             long deviceId = ((Long.reverseBytes((frame.getLong(0)))) >> 32) & 0xFFFFFFFFL;
-            return ChannelBuffers.copiedBuffer("$ID:"+String.valueOf(deviceId), StandardCharsets.US_ASCII);
+            return ChannelBuffers.copiedBuffer("$ID:" + String.valueOf(deviceId), StandardCharsets.US_ASCII);
 
         } else {
 

--- a/src/org/traccar/protocol/WondexProtocol.java
+++ b/src/org/traccar/protocol/WondexProtocol.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.bootstrap.ConnectionlessBootstrap;
 import org.jboss.netty.bootstrap.ServerBootstrap;
 import org.jboss.netty.channel.ChannelPipeline;
-import org.jboss.netty.handler.codec.string.StringDecoder;
 import org.jboss.netty.handler.codec.string.StringEncoder;
 import org.traccar.BaseProtocol;
 import org.traccar.TrackerServer;
@@ -42,7 +41,6 @@ public class WondexProtocol extends BaseProtocol {
             protected void addSpecificHandlers(ChannelPipeline pipeline) {
                 pipeline.addLast("frameDecoder", new WondexFrameDecoder());
                 pipeline.addLast("stringEncoder", new StringEncoder());
-                pipeline.addLast("stringDecoder", new StringDecoder());
                 pipeline.addLast("objectEncoder", new WondexProtocolEncoder());
                 pipeline.addLast("objectDecoder", new WondexProtocolDecoder(WondexProtocol.this));
             }
@@ -51,7 +49,6 @@ public class WondexProtocol extends BaseProtocol {
             @Override
             protected void addSpecificHandlers(ChannelPipeline pipeline) {
                 pipeline.addLast("stringEncoder", new StringEncoder());
-                pipeline.addLast("stringDecoder", new StringDecoder());
                 pipeline.addLast("objectEncoder", new WondexProtocolEncoder());
                 pipeline.addLast("objectDecoder", new WondexProtocolDecoder(WondexProtocol.this));
             }

--- a/src/org/traccar/protocol/WondexProtocolDecoder.java
+++ b/src/org/traccar/protocol/WondexProtocolDecoder.java
@@ -61,26 +61,28 @@ public class WondexProtocolDecoder extends BaseProtocolDecoder {
     protected Object decode(
             Channel channel, SocketAddress remoteAddress, Object msg) throws Exception {
 
-        if (((ChannelBuffer) msg).getUnsignedByte(0) == 0xD0) {
+        ChannelBuffer buf = (ChannelBuffer) msg;
 
-            long deviceId = ((Long.reverseBytes((((ChannelBuffer) msg).getLong(0)))) >> 32) & 0xFFFFFFFFL;
+        if (buf.getUnsignedByte(0) == 0xD0) {
+
+            long deviceId = ((Long.reverseBytes(buf.getLong(0))) >> 32) & 0xFFFFFFFFL;
             identify(String.valueOf(deviceId), channel, remoteAddress);
 
             return null;
-        } else if (((ChannelBuffer) msg).toString(StandardCharsets.US_ASCII).startsWith("$OK:")
-            || ((ChannelBuffer) msg).toString(StandardCharsets.US_ASCII).startsWith("$ERR:")) {
+        } else if (buf.toString(StandardCharsets.US_ASCII).startsWith("$OK:")
+            || buf.toString(StandardCharsets.US_ASCII).startsWith("$ERR:")) {
 
             Position position = new Position();
             position.setProtocol(getProtocolName());
             position.setDeviceId(getDeviceId());
             getLastLocation(position, new Date());
             position.setValid(false);
-            position.set(Event.KEY_RESULT, ((ChannelBuffer) msg).toString(StandardCharsets.US_ASCII));
+            position.set(Event.KEY_RESULT, buf.toString(StandardCharsets.US_ASCII));
 
             return position;
         } else {
 
-            Parser parser = new Parser(PATTERN, ((ChannelBuffer) msg).toString(StandardCharsets.US_ASCII));
+            Parser parser = new Parser(PATTERN, buf.toString(StandardCharsets.US_ASCII));
             if (!parser.matches()) {
                 return null;
             }

--- a/src/org/traccar/protocol/WondexProtocolDecoder.java
+++ b/src/org/traccar/protocol/WondexProtocolDecoder.java
@@ -60,17 +60,14 @@ public class WondexProtocolDecoder extends BaseProtocolDecoder {
             Channel channel, SocketAddress remoteAddress, Object msg) throws Exception {
 
         if (((String) msg).startsWith("$ID:")) {
-            identify(((String) msg).substring(4), channel, remoteAddress); 
+            identify(((String) msg).substring(4), channel, remoteAddress);
             return null;
-        }
-
-        else if (((String) msg).startsWith("$OK:") || ((String) msg).startsWith("$ERR:")) {
+        } else if (((String) msg).startsWith("$OK:") || ((String) msg).startsWith("$ERR:")) {
 
             Position position = new Position();
             position.setProtocol(getProtocolName());
             position.setDeviceId(getDeviceId());
-            getLastLocation(position, null);
-            position.setTime(new Date());
+            getLastLocation(position, new Date());
             position.setValid(false);
             position.set(Event.KEY_RESULT, (String) msg);
 

--- a/test/org/traccar/protocol/WondexFrameDecoderTest.java
+++ b/test/org/traccar/protocol/WondexFrameDecoderTest.java
@@ -9,14 +9,17 @@ public class WondexFrameDecoderTest extends ProtocolTest {
     @Test
     public void testDecode() throws Exception {
 
-        Pt502FrameDecoder decoder = new Pt502FrameDecoder();
+        WondexFrameDecoder decoder = new WondexFrameDecoder();
 
         Assert.assertNull(
-                decoder.decode(null, null, binary("d0d70b0001ca9a3b")));
+                decoder.decode(null, null, binary("f0d70b0001ca9a3b")));
 
         Assert.assertEquals(
                 binary("313034343938393630312c32303133303332333039353531352c31332e3537323737362c35322e3430303833382c302c3030302c37322c302c32"),
                 decoder.decode(null, null, binary("313034343938393630312c32303133303332333039353531352c31332e3537323737362c35322e3430303833382c302c3030302c37322c302c320d0a")));
+
+        Assert.assertEquals(binary("2449443a31303030303030303031"),
+                decoder.decode(null, null, binary("d0d70b0001ca9a3b")));
 
     }
 

--- a/test/org/traccar/protocol/WondexFrameDecoderTest.java
+++ b/test/org/traccar/protocol/WondexFrameDecoderTest.java
@@ -18,7 +18,7 @@ public class WondexFrameDecoderTest extends ProtocolTest {
                 binary("313034343938393630312c32303133303332333039353531352c31332e3537323737362c35322e3430303833382c302c3030302c37322c302c32"),
                 decoder.decode(null, null, binary("313034343938393630312c32303133303332333039353531352c31332e3537323737362c35322e3430303833382c302c3030302c37322c302c320d0a")));
 
-        Assert.assertEquals(binary("2449443a31303030303030303031"),
+        Assert.assertEquals(binary("d0d70b0001ca9a3b"),
                 decoder.decode(null, null, binary("d0d70b0001ca9a3b")));
 
     }

--- a/test/org/traccar/protocol/WondexProtocolDecoderTest.java
+++ b/test/org/traccar/protocol/WondexProtocolDecoderTest.java
@@ -23,7 +23,7 @@ public class WondexProtocolDecoderTest extends ProtocolTest {
 
         verifyPosition(decoder, text(
                 "2000000259,20151030145653,69.380826,53.283890,9,10,15,2,1,695,1002.6,108.2,0.0"));
-        
+
         verifyPosition(decoder, text(
                 "1044989601,20130323074605,0.000000,90.000000,0,000,0,0,2"));
 
@@ -38,12 +38,21 @@ public class WondexProtocolDecoderTest extends ProtocolTest {
 
         verifyPosition(decoder, text(
                 "1044989601,20130322172647,13.572583,52.401070,22,204,-49,0,2"));
-        
+
         verifyPosition(decoder, text(
                 "3997324533,20140326074908,28.797603,47.041635,0,48,0,6,2,3.90V,0"));
-        
+
         verifyPosition(decoder, text(
                 "2000000001,20140529213210,-63.179111,9.781493,0,0,54.0,8,2,0.0,0,0.01,0.01,0,0,0,0"));
+
+        verifyNotNull(decoder, text(
+                "$OK:VER=M7 2.003 DVB rev02c,V2"));
+
+        verifyNotNull(decoder, text(
+                "$OK:REBOOT"));
+
+        verifyNotNull(decoder, text(
+                "$ERR:GETLOCATION=1"));
 
     }
 

--- a/test/org/traccar/protocol/WondexProtocolDecoderTest.java
+++ b/test/org/traccar/protocol/WondexProtocolDecoderTest.java
@@ -10,49 +10,52 @@ public class WondexProtocolDecoderTest extends ProtocolTest {
 
         WondexProtocolDecoder decoder = new WondexProtocolDecoder(new WondexProtocol());
 
-        verifyPosition(decoder, text(
+        verifyPosition(decoder, buffer(
                 "2000000108,20151030145404,76.948633,43.354700,0,140,15,100,1,1325,125.4,10.5,0.0"),
                 position("2015-10-30 14:54:04.000", true, 43.35470, 76.94863));
 
-        verifyPosition(decoder, text(
+        verifyPosition(decoder, buffer(
                 "2000000257,20151030145351,69.379976,53.283905,0,0,16,2,0,0,469.1,58.9,0.0"),
                 position("2015-10-30 14:53:51.000", false, 53.28390, 69.37998));
 
-        verifyPosition(decoder, text(
+        verifyPosition(decoder, buffer(
                 "2000000232,20151030145206,51.166900,43.651353,0,132,11,2,0,0,0.0,0.0,0.0"));
 
-        verifyPosition(decoder, text(
+        verifyPosition(decoder, buffer(
                 "2000000259,20151030145653,69.380826,53.283890,9,10,15,2,1,695,1002.6,108.2,0.0"));
 
-        verifyPosition(decoder, text(
+        verifyPosition(decoder, buffer(
                 "1044989601,20130323074605,0.000000,90.000000,0,000,0,0,2"));
 
-        verifyPosition(decoder, text(
+        verifyPosition(decoder, buffer(
                 "123456789000001,20120101123200,130.000000,60.000000,0,000,0,0,0,0"));
 
-        verifyPosition(decoder, text(
+        verifyPosition(decoder, buffer(
                 "210000001,20070313170040,121.123456,12.654321,0,233,0,9,2,0.0,0,0.00,0.00,0"));
 
-        verifyPosition(decoder, text(
+        verifyPosition(decoder, buffer(
                 "1044989601,20130322172647,13.572583,52.401070,22,204,49,0,2"));
 
-        verifyPosition(decoder, text(
+        verifyPosition(decoder, buffer(
                 "1044989601,20130322172647,13.572583,52.401070,22,204,-49,0,2"));
 
-        verifyPosition(decoder, text(
+        verifyPosition(decoder, buffer(
                 "3997324533,20140326074908,28.797603,47.041635,0,48,0,6,2,3.90V,0"));
 
-        verifyPosition(decoder, text(
+        verifyPosition(decoder, buffer(
                 "2000000001,20140529213210,-63.179111,9.781493,0,0,54.0,8,2,0.0,0,0.01,0.01,0,0,0,0"));
 
-        verifyNotNull(decoder, text(
+        verifyNotNull(decoder, buffer(
                 "$OK:VER=M7 2.003 DVB rev02c,V2"));
 
-        verifyNotNull(decoder, text(
+        verifyNotNull(decoder, buffer(
                 "$OK:REBOOT"));
 
-        verifyNotNull(decoder, text(
+        verifyNotNull(decoder, buffer(
                 "$ERR:GETLOCATION=1"));
+
+        verifyNothing(decoder, binary(
+                "d0d70b0001ca9a3b"));
 
     }
 


### PR DESCRIPTION
Firstly I've made a device identification on ping packet (because it is a binary I convert it in the framedecoder to string and pass to the protocoldecoder). It helps to avoid problems then command results came before any positions received and helps to better handle device online status.

Secondly I store command result to "result" field.

And Fixed wrong class name in WondexFrameDecoderTest

It is better to identify device in framedecoder (and don't answer on ping packets) but there is not `remoteAddress` to pass `identify` function.
