### PR TITLE
Notifications via email

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -98,7 +98,6 @@
 
         <!-- Checks for common coding problems               -->
         <!-- See http://checkstyle.sf.net/config_coding.html -->
-        <module name="AvoidInlineConditionals"/>
         <module name="EmptyStatement"/>
         <module name="EqualsHashCode"/>
         <module name="IllegalInstantiation"/>

--- a/debug.xml
+++ b/debug.xml
@@ -52,6 +52,21 @@
 
     <entry key='event.geofenceHandler'>true</entry>
 
+
+    <!--<entry key='mail.smtp.host'>smtp.example.com</entry>
+    for STARTTLS
+    <entry key='mail.smtp.port'>587</entry>
+    <entry key='mail.smtp.starttls.enable'>true</entry>
+    for SSL
+    <entry key='mail.smtp.port'>465</entry>
+    <entry key='mail.smtp.ssl.enable'>true</entry>
+
+    <entry key='mail.smtp.from'>traccar@example.com</entry>
+
+    <entry key='mail.smtp.auth'>true</entry>
+    <entry key='mail.smtp.username'>traccar@example.com</entry>
+    <entry key='mail.smtp.password'>password</entry>-->
+
     <!-- DATABASE CONFIG -->
 
     <!--<entry key='database.driverFile'>hsqldb.jar</entry>-->
@@ -278,6 +293,27 @@
 
     <entry key='database.unlinkDeviceGeofence'>
         DELETE FROM device_geofence WHERE deviceId = :deviceId AND geofenceId = :geofenceId;
+    </entry>
+
+    <entry key='database.selectNotifications'>
+        SELECT * FROM notifications;
+    </entry>
+
+    <entry key='database.insertNotification'>
+        INSERT INTO notifications (userId, type, attributes)
+        VALUES (:userId, :type, :attributes);
+    </entry>
+
+    <entry key='database.updateNotification'>
+        UPDATE notifications SET
+        userId = :userId,
+        type = :type,
+        attributes = :attributes
+        WHERE id = :id;
+    </entry>
+
+    <entry key='database.deleteNotification'>
+        DELETE FROM notifications WHERE id = :id;
     </entry>
 
     <!-- PROTOCOL CONFIG -->

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,12 @@
             <artifactId>liquibase-core</artifactId>
             <version>3.4.2</version>
         </dependency>
+        <dependency>
+            <groupId>javax.mail</groupId>
+            <artifactId>mail</artifactId>
+            <version>1.4.7</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/schema/changelog-3.6.xml
+++ b/schema/changelog-3.6.xml
@@ -90,5 +90,28 @@
     <addForeignKeyConstraint baseTableName="device_geofence" baseColumnNames="deviceid" constraintName="fk_user_device_geofence_deviceid" referencedTableName="devices" referencedColumnNames="id" onDelete="CASCADE" />
     <addForeignKeyConstraint baseTableName="device_geofence" baseColumnNames="geofenceid" constraintName="fk_user_device_geofence_geofenceid" referencedTableName="geofences" referencedColumnNames="id" onDelete="CASCADE" />
 
+    <createTable tableName="notifications">
+      <column name="id" type="INT" autoIncrement="true">
+        <constraints primaryKey="true" />
+      </column>
+      <column name="userid" type="INT">
+        <constraints nullable="false" />
+      </column>
+      <column name="type" type="VARCHAR(128)">
+        <constraints nullable="false" />
+      </column>
+      <column name="attributes" type="VARCHAR(4096)">
+        <constraints nullable="false" />
+      </column>
+    </createTable>
+
+    <addForeignKeyConstraint baseTableName="notifications" baseColumnNames="userid" constraintName="fk_notifications_userid" referencedTableName="users" referencedColumnNames="id" onDelete="CASCADE" />
+
+    <addColumn tableName="users">
+      <column name="attributes" type="VARCHAR(4096)" />
+    </addColumn>
+
+    <addNotNullConstraint tableName="users" columnName="attributes" columnDataType="VARCHAR(4096)" defaultNullValue="{}" />
+
   </changeSet>
 </databaseChangeLog>

--- a/setup/unix/traccar.xml
+++ b/setup/unix/traccar.xml
@@ -28,20 +28,6 @@
 
     <entry key='event.geofenceHandler'>true</entry>
 
-    <!--<entry key='mail.smtp.host'>smtp.example.com</entry>
-    for STARTTLS
-    <entry key='mail.smtp.port'>587</entry>
-    <entry key='mail.smtp.starttls.enable'>true</entry>
-    for SSL
-    <entry key='mail.smtp.port'>465</entry>
-    <entry key='mail.smtp.ssl.enable'>true</entry>
-
-    <entry key='mail.smtp.from'>traccar@example.com</entry>
-
-    <entry key='mail.smtp.auth'>true</entry>
-    <entry key='mail.smtp.username'>traccar@example.com</entry>
-    <entry key='mail.smtp.password'>password</entry>-->
-
     <!-- DATABASE CONFIG -->
 
     <entry key='database.driver'>org.h2.Driver</entry>

--- a/setup/unix/traccar.xml
+++ b/setup/unix/traccar.xml
@@ -28,6 +28,20 @@
 
     <entry key='event.geofenceHandler'>true</entry>
 
+    <!--<entry key='mail.smtp.host'>smtp.example.com</entry>
+    for STARTTLS
+    <entry key='mail.smtp.port'>587</entry>
+    <entry key='mail.smtp.starttls.enable'>true</entry>
+    for SSL
+    <entry key='mail.smtp.port'>465</entry>
+    <entry key='mail.smtp.ssl.enable'>true</entry>
+
+    <entry key='mail.smtp.from'>traccar@example.com</entry>
+
+    <entry key='mail.smtp.auth'>true</entry>
+    <entry key='mail.smtp.username'>traccar@example.com</entry>
+    <entry key='mail.smtp.password'>password</entry>-->
+
     <!-- DATABASE CONFIG -->
 
     <entry key='database.driver'>org.h2.Driver</entry>
@@ -250,6 +264,27 @@
 
     <entry key='database.unlinkDeviceGeofence'>
         DELETE FROM device_geofence WHERE deviceId = :deviceId AND geofenceId = :geofenceId;
+    </entry>
+
+    <entry key='database.selectNotifications'>
+        SELECT * FROM notifications;
+    </entry>
+
+    <entry key='database.insertNotification'>
+        INSERT INTO notifications (userId, type, attributes)
+        VALUES (:userId, :type, :attributes);
+    </entry>
+
+    <entry key='database.updateNotification'>
+        UPDATE notifications SET
+        userId = :userId,
+        type = :type,
+        attributes = :attributes
+        WHERE id = :id;
+    </entry>
+
+    <entry key='database.deleteNotification'>
+        DELETE FROM notifications WHERE id = :id;
     </entry>
 
     <!-- PROTOCOL CONFIG -->

--- a/setup/windows/traccar.xml
+++ b/setup/windows/traccar.xml
@@ -28,20 +28,6 @@
 
     <entry key='event.geofenceHandler'>true</entry>
 
-    <!--<entry key='mail.smtp.host'>smtp.example.com</entry>
-    for STARTTLS
-    <entry key='mail.smtp.port'>587</entry>
-    <entry key='mail.smtp.starttls.enable'>true</entry>
-    for SSL
-    <entry key='mail.smtp.port'>465</entry>
-    <entry key='mail.smtp.ssl.enable'>true</entry>
-
-    <entry key='mail.smtp.from'>traccar@example.com</entry>
-
-    <entry key='mail.smtp.auth'>true</entry>
-    <entry key='mail.smtp.username'>traccar@example.com</entry>
-    <entry key='mail.smtp.password'>password</entry>-->
-
     <!-- DATABASE CONFIG -->
 
     <entry key='database.driver'>org.h2.Driver</entry>

--- a/setup/windows/traccar.xml
+++ b/setup/windows/traccar.xml
@@ -28,6 +28,20 @@
 
     <entry key='event.geofenceHandler'>true</entry>
 
+    <!--<entry key='mail.smtp.host'>smtp.example.com</entry>
+    for STARTTLS
+    <entry key='mail.smtp.port'>587</entry>
+    <entry key='mail.smtp.starttls.enable'>true</entry>
+    for SSL
+    <entry key='mail.smtp.port'>465</entry>
+    <entry key='mail.smtp.ssl.enable'>true</entry>
+
+    <entry key='mail.smtp.from'>traccar@example.com</entry>
+
+    <entry key='mail.smtp.auth'>true</entry>
+    <entry key='mail.smtp.username'>traccar@example.com</entry>
+    <entry key='mail.smtp.password'>password</entry>-->
+
     <!-- DATABASE CONFIG -->
 
     <entry key='database.driver'>org.h2.Driver</entry>
@@ -250,6 +264,27 @@
 
     <entry key='database.unlinkDeviceGeofence'>
         DELETE FROM device_geofence WHERE deviceId = :deviceId AND geofenceId = :geofenceId;
+    </entry>
+
+    <entry key='database.selectNotifications'>
+        SELECT * FROM notifications;
+    </entry>
+
+    <entry key='database.insertNotification'>
+        INSERT INTO notifications (userId, type, attributes)
+        VALUES (:userId, :type, :attributes);
+    </entry>
+
+    <entry key='database.updateNotification'>
+        UPDATE notifications SET
+        userId = :userId,
+        type = :type,
+        attributes = :attributes
+        WHERE id = :id;
+    </entry>
+
+    <entry key='database.deleteNotification'>
+        DELETE FROM notifications WHERE id = :id;
     </entry>
 
     <!-- PROTOCOL CONFIG -->

--- a/src/org/traccar/api/resource/DevicePermissionResource.java
+++ b/src/org/traccar/api/resource/DevicePermissionResource.java
@@ -38,7 +38,9 @@ public class DevicePermissionResource extends BaseResource {
         Context.getPermissionsManager().checkAdmin(getUserId());
         Context.getDataManager().linkDevice(entity.getUserId(), entity.getDeviceId());
         Context.getPermissionsManager().refresh();
-        Context.getGeofenceManager().refresh();
+        if (Context.getGeofenceManager() != null) {
+            Context.getGeofenceManager().refresh();
+        }
         return Response.ok(entity).build();
     }
 
@@ -47,7 +49,9 @@ public class DevicePermissionResource extends BaseResource {
         Context.getPermissionsManager().checkAdmin(getUserId());
         Context.getDataManager().unlinkDevice(entity.getUserId(), entity.getDeviceId());
         Context.getPermissionsManager().refresh();
-        Context.getGeofenceManager().refresh();
+        if (Context.getGeofenceManager() != null) {
+            Context.getGeofenceManager().refresh();
+        }
         return Response.noContent().build();
     }
 

--- a/src/org/traccar/api/resource/DeviceResource.java
+++ b/src/org/traccar/api/resource/DeviceResource.java
@@ -60,7 +60,9 @@ public class DeviceResource extends BaseResource {
         Context.getDataManager().addDevice(entity);
         Context.getDataManager().linkDevice(getUserId(), entity.getId());
         Context.getPermissionsManager().refresh();
-        Context.getGeofenceManager().refresh();
+        if (Context.getGeofenceManager() != null) {
+            Context.getGeofenceManager().refresh();
+        }
         return Response.ok(entity).build();
     }
 
@@ -70,6 +72,9 @@ public class DeviceResource extends BaseResource {
         Context.getPermissionsManager().checkReadonly(getUserId());
         Context.getPermissionsManager().checkDevice(getUserId(), id);
         Context.getDataManager().updateDevice(entity);
+        if (Context.getGeofenceManager() != null) {
+            Context.getGeofenceManager().refresh();
+        }
         return Response.ok(entity).build();
     }
 
@@ -80,7 +85,9 @@ public class DeviceResource extends BaseResource {
         Context.getPermissionsManager().checkDevice(getUserId(), id);
         Context.getDataManager().removeDevice(id);
         Context.getPermissionsManager().refresh();
-        Context.getGeofenceManager().refresh();
+        if (Context.getGeofenceManager() != null) {
+            Context.getGeofenceManager().refresh();
+        }
         return Response.noContent().build();
     }
 

--- a/src/org/traccar/api/resource/GroupPermissionResource.java
+++ b/src/org/traccar/api/resource/GroupPermissionResource.java
@@ -38,7 +38,9 @@ public class GroupPermissionResource extends BaseResource {
         Context.getPermissionsManager().checkAdmin(getUserId());
         Context.getDataManager().linkGroup(entity.getUserId(), entity.getGroupId());
         Context.getPermissionsManager().refresh();
-        Context.getGeofenceManager().refresh();
+        if (Context.getGeofenceManager() != null) {
+            Context.getGeofenceManager().refresh();
+        }
         return Response.ok(entity).build();
     }
 
@@ -47,7 +49,9 @@ public class GroupPermissionResource extends BaseResource {
         Context.getPermissionsManager().checkAdmin(getUserId());
         Context.getDataManager().unlinkGroup(entity.getUserId(), entity.getGroupId());
         Context.getPermissionsManager().refresh();
-        Context.getGeofenceManager().refresh();
+        if (Context.getGeofenceManager() != null) {
+            Context.getGeofenceManager().refresh();
+        }
         return Response.noContent().build();
     }
 

--- a/src/org/traccar/api/resource/GroupResource.java
+++ b/src/org/traccar/api/resource/GroupResource.java
@@ -59,7 +59,9 @@ public class GroupResource extends BaseResource {
         Context.getDataManager().addGroup(entity);
         Context.getDataManager().linkGroup(getUserId(), entity.getId());
         Context.getPermissionsManager().refresh();
-        Context.getGeofenceManager().refresh();
+        if (Context.getGeofenceManager() != null) {
+            Context.getGeofenceManager().refresh();
+        }
         return Response.ok(entity).build();
     }
 
@@ -69,6 +71,9 @@ public class GroupResource extends BaseResource {
         Context.getPermissionsManager().checkReadonly(getUserId());
         Context.getPermissionsManager().checkGroup(getUserId(), id);
         Context.getDataManager().updateGroup(entity);
+        if (Context.getGeofenceManager() != null) {
+            Context.getGeofenceManager().refresh();
+        }
         return Response.ok(entity).build();
     }
 
@@ -79,7 +84,9 @@ public class GroupResource extends BaseResource {
         Context.getPermissionsManager().checkGroup(getUserId(), id);
         Context.getDataManager().removeGroup(id);
         Context.getPermissionsManager().refresh();
-        Context.getGeofenceManager().refresh();
+        if (Context.getGeofenceManager() != null) {
+            Context.getGeofenceManager().refresh();
+        }
         return Response.noContent().build();
     }
 

--- a/src/org/traccar/api/resource/NotificationResource.java
+++ b/src/org/traccar/api/resource/NotificationResource.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Anton Tananaev (anton.tananaev@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.traccar.api.resource;
 
 import java.sql.SQLException;

--- a/src/org/traccar/api/resource/NotificationResource.java
+++ b/src/org/traccar/api/resource/NotificationResource.java
@@ -1,0 +1,44 @@
+package org.traccar.api.resource;
+
+import java.sql.SQLException;
+import java.util.Collection;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.traccar.Context;
+import org.traccar.api.BaseResource;
+import org.traccar.model.Notification;
+
+@Path("users/notifications")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class NotificationResource extends BaseResource {
+
+    @GET
+    public Collection<Notification> get(@QueryParam("all") boolean all,
+            @QueryParam("userId") long userId) throws SQLException {
+        if (all) {
+            return Context.getNotificationManager().getAllNotifications();
+        }
+        if (userId == 0) {
+            userId = getUserId();
+        }
+        Context.getPermissionsManager().checkUser(getUserId(), userId);
+        return Context.getNotificationManager().getUserNotifications(userId);
+    }
+
+    @POST
+    public Response update(Notification entity) throws SQLException {
+        Context.getPermissionsManager().checkReadonly(getUserId());
+        Context.getPermissionsManager().checkUser(getUserId(), entity.getUserId());
+        Context.getNotificationManager().updateNotification(entity);
+        return Response.ok(entity).build();
+    }
+}

--- a/src/org/traccar/api/resource/UserResource.java
+++ b/src/org/traccar/api/resource/UserResource.java
@@ -52,7 +52,12 @@ public class UserResource extends BaseResource {
         }
         Context.getDataManager().addUser(entity);
         Context.getPermissionsManager().refresh();
-        Context.getGeofenceManager().refresh();
+        if (Context.getGeofenceManager() != null) {
+            Context.getGeofenceManager().refresh();
+        }
+        if (Context.getNotificationManager() != null) {
+            Context.getNotificationManager().refresh();
+        }
         return Response.ok(entity).build();
     }
 
@@ -66,7 +71,12 @@ public class UserResource extends BaseResource {
         }
         Context.getDataManager().updateUser(entity);
         Context.getPermissionsManager().refresh();
-        Context.getGeofenceManager().refresh();
+        if (Context.getGeofenceManager() != null) {
+            Context.getGeofenceManager().refresh();
+        }
+        if (Context.getNotificationManager() != null) {
+            Context.getNotificationManager().refresh();
+        }
         return Response.ok(entity).build();
     }
 
@@ -76,7 +86,12 @@ public class UserResource extends BaseResource {
         Context.getPermissionsManager().checkUser(getUserId(), id);
         Context.getDataManager().removeUser(id);
         Context.getPermissionsManager().refresh();
-        Context.getGeofenceManager().refresh();
+        if (Context.getGeofenceManager() != null) {
+            Context.getGeofenceManager().refresh();
+        }
+        if (Context.getNotificationManager() != null) {
+            Context.getNotificationManager().refresh();
+        }
         return Response.noContent().build();
     }
 

--- a/src/org/traccar/database/DataManager.java
+++ b/src/org/traccar/database/DataManager.java
@@ -52,6 +52,7 @@ import org.traccar.model.Geofence;
 import org.traccar.model.Group;
 import org.traccar.model.GroupGeofence;
 import org.traccar.model.GroupPermission;
+import org.traccar.model.Notification;
 import org.traccar.model.Position;
 import org.traccar.model.Server;
 import org.traccar.model.User;
@@ -642,6 +643,29 @@ public class DataManager implements IdentityManager {
         QueryBuilder.create(dataSource, getQuery("database.unlinkDeviceGeofence"))
                 .setLong("deviceId", deviceId)
                 .setLong("geofenceId", geofenceId)
+                .executeUpdate();
+    }
+
+    public Collection<Notification> getNotifications() throws SQLException {
+        return QueryBuilder.create(dataSource, getQuery("database.selectNotifications"))
+                .executeQuery(Notification.class);
+    }
+
+    public void addNotification(Notification notification) throws SQLException {
+        notification.setId(QueryBuilder.create(dataSource, getQuery("database.insertNotification"), true)
+                .setObject(notification)
+                .executeUpdate());
+    }
+
+    public void updateNotification(Notification notification) throws SQLException {
+        QueryBuilder.create(dataSource, getQuery("database.updateNotification"))
+                .setObject(notification)
+                .executeUpdate();
+    }
+
+    public void removeNotification(Notification notification) throws SQLException {
+        QueryBuilder.create(dataSource, getQuery("database.deleteNotification"))
+                .setLong("id", notification.getId())
                 .executeUpdate();
     }
 }

--- a/src/org/traccar/model/Notification.java
+++ b/src/org/traccar/model/Notification.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016 Anton Tananaev (anton.tananaev@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.model;
+
+public class Notification extends Extensible {
+
+    private long userId;
+
+    public long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(long userId) {
+        this.userId = userId;
+    }
+
+    private String type;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+}

--- a/src/org/traccar/model/User.java
+++ b/src/org/traccar/model/User.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 - 2015 Anton Tananaev (anton.tananaev@gmail.com)
+ * Copyright 2013 - 2016 Anton Tananaev (anton.tananaev@gmail.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,17 +18,7 @@ package org.traccar.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.traccar.helper.Hashing;
 
-public class User {
-
-    private long id;
-
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
-    }
+public class User extends Extensible {
 
     private String name;
 

--- a/src/org/traccar/notification/NotificationFormatter.java
+++ b/src/org/traccar/notification/NotificationFormatter.java
@@ -127,25 +127,25 @@ public final class NotificationFormatter {
                 break;
             case Event.TYPE_DEVICE_MOVING:
                 formatter.format(MESSAGE_TEMPLATE_TYPE_DEVICE_MOVING, device.getName(), position.getFixTime(),
-                    position.getLatitude(), position.getLongitude());
+                        position.getLatitude(), position.getLongitude());
                 break;
             case Event.TYPE_DEVICE_STOPPED:
                 formatter.format(MESSAGE_TEMPLATE_TYPE_DEVICE_STOPPED, device.getName(), position.getFixTime(),
-                    position.getLatitude(), position.getLongitude());
+                        position.getLatitude(), position.getLongitude());
                 break;
             case Event.TYPE_DEVICE_OVERSPEED:
                 formatter.format(MESSAGE_TEMPLATE_TYPE_DEVICE_OVERSPEED, device.getName(), position.getFixTime(),
-                    position.getLatitude(), position.getLongitude(), position.getSpeed());
+                        position.getLatitude(), position.getLongitude(), position.getSpeed());
                 break;
             case Event.TYPE_GEOFENCE_ENTER:
                 formatter.format(MESSAGE_TEMPLATE_TYPE_GEOFENCE_ENTER, device.getName(), position.getFixTime(),
-                    position.getLatitude(), position.getLongitude(), Context.getGeofenceManager() != null
-                    ? Context.getGeofenceManager().getGeofence(event.getGeofenceId()).getName() : "");
+                        position.getLatitude(), position.getLongitude(),
+                        Context.getGeofenceManager().getGeofence(event.getGeofenceId()).getName());
                 break;
             case Event.TYPE_GEOFENCE_EXIT:
                 formatter.format(MESSAGE_TEMPLATE_TYPE_GEOFENCE_EXIT, device.getName(), position.getFixTime(),
-                    position.getLatitude(), position.getLongitude(), Context.getGeofenceManager() != null
-                    ? Context.getGeofenceManager().getGeofence(event.getGeofenceId()).getName() : "");
+                        position.getLatitude(), position.getLongitude(),
+                        Context.getGeofenceManager().getGeofence(event.getGeofenceId()).getName());
                 break;
             default:
                 formatter.format("Unknown type");

--- a/src/org/traccar/notification/NotificationFormatter.java
+++ b/src/org/traccar/notification/NotificationFormatter.java
@@ -76,24 +76,33 @@ public final class NotificationFormatter {
         Formatter formatter = new Formatter(stringBuilder, Locale.getDefault());
 
         switch (event.getType()) {
-            case Event.TYPE_COMMAND_RESULT  : formatter.format(TITLE_TEMPLATE_TYPE_COMMAND_RESULT, device.getName());
-                                              break;
-            case Event.TYPE_DEVICE_ONLINE   : formatter.format(TITLE_TEMPLATE_TYPE_DEVICE_ONLINE, device.getName());
-                                              break;
-            case Event.TYPE_DEVICE_OFFLINE  : formatter.format(TITLE_TEMPLATE_TYPE_DEVICE_OFFLINE, device.getName());
-                                              break;
-            case Event.TYPE_DEVICE_MOVING   : formatter.format(TITLE_TEMPLATE_TYPE_DEVICE_MOVING, device.getName());
-                                              break;
-            case Event.TYPE_DEVICE_STOPPED  : formatter.format(TITLE_TEMPLATE_TYPE_DEVICE_STOPPED, device.getName());
-                                              break;
-            case Event.TYPE_DEVICE_OVERSPEED: formatter.format(TITLE_TEMPLATE_TYPE_DEVICE_OVERSPEED, device.getName());
-                                              break;
-            case Event.TYPE_GEOFENCE_ENTER  : formatter.format(TITLE_TEMPLATE_TYPE_GEOFENCE_ENTER, device.getName());
-                                              break;
-            case Event.TYPE_GEOFENCE_EXIT   : formatter.format(TITLE_TEMPLATE_TYPE_GEOFENCE_EXIT, device.getName());
-                                              break;
-            default                         : formatter.format("Unknown type");
-                                              break;
+            case Event.TYPE_COMMAND_RESULT:
+                formatter.format(TITLE_TEMPLATE_TYPE_COMMAND_RESULT, device.getName());
+                break;
+            case Event.TYPE_DEVICE_ONLINE:
+                formatter.format(TITLE_TEMPLATE_TYPE_DEVICE_ONLINE, device.getName());
+                break;
+            case Event.TYPE_DEVICE_OFFLINE:
+                formatter.format(TITLE_TEMPLATE_TYPE_DEVICE_OFFLINE, device.getName());
+                break;
+            case Event.TYPE_DEVICE_MOVING:
+                formatter.format(TITLE_TEMPLATE_TYPE_DEVICE_MOVING, device.getName());
+                break;
+            case Event.TYPE_DEVICE_STOPPED:
+                formatter.format(TITLE_TEMPLATE_TYPE_DEVICE_STOPPED, device.getName());
+                break;
+            case Event.TYPE_DEVICE_OVERSPEED:
+                formatter.format(TITLE_TEMPLATE_TYPE_DEVICE_OVERSPEED, device.getName());
+                break;
+            case Event.TYPE_GEOFENCE_ENTER:
+                formatter.format(TITLE_TEMPLATE_TYPE_GEOFENCE_ENTER, device.getName());
+                break;
+            case Event.TYPE_GEOFENCE_EXIT:
+                formatter.format(TITLE_TEMPLATE_TYPE_GEOFENCE_EXIT, device.getName());
+                break;
+            default:
+                formatter.format("Unknown type");
+                break;
         }
         String result = formatter.toString();
         formatter.close();
@@ -106,56 +115,41 @@ public final class NotificationFormatter {
         Formatter formatter = new Formatter(stringBuilder, Locale.getDefault());
 
         switch (event.getType()) {
-            case Event.TYPE_COMMAND_RESULT  : formatter.format(MESSAGE_TEMPLATE_TYPE_COMMAND_RESULT,
-                    device.getName(),
-                    event.getServerTime(),
-                    position.getAttributes().get("result"));
-                                              break;
-            case Event.TYPE_DEVICE_ONLINE   : formatter.format(MESSAGE_TEMPLATE_TYPE_DEVICE_ONLINE,
-                    device.getName(),
-                    event.getServerTime());
-                                              break;
-            case Event.TYPE_DEVICE_OFFLINE  : formatter.format(MESSAGE_TEMPLATE_TYPE_DEVICE_OFFLINE,
-                    device.getName(),
-                    event.getServerTime());
-                                              break;
-            case Event.TYPE_DEVICE_MOVING   : formatter.format(MESSAGE_TEMPLATE_TYPE_DEVICE_MOVING,
-                    device.getName(),
-                    position.getFixTime(),
-                    position.getLatitude(),
-                    position.getLongitude());
-                                              break;
-            case Event.TYPE_DEVICE_STOPPED  : formatter.format(MESSAGE_TEMPLATE_TYPE_DEVICE_STOPPED,
-                    device.getName(),
-                    position.getFixTime(),
-                    position.getLatitude(),
-                    position.getLongitude());
-                                              break;
-            case Event.TYPE_DEVICE_OVERSPEED: formatter.format(MESSAGE_TEMPLATE_TYPE_DEVICE_OVERSPEED,
-                    device.getName(),
-                    position.getFixTime(),
-                    position.getLatitude(),
-                    position.getLongitude(),
-                    position.getSpeed());
-                                              break;
-            case Event.TYPE_GEOFENCE_ENTER  : formatter.format(MESSAGE_TEMPLATE_TYPE_GEOFENCE_ENTER,
-                    device.getName(),
-                    position.getFixTime(),
-                    position.getLatitude(),
-                    position.getLongitude(),
-                    (Context.getGeofenceManager() != null)
-                            ? Context.getGeofenceManager().getGeofence(event.getGeofenceId()).getName() : "");
-                                              break;
-            case Event.TYPE_GEOFENCE_EXIT   : formatter.format(MESSAGE_TEMPLATE_TYPE_GEOFENCE_EXIT,
-                    device.getName(),
-                    position.getFixTime(),
-                    position.getLatitude(),
-                    position.getLongitude(),
-                    (Context.getGeofenceManager() != null)
-                            ? Context.getGeofenceManager().getGeofence(event.getGeofenceId()).getName() : "");
-                                              break;
-            default                         : formatter.format("Unknown type");
-                                              break;
+            case Event.TYPE_COMMAND_RESULT:
+                formatter.format(MESSAGE_TEMPLATE_TYPE_COMMAND_RESULT, device.getName(), event.getServerTime(),
+                        position.getAttributes().get("result"));
+                break;
+            case Event.TYPE_DEVICE_ONLINE:
+                formatter.format(MESSAGE_TEMPLATE_TYPE_DEVICE_ONLINE, device.getName(), event.getServerTime());
+                break;
+            case Event.TYPE_DEVICE_OFFLINE:
+                formatter.format(MESSAGE_TEMPLATE_TYPE_DEVICE_OFFLINE, device.getName(), event.getServerTime());
+                break;
+            case Event.TYPE_DEVICE_MOVING:
+                formatter.format(MESSAGE_TEMPLATE_TYPE_DEVICE_MOVING, device.getName(), position.getFixTime(),
+                    position.getLatitude(), position.getLongitude());
+                break;
+            case Event.TYPE_DEVICE_STOPPED:
+                formatter.format(MESSAGE_TEMPLATE_TYPE_DEVICE_STOPPED, device.getName(), position.getFixTime(),
+                    position.getLatitude(), position.getLongitude());
+                break;
+            case Event.TYPE_DEVICE_OVERSPEED:
+                formatter.format(MESSAGE_TEMPLATE_TYPE_DEVICE_OVERSPEED, device.getName(), position.getFixTime(),
+                    position.getLatitude(), position.getLongitude(), position.getSpeed());
+                break;
+            case Event.TYPE_GEOFENCE_ENTER:
+                formatter.format(MESSAGE_TEMPLATE_TYPE_GEOFENCE_ENTER, device.getName(), position.getFixTime(),
+                    position.getLatitude(), position.getLongitude(), Context.getGeofenceManager() != null
+                    ? Context.getGeofenceManager().getGeofence(event.getGeofenceId()).getName() : "");
+                break;
+            case Event.TYPE_GEOFENCE_EXIT:
+                formatter.format(MESSAGE_TEMPLATE_TYPE_GEOFENCE_EXIT, device.getName(), position.getFixTime(),
+                    position.getLatitude(), position.getLongitude(), Context.getGeofenceManager() != null
+                    ? Context.getGeofenceManager().getGeofence(event.getGeofenceId()).getName() : "");
+                break;
+            default:
+                formatter.format("Unknown type");
+                break;
         }
         String result = formatter.toString();
         formatter.close();

--- a/src/org/traccar/notification/NotificationFormatter.java
+++ b/src/org/traccar/notification/NotificationFormatter.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2016 Anton Tananaev (anton.tananaev@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.notification;
+
+import java.util.Formatter;
+import java.util.Locale;
+
+import org.traccar.Context;
+import org.traccar.model.Device;
+import org.traccar.model.Event;
+import org.traccar.model.Position;
+
+public final class NotificationFormatter {
+
+    private NotificationFormatter() {
+    }
+
+    public static final String TITLE_TEMPLATE_TYPE_COMMAND_RESULT = "%1$s: command result received";
+    public static final String MESSAGE_TEMPLATE_TYPE_COMMAND_RESULT = "Device: %1$s%n"
+            + "Result: %3$s%n"
+            + "Time: %2$tc%n";
+
+    public static final String TITLE_TEMPLATE_TYPE_DEVICE_ONLINE = "%1$s: online";
+    public static final String MESSAGE_TEMPLATE_TYPE_DEVICE_ONLINE = "Device: %1$s%n"
+            + "Online%n"
+            + "Time: %2$tc%n";
+    public static final String TITLE_TEMPLATE_TYPE_DEVICE_OFFLINE = "%1$s: offline";
+    public static final String MESSAGE_TEMPLATE_TYPE_DEVICE_OFFLINE = "Device: %1$s%n"
+            + "Offline%n"
+            + "Time: %2$tc%n";
+
+    public static final String TITLE_TEMPLATE_TYPE_DEVICE_MOVING = "%1$s: moving";
+    public static final String MESSAGE_TEMPLATE_TYPE_DEVICE_MOVING = "Device: %1$s%n"
+            + "Moving%n"
+            + "Point: http://www.openstreetmap.org/?mlat=%3$f&mlon=%4$f#map=16/%3$f/%4$f%n"
+            + "Time: %2$tc%n";
+    public static final String TITLE_TEMPLATE_TYPE_DEVICE_STOPPED = "%1$s: stopped";
+    public static final String MESSAGE_TEMPLATE_TYPE_DEVICE_STOPPED = "Device: %1$s%n"
+            + "Stopped%n"
+            + "Point: http://www.openstreetmap.org/?mlat=%3$f&mlon=%4$f#map=16/%3$f/%4$f%n"
+            + "Time: %2$tc%n";
+
+    public static final String TITLE_TEMPLATE_TYPE_DEVICE_OVERSPEED = "%1$s: exeeds the speed";
+    public static final String MESSAGE_TEMPLATE_TYPE_DEVICE_OVERSPEED = "Device: %1$s%n"
+            + "Exeeds the speed: %5$f%n"
+            + "Point: http://www.openstreetmap.org/?mlat=%3$f&mlon=%4$f#map=16/%3$f/%4$f%n"
+            + "Time: %2$tc%n";
+
+    public static final String TITLE_TEMPLATE_TYPE_GEOFENCE_ENTER = "%1$s: has entered geofence";
+    public static final String MESSAGE_TEMPLATE_TYPE_GEOFENCE_ENTER = "Device: %1$s%n"
+            + "Has entered geofence: %5$s%n"
+            + "Point: http://www.openstreetmap.org/?mlat=%3$f&mlon=%4$f#map=16/%3$f/%4$f%n"
+            + "Time: %2$tc%n";
+    public static final String TITLE_TEMPLATE_TYPE_GEOFENCE_EXIT = "%1$s: has exited geofence";
+    public static final String MESSAGE_TEMPLATE_TYPE_GEOFENCE_EXIT = "Device: %1$s%n"
+            + "Has exited geofence: %5$s%n"
+            + "Point: http://www.openstreetmap.org/?mlat=%3$f&mlon=%4$f#map=16/%3$f/%4$f%n"
+            + "Time: %2$tc%n";
+
+    public static String formatTitle(long userId, Event event, Position position) {
+        Device device = Context.getIdentityManager().getDeviceById(event.getDeviceId());
+        StringBuilder stringBuilder = new StringBuilder();
+        Formatter formatter = new Formatter(stringBuilder, Locale.getDefault());
+
+        switch (event.getType()) {
+            case Event.TYPE_COMMAND_RESULT  : formatter.format(TITLE_TEMPLATE_TYPE_COMMAND_RESULT, device.getName());
+                                              break;
+            case Event.TYPE_DEVICE_ONLINE   : formatter.format(TITLE_TEMPLATE_TYPE_DEVICE_ONLINE, device.getName());
+                                              break;
+            case Event.TYPE_DEVICE_OFFLINE  : formatter.format(TITLE_TEMPLATE_TYPE_DEVICE_OFFLINE, device.getName());
+                                              break;
+            case Event.TYPE_DEVICE_MOVING   : formatter.format(TITLE_TEMPLATE_TYPE_DEVICE_MOVING, device.getName());
+                                              break;
+            case Event.TYPE_DEVICE_STOPPED  : formatter.format(TITLE_TEMPLATE_TYPE_DEVICE_STOPPED, device.getName());
+                                              break;
+            case Event.TYPE_DEVICE_OVERSPEED: formatter.format(TITLE_TEMPLATE_TYPE_DEVICE_OVERSPEED, device.getName());
+                                              break;
+            case Event.TYPE_GEOFENCE_ENTER  : formatter.format(TITLE_TEMPLATE_TYPE_GEOFENCE_ENTER, device.getName());
+                                              break;
+            case Event.TYPE_GEOFENCE_EXIT   : formatter.format(TITLE_TEMPLATE_TYPE_GEOFENCE_EXIT, device.getName());
+                                              break;
+            default                         : formatter.format("Unknown type");
+                                              break;
+        }
+        String result = formatter.toString();
+        formatter.close();
+        return result;
+    }
+
+    public static String formatMessage(long userId, Event event, Position position) {
+        Device device = Context.getIdentityManager().getDeviceById(event.getDeviceId());
+        StringBuilder stringBuilder = new StringBuilder();
+        Formatter formatter = new Formatter(stringBuilder, Locale.getDefault());
+
+        switch (event.getType()) {
+            case Event.TYPE_COMMAND_RESULT  : formatter.format(MESSAGE_TEMPLATE_TYPE_COMMAND_RESULT,
+                    device.getName(),
+                    event.getServerTime(),
+                    position.getAttributes().get("result"));
+                                              break;
+            case Event.TYPE_DEVICE_ONLINE   : formatter.format(MESSAGE_TEMPLATE_TYPE_DEVICE_ONLINE,
+                    device.getName(),
+                    event.getServerTime());
+                                              break;
+            case Event.TYPE_DEVICE_OFFLINE  : formatter.format(MESSAGE_TEMPLATE_TYPE_DEVICE_OFFLINE,
+                    device.getName(),
+                    event.getServerTime());
+                                              break;
+            case Event.TYPE_DEVICE_MOVING   : formatter.format(MESSAGE_TEMPLATE_TYPE_DEVICE_MOVING,
+                    device.getName(),
+                    position.getFixTime(),
+                    position.getLatitude(),
+                    position.getLongitude());
+                                              break;
+            case Event.TYPE_DEVICE_STOPPED  : formatter.format(MESSAGE_TEMPLATE_TYPE_DEVICE_STOPPED,
+                    device.getName(),
+                    position.getFixTime(),
+                    position.getLatitude(),
+                    position.getLongitude());
+                                              break;
+            case Event.TYPE_DEVICE_OVERSPEED: formatter.format(MESSAGE_TEMPLATE_TYPE_DEVICE_OVERSPEED,
+                    device.getName(),
+                    position.getFixTime(),
+                    position.getLatitude(),
+                    position.getLongitude(),
+                    position.getSpeed());
+                                              break;
+            case Event.TYPE_GEOFENCE_ENTER  : formatter.format(MESSAGE_TEMPLATE_TYPE_GEOFENCE_ENTER,
+                    device.getName(),
+                    position.getFixTime(),
+                    position.getLatitude(),
+                    position.getLongitude(),
+                    (Context.getGeofenceManager() != null)
+                            ? Context.getGeofenceManager().getGeofence(event.getGeofenceId()).getName() : "");
+                                              break;
+            case Event.TYPE_GEOFENCE_EXIT   : formatter.format(MESSAGE_TEMPLATE_TYPE_GEOFENCE_EXIT,
+                    device.getName(),
+                    position.getFixTime(),
+                    position.getLatitude(),
+                    position.getLongitude(),
+                    (Context.getGeofenceManager() != null)
+                            ? Context.getGeofenceManager().getGeofence(event.getGeofenceId()).getName() : "");
+                                              break;
+            default                         : formatter.format("Unknown type");
+                                              break;
+        }
+        String result = formatter.toString();
+        formatter.close();
+        return result;
+    }
+}

--- a/src/org/traccar/notification/NotificationMail.java
+++ b/src/org/traccar/notification/NotificationMail.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2016 Anton Tananaev (anton.tananaev@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.notification;
+
+import java.sql.SQLException;
+import java.util.Properties;
+
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.Session;
+import javax.mail.Transport;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+
+import org.traccar.Config;
+import org.traccar.Context;
+import org.traccar.database.DataManager;
+import org.traccar.helper.Log;
+import org.traccar.model.Event;
+import org.traccar.model.Position;
+import org.traccar.model.User;
+
+public final class NotificationMail {
+
+    private NotificationMail() {
+    }
+
+    public static void sendMailSync(long userId, Event event, Position position) {
+        Config config = Context.getConfig();
+        DataManager dataManager = Context.getDataManager();
+
+        Properties mailServerProperties;
+        Session mailSession;
+        MimeMessage mailMessage;
+
+        String from = null;
+        String username = null;
+        String password = null;
+
+        try {
+        User user = dataManager.getUser(userId);
+
+        mailServerProperties = new Properties();
+        String host = config.getString("mail.smtp.host", null);
+        if (host != null) {
+            mailServerProperties.put("mail.smtp.host", host);
+            mailServerProperties.put("mail.smtp.port", config.getString("mail.smtp.port", "25"));
+
+            if (config.getBoolean("mail.smtp.starttls.enable")) {
+                mailServerProperties.put("mail.smtp.starttls.enable",
+                        config.getBoolean("mail.smtp.starttls.enable"));
+            } else if (config.getBoolean("mail.smtp.ssl.enable")) {
+                mailServerProperties.put("mail.smtp.socketFactory.port",
+                        mailServerProperties.getProperty("mail.smtp.port"));
+                mailServerProperties.put("mail.smtp.socketFactory.class",
+                        "javax.net.ssl.SSLSocketFactory");
+            }
+
+            mailServerProperties.put("mail.smtp.auth", config.getBoolean("mail.smtp.auth"));
+            username = config.getString("mail.smtp.username", null);
+            password = config.getString("mail.smtp.password", null);
+            from = config.getString("mail.smtp.from", null);
+        } else if (user.getAttributes().containsKey("mail.smtp.host")) {
+            mailServerProperties.put("mail.smtp.host", user.getAttributes().get("mail.smtp.host"));
+            String port = (String) user.getAttributes().get("mail.smtp.port");
+            mailServerProperties.put("mail.smtp.port", (port != null) ? port : "25");
+            if (user.getAttributes().containsKey("mail.smtp.starttls.enable")) {
+                boolean tls = Boolean.parseBoolean((String) user.getAttributes().get("mail.smtp.starttls.enable"));
+                mailServerProperties.put("mail.smtp.starttls.enable", tls);
+            } else if (user.getAttributes().containsKey("mail.smtp.ssl.enable")) {
+                boolean ssl = Boolean.parseBoolean((String) user.getAttributes().get("mail.smtp.ssl.enable"));
+                if (ssl) {
+                    mailServerProperties.put("mail.smtp.socketFactory.port",
+                            mailServerProperties.getProperty("mail.smtp.port"));
+                    mailServerProperties.put("mail.smtp.socketFactory.class",
+                            "javax.net.ssl.SSLSocketFactory");
+                }
+            }
+            boolean auth = Boolean.parseBoolean((String) user.getAttributes().get("mail.smtp.auth"));
+            mailServerProperties.put("mail.smtp.auth", auth);
+
+            username = (String) user.getAttributes().get("mail.smtp.username");
+            password = (String) user.getAttributes().get("mail.smtp.password");
+            from = (String) user.getAttributes().get("mail.smtp.from");
+        } else {
+            return;
+        }
+
+        mailSession = Session.getDefaultInstance(mailServerProperties, null);
+
+        mailMessage = new MimeMessage(mailSession);
+
+        if (from != null) {
+            mailMessage.setFrom(new InternetAddress(from));
+        }
+        mailMessage.addRecipient(Message.RecipientType.TO, new InternetAddress(
+                Context.getDataManager().getUser(userId).getEmail()));
+        mailMessage.setSubject(NotificationFormatter.formatTitle(userId, event, position));
+        mailMessage.setText(NotificationFormatter.formatMessage(userId, event, position));
+
+        Transport transport = mailSession.getTransport("smtp");
+        transport.connect(mailServerProperties.getProperty("mail.smtp.host"), username, password);
+        transport.sendMessage(mailMessage, mailMessage.getAllRecipients());
+        transport.close();
+
+        } catch (MessagingException | SQLException error) {
+            Log.warning(error);
+        }
+    }
+
+    public static void sendMailAsync(final long userId, final Event event, final Position position) {
+        Runnable runnableSend = new Runnable() {
+            public void run() {
+                sendMailSync(userId, event, position);
+            }
+        };
+
+        new Thread(runnableSend).start();
+    }
+}

--- a/src/org/traccar/notification/NotificationMail.java
+++ b/src/org/traccar/notification/NotificationMail.java
@@ -30,6 +30,7 @@ import org.traccar.Context;
 import org.traccar.database.DataManager;
 import org.traccar.helper.Log;
 import org.traccar.model.Event;
+import org.traccar.model.Extensible;
 import org.traccar.model.Position;
 import org.traccar.model.User;
 
@@ -38,81 +39,91 @@ public final class NotificationMail {
     private NotificationMail() {
     }
 
-    public static void sendMailSync(long userId, Event event, Position position) {
+    private static Properties getConfigProperies() {
         Config config = Context.getConfig();
+        Properties result = new Properties();
+        String host = config.getString("mail.smtp.host", null);
+        if (host != null) {
+            result.put("mail.smtp.host", host);
+            result.put("mail.smtp.port", config.getString("mail.smtp.port", "25"));
+
+            if (config.getBoolean("mail.smtp.starttls.enable")) {
+                result.put("mail.smtp.starttls.enable",
+                        config.getBoolean("mail.smtp.starttls.enable"));
+            } else if (config.getBoolean("mail.smtp.ssl.enable")) {
+                result.put("mail.smtp.socketFactory.port",
+                        result.getProperty("mail.smtp.port"));
+                result.put("mail.smtp.socketFactory.class",
+                        "javax.net.ssl.SSLSocketFactory");
+            }
+
+            result.put("mail.smtp.auth", config.getBoolean("mail.smtp.auth"));
+            result.put("mail.smtp.user", config.getString("mail.smtp.username", null));
+            result.put("mail.smtp.password", config.getString("mail.smtp.password", null));
+            result.put("mail.smtp.from", config.getString("mail.smtp.from", null));
+        }
+        return result;
+    }
+
+    private static Properties getAttributesProperties(Extensible object) {
+        Properties result = new Properties();
+
+        if (object.getAttributes().containsKey("mail.smtp.host")) {
+            result.put("mail.smtp.host", object.getAttributes().get("mail.smtp.host"));
+            String port = (String) object.getAttributes().get("mail.smtp.port");
+            result.put("mail.smtp.port", (port != null) ? port : "25");
+            if (object.getAttributes().containsKey("mail.smtp.starttls.enable")) {
+                boolean tls = Boolean.parseBoolean((String) object.getAttributes().get("mail.smtp.starttls.enable"));
+                result.put("mail.smtp.starttls.enable", tls);
+            } else if (object.getAttributes().containsKey("mail.smtp.ssl.enable")) {
+                boolean ssl = Boolean.parseBoolean((String) object.getAttributes().get("mail.smtp.ssl.enable"));
+                if (ssl) {
+                    result.put("mail.smtp.socketFactory.port",
+                            result.getProperty("mail.smtp.port"));
+                    result.put("mail.smtp.socketFactory.class",
+                            "javax.net.ssl.SSLSocketFactory");
+                }
+            }
+            boolean auth = Boolean.parseBoolean((String) object.getAttributes().get("mail.smtp.auth"));
+            result.put("mail.smtp.auth", auth);
+
+            result.put("mail.smtp.username", object.getAttributes().get("mail.smtp.username"));
+            result.put("mail.smtp.password", object.getAttributes().get("mail.smtp.password"));
+            result.put("mail.smtp.from", object.getAttributes().get("mail.smtp.from"));
+        }
+        return result;
+    }
+
+    public static void sendMailSync(long userId, Event event, Position position) {
         DataManager dataManager = Context.getDataManager();
 
         Properties mailServerProperties;
         Session mailSession;
         MimeMessage mailMessage;
 
-        String from = null;
-        String username = null;
-        String password = null;
-
         try {
             User user = dataManager.getUser(userId);
 
-            mailServerProperties = new Properties();
-            String host = config.getString("mail.smtp.host", null);
-            if (host != null) {
-                mailServerProperties.put("mail.smtp.host", host);
-                mailServerProperties.put("mail.smtp.port", config.getString("mail.smtp.port", "25"));
-
-                if (config.getBoolean("mail.smtp.starttls.enable")) {
-                    mailServerProperties.put("mail.smtp.starttls.enable",
-                            config.getBoolean("mail.smtp.starttls.enable"));
-                } else if (config.getBoolean("mail.smtp.ssl.enable")) {
-                    mailServerProperties.put("mail.smtp.socketFactory.port",
-                            mailServerProperties.getProperty("mail.smtp.port"));
-                    mailServerProperties.put("mail.smtp.socketFactory.class",
-                            "javax.net.ssl.SSLSocketFactory");
+            mailServerProperties = getConfigProperies();
+            if (!mailServerProperties.containsKey("mail.smtp.host")) {
+                mailServerProperties = getAttributesProperties(user);
+                if (!mailServerProperties.containsKey("mail.smtp.host")) {
+                    return;
                 }
-
-                mailServerProperties.put("mail.smtp.auth", config.getBoolean("mail.smtp.auth"));
-                username = config.getString("mail.smtp.username", null);
-                password = config.getString("mail.smtp.password", null);
-                from = config.getString("mail.smtp.from", null);
-            } else if (user.getAttributes().containsKey("mail.smtp.host")) {
-                mailServerProperties.put("mail.smtp.host", user.getAttributes().get("mail.smtp.host"));
-                String port = (String) user.getAttributes().get("mail.smtp.port");
-                mailServerProperties.put("mail.smtp.port", (port != null) ? port : "25");
-                if (user.getAttributes().containsKey("mail.smtp.starttls.enable")) {
-                    boolean tls = Boolean.parseBoolean((String) user.getAttributes().get("mail.smtp.starttls.enable"));
-                    mailServerProperties.put("mail.smtp.starttls.enable", tls);
-                } else if (user.getAttributes().containsKey("mail.smtp.ssl.enable")) {
-                    boolean ssl = Boolean.parseBoolean((String) user.getAttributes().get("mail.smtp.ssl.enable"));
-                    if (ssl) {
-                        mailServerProperties.put("mail.smtp.socketFactory.port",
-                                mailServerProperties.getProperty("mail.smtp.port"));
-                        mailServerProperties.put("mail.smtp.socketFactory.class",
-                                "javax.net.ssl.SSLSocketFactory");
-                    }
-                }
-                boolean auth = Boolean.parseBoolean((String) user.getAttributes().get("mail.smtp.auth"));
-                mailServerProperties.put("mail.smtp.auth", auth);
-
-                username = (String) user.getAttributes().get("mail.smtp.username");
-                password = (String) user.getAttributes().get("mail.smtp.password");
-                from = (String) user.getAttributes().get("mail.smtp.from");
-            } else {
-                return;
             }
-
             mailSession = Session.getDefaultInstance(mailServerProperties, null);
 
             mailMessage = new MimeMessage(mailSession);
 
-            if (from != null) {
-                mailMessage.setFrom(new InternetAddress(from));
-            }
             mailMessage.addRecipient(Message.RecipientType.TO, new InternetAddress(
                     Context.getDataManager().getUser(userId).getEmail()));
             mailMessage.setSubject(NotificationFormatter.formatTitle(userId, event, position));
             mailMessage.setText(NotificationFormatter.formatMessage(userId, event, position));
 
             Transport transport = mailSession.getTransport("smtp");
-            transport.connect(mailServerProperties.getProperty("mail.smtp.host"), username, password);
+            transport.connect(mailServerProperties.getProperty("mail.smtp.host"),
+                    mailServerProperties.getProperty("mail.smtp.username"),
+                    mailServerProperties.getProperty("mail.smtp.password"));
             transport.sendMessage(mailMessage, mailMessage.getAllRecipients());
             transport.close();
 

--- a/src/org/traccar/web/WebServer.java
+++ b/src/org/traccar/web/WebServer.java
@@ -41,6 +41,7 @@ import org.traccar.api.resource.SessionResource;
 import org.traccar.api.resource.DevicePermissionResource;
 import org.traccar.api.resource.UserResource;
 import org.traccar.api.resource.GroupResource;
+import org.traccar.api.resource.NotificationResource;
 import org.traccar.api.resource.DeviceResource;
 import org.traccar.api.resource.PositionResource;
 import org.traccar.api.resource.CommandTypeResource;
@@ -155,7 +156,8 @@ public class WebServer {
                 GroupPermissionResource.class, DevicePermissionResource.class, UserResource.class,
                 GroupResource.class, DeviceResource.class, PositionResource.class,
                 CommandTypeResource.class, EventResource.class, GeofenceResource.class,
-                DeviceGeofenceResource.class, GeofencePermissionResource.class, GroupGeofenceResource.class);
+                DeviceGeofenceResource.class, GeofencePermissionResource.class, GroupGeofenceResource.class,
+                NotificationResource.class);
         servletHandler.addServlet(new ServletHolder(new ServletContainer(resourceConfig)), "/*");
 
         handlers.addHandler(servletHandler);

--- a/web/app/Application.js
+++ b/web/app/Application.js
@@ -32,7 +32,8 @@ Ext.define('Traccar.Application', {
         'Attribute',
         'Command',
         'Event',
-        'Geofence'
+        'Geofence',
+        'Notification'
     ],
 
     stores: [
@@ -52,7 +53,9 @@ Ext.define('Traccar.Application', {
         'Languages',
         'Events',
         'Geofences',
-        'AllGeofences'
+        'AllGeofences',
+        'Notifications',
+        'AllNotifications'
     ],
 
     controllers: [

--- a/web/app/controller/Root.js
+++ b/web/app/controller/Root.js
@@ -144,7 +144,7 @@ Ext.define('Traccar.controller.Root', {
                                 break;
                             }
                         }
-                        text = Strings.eventCommandResult + text;
+                        text = Strings.eventCommandResult + ": " + text;
                     } else {
                         typeKey = 'event' + array[i].type.charAt(0).toUpperCase() + array[i].type.slice(1);
                         text = Strings[typeKey];

--- a/web/app/model/Notification.js
+++ b/web/app/model/Notification.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Anton Tananaev (anton.tananaev@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Ext.define('Traccar.model.Notification', {
+    extend: 'Ext.data.Model',
+    identifier: 'negative',
+
+    fields: [{
+        name: 'id',
+        type: 'int'
+    }, {
+        name: 'type',
+        type: 'string'
+    }, {
+        name: 'userId',
+        type: 'int'
+    }, {
+        name: 'attributes'
+    }]
+});

--- a/web/app/model/User.js
+++ b/web/app/model/User.js
@@ -54,6 +54,8 @@ Ext.define('Traccar.model.User', {
     }, {
         name: 'twelveHourFormat',
         type: 'boolean'
+    }, {
+        name: 'attributes'
     }],
 
     proxy: {

--- a/web/app/store/AllNotifications.js
+++ b/web/app/store/AllNotifications.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015 Anton Tananaev (anton.tananaev@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Ext.define('Traccar.store.AllNotifications', {
+    extend: 'Ext.data.Store',
+    model: 'Traccar.model.Notification',
+
+    proxy: {
+        type: 'rest',
+        url: '/api/users/notifications',
+        extraParams: {
+            all: true
+        }
+    },
+    sortOnLoad: true,
+    sorters: { property: 'type', direction : 'ASC' }
+});

--- a/web/app/store/Notifications.js
+++ b/web/app/store/Notifications.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 Anton Tananaev (anton.tananaev@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Ext.define('Traccar.store.Notifications', {
+    extend: 'Ext.data.Store',
+    model: 'Traccar.model.Notification',
+
+    proxy: {
+        type: 'rest',
+        url: '/api/users/notifications'
+    }
+});

--- a/web/app/view/Notifications.js
+++ b/web/app/view/Notifications.js
@@ -39,7 +39,7 @@ Ext.define('Traccar.view.Notifications', {
         }
     }, {
         text: Strings.notificationWeb,
-        dataIndex: 'web',
+        dataIndex: 'attributes.web',
         xtype: 'checkcolumn',
         flex: 1,
         listeners: {
@@ -47,11 +47,12 @@ Ext.define('Traccar.view.Notifications', {
             checkChange: 'onCheckChange'
         },
         renderer: function (value, metaData, record) {
-            return (new Ext.ux.CheckColumn()).renderer(record.getData().attributes.web, metaData);
+            var fields = this.dataIndex.split('\.',2);
+            return (new Ext.ux.CheckColumn()).renderer(record.get(fields[0])[fields[1]], metaData);
         }
     }, {
         text: Strings.notificationMail,
-        dataIndex: 'mail',
+        dataIndex: 'attributes.mail',
         xtype: 'checkcolumn',
         flex: 1,
         listeners: {
@@ -59,7 +60,8 @@ Ext.define('Traccar.view.Notifications', {
             checkChange: 'onCheckChange'
         },
         renderer: function (value, metaData, record) {
-            return (new Ext.ux.CheckColumn()).renderer(record.getData().attributes.mail, metaData);
+            var fields = this.dataIndex.split('\.',2);
+            return (new Ext.ux.CheckColumn()).renderer(record.get(fields[0])[fields[1]], metaData);
         }
     }],
 

--- a/web/app/view/Notifications.js
+++ b/web/app/view/Notifications.js
@@ -43,7 +43,11 @@ Ext.define('Traccar.view.Notifications', {
         xtype: 'checkcolumn',
         flex: 1,
         listeners: {
+            beforeCheckChange: 'onBeforeCheckChange',
             checkChange: 'onCheckChange'
+        },
+        renderer: function (value, metaData, record) {
+            return (new Ext.ux.CheckColumn()).renderer(record.getData().attributes.web, metaData);
         }
     }, {
         text: Strings.notificationMail,
@@ -51,7 +55,11 @@ Ext.define('Traccar.view.Notifications', {
         xtype: 'checkcolumn',
         flex: 1,
         listeners: {
+            beforeCheckChange: 'onBeforeCheckChange',
             checkChange: 'onCheckChange'
+        },
+        renderer: function (value, metaData, record) {
+            return (new Ext.ux.CheckColumn()).renderer(record.getData().attributes.mail, metaData);
         }
     }],
 

--- a/web/app/view/Notifications.js
+++ b/web/app/view/Notifications.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 Anton Tananaev (anton.tananaev@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Ext.define('Traccar.view.Notifications', {
+    extend: 'Ext.grid.Panel',
+    xtype: 'notificationsView',
+
+    requires: [
+        'Traccar.view.NotificationsController'
+    ],
+
+    controller: 'notificationsController',
+    store: 'AllNotifications',
+
+    selModel: {
+        selType: 'cellmodel',
+    },
+
+    columns: [{
+        text: Strings.notificationType,
+        dataIndex: 'type',
+        flex: 1,
+        renderer: function (value) {
+            var typeKey = 'event' + value.charAt(0).toUpperCase() + value.slice(1);
+            return Strings[typeKey];
+        }
+    }, {
+        text: Strings.notificationWeb,
+        dataIndex: 'web',
+        xtype: 'checkcolumn',
+        flex: 1,
+        listeners: {
+            checkChange: 'onCheckChange'
+        }
+    }, {
+        text: Strings.notificationMail,
+        dataIndex: 'mail',
+        xtype: 'checkcolumn',
+        flex: 1,
+        listeners: {
+            checkChange: 'onCheckChange'
+        }
+    }],
+
+});

--- a/web/app/view/NotificationsController.js
+++ b/web/app/view/NotificationsController.js
@@ -36,13 +36,7 @@ Ext.define('Traccar.view.NotificationsController', {
                                 index = this.getView().getStore().find('type', records[i].getData().type);
                                 attributes = records[i].getData().attributes;
                                 storeRecord = this.getView().getStore().getAt(index);
-                                if (typeof attributes.web != 'undefined') {
-                                    storeRecord.set('web', attributes.web);
-                                }
-                                if (typeof attributes.mail != 'undefined') {
-                                    storeRecord.set('mail', attributes.mail);
-                                }
-                                
+                                storeRecord.set('attributes', attributes);
                                 storeRecord.commit();
                             }
                         }
@@ -52,32 +46,33 @@ Ext.define('Traccar.view.NotificationsController', {
         });
     },
  
+    onBeforeCheckChange: function (column, rowIndex, checked, eOpts) {
+        var record = this.getView().getStore().getAt(rowIndex);
+        var attributes = record.getData().attributes;
+        if (!attributes[column.dataIndex]) {
+            attributes[column.dataIndex] = "true";
+        } else {
+            delete attributes[column.dataIndex];
+        }
+        record.set('attributes', attributes);
+        record.commit();
+    },
+
     onCheckChange: function (column, rowIndex, checked, eOpts) {
         var record = this.getView().getStore().getAt(rowIndex);
-        var web, mail;
-        var data = {
-            userId: this.userId,
-            type: record.getData().type,
-            attributes: {}
-        };
-        web = record.getData().web;
-        if (typeof web != 'undefined' && web) {
-            data.attributes.web = "true";
-        }
-        mail = record.getData().mail;
-        if (typeof mail != 'undefined' && mail) {
-            data.attributes.mail = "true";
-        }
         Ext.Ajax.request({
             scope: this,
             url: '/api/users/notifications',
-            jsonData: data,
+            jsonData: {
+                userId: this.userId,
+                type: record.getData().type,
+                attributes: record.getData().attributes
+            },
             callback: function (options, success, response) {
                 if (!success) {
                     Traccar.app.showError(response);
                 }
             }
         });
-        
     }
 });

--- a/web/app/view/NotificationsController.js
+++ b/web/app/view/NotificationsController.js
@@ -45,16 +45,17 @@ Ext.define('Traccar.view.NotificationsController', {
             }
         });
     },
- 
+
     onBeforeCheckChange: function (column, rowIndex, checked, eOpts) {
+        var fields = column.dataIndex.split('\.',2);
         var record = this.getView().getStore().getAt(rowIndex);
-        var attributes = record.getData().attributes;
-        if (!attributes[column.dataIndex]) {
-            attributes[column.dataIndex] = "true";
+        var data = record.get(fields[0]);
+        if (!data[fields[1]]) {
+            data[fields[1]] = "true";
         } else {
-            delete attributes[column.dataIndex];
+            delete data[fields[1]];
         }
-        record.set('attributes', attributes);
+        record.set(fields[0], data);
         record.commit();
     },
 

--- a/web/app/view/NotificationsController.js
+++ b/web/app/view/NotificationsController.js
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2016 Anton Tananaev (anton.tananaev@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Ext.define('Traccar.view.NotificationsController', {
+    extend: 'Ext.app.ViewController',
+    alias: 'controller.notificationsController',
+
+    init: function () {
+        this.userId = this.getView().user.getData().id;
+        this.getView().getStore().load({
+            scope: this,
+            callback: function (records, operation, success) {
+                var notificationsStore = Ext.create('Traccar.store.Notifications');
+                notificationsStore.load({
+                    params: {
+                        userId: this.userId
+                    },
+                    scope: this,
+                    callback: function (records, operation, success) {
+                        var i, index, attributes, storeRecord;
+                        if (success) {
+                            for (i = 0; i < records.length; i++) {
+                                index = this.getView().getStore().find('type', records[i].getData().type);
+                                attributes = records[i].getData().attributes;
+                                storeRecord = this.getView().getStore().getAt(index);
+                                if (typeof attributes.web != 'undefined') {
+                                    storeRecord.set('web', attributes.web);
+                                }
+                                if (typeof attributes.mail != 'undefined') {
+                                    storeRecord.set('mail', attributes.mail);
+                                }
+                                
+                                storeRecord.commit();
+                            }
+                        }
+                    }
+                });
+            }
+        });
+    },
+ 
+    onCheckChange: function (column, rowIndex, checked, eOpts) {
+        var record = this.getView().getStore().getAt(rowIndex);
+        var web, mail;
+        var data = {
+            userId: this.userId,
+            type: record.getData().type,
+            attributes: {}
+        };
+        web = record.getData().web;
+        if (typeof web != 'undefined' && web) {
+            data.attributes.web = "true";
+        }
+        mail = record.getData().mail;
+        if (typeof mail != 'undefined' && mail) {
+            data.attributes.mail = "true";
+        }
+        Ext.Ajax.request({
+            scope: this,
+            url: '/api/users/notifications',
+            jsonData: data,
+            callback: function (options, success, response) {
+                if (!success) {
+                    Traccar.app.showError(response);
+                }
+            }
+        });
+        
+    }
+});

--- a/web/app/view/SettingsMenu.js
+++ b/web/app/view/SettingsMenu.js
@@ -48,6 +48,9 @@ Ext.define('Traccar.view.SettingsMenu', {
             handler: 'onUsersClick',
             reference: 'settingsUsersButton'
         }, {
+            text: Strings.sharedNotifications,
+            handler: 'onNotificationsClick',
+        }, {
             text: Strings.loginLogout,
             handler: 'onLogoutClick'
         }]

--- a/web/app/view/SettingsMenuController.js
+++ b/web/app/view/SettingsMenuController.js
@@ -25,6 +25,7 @@ Ext.define('Traccar.view.SettingsMenuController', {
         'Traccar.view.Users',
         'Traccar.view.Groups',
         'Traccar.view.Geofences',
+        'Traccar.view.Notifications',
         'Traccar.view.BaseWindow'
     ],
 
@@ -73,6 +74,18 @@ Ext.define('Traccar.view.SettingsMenuController', {
             modal: false,
             items: {
                 xtype: 'usersView'
+            }
+        }).show();
+    },
+
+    onNotificationsClick: function () {
+        var user = Traccar.app.getUser();
+        Ext.create('Traccar.view.BaseWindow', {
+            title: Strings.sharedNotifications,
+            modal: false,
+            items: {
+                xtype: 'notificationsView',
+                user: user
             }
         }).show();
     },

--- a/web/app/view/Users.js
+++ b/web/app/view/Users.js
@@ -45,6 +45,11 @@ Ext.define('Traccar.view.Users', {
             disabled: true,
             handler: 'onGeofencesClick',
             reference: 'userGeofencesButton'
+        }, {
+            text: Strings.sharedNotifications,
+            disabled: true,
+            handler: 'onNotificationsClick',
+            reference: 'userNotificationsButton'
         }]
     },
 

--- a/web/app/view/UsersController.js
+++ b/web/app/view/UsersController.js
@@ -23,6 +23,7 @@ Ext.define('Traccar.view.UsersController', {
         'Traccar.view.UserDevices',
         'Traccar.view.UserGroups',
         'Traccar.view.UserGeofences',
+        'Traccar.view.Notifications',
         'Traccar.view.BaseWindow'
     ],
 
@@ -114,6 +115,18 @@ Ext.define('Traccar.view.UsersController', {
         }).show();
     },
 
+    onNotificationsClick: function () {
+        var user = this.getView().getSelectionModel().getSelection()[0];
+        Ext.create('Traccar.view.BaseWindow', {
+            title: Strings.sharedNotifications,
+            modal: false,
+            items: {
+                xtype: 'notificationsView',
+                user: user
+            }
+        }).show();
+    },
+
     onSelectionChange: function (selected) {
         var disabled = selected.length > 0;
         this.lookupReference('toolbarEditButton').setDisabled(disabled);
@@ -121,5 +134,6 @@ Ext.define('Traccar.view.UsersController', {
         this.lookupReference('userDevicesButton').setDisabled(disabled);
         this.lookupReference('userGroupsButton').setDisabled(disabled);
         this.lookupReference('userGeofencesButton').setDisabled(disabled);
+        this.lookupReference('userNotificationsButton').setDisabled(disabled);
     }
 });

--- a/web/l10n/en.json
+++ b/web/l10n/en.json
@@ -19,6 +19,7 @@
     "sharedSearch": "Search",
     "sharedGeofence": "Geofence",
     "sharedGeofences": "Geofences",
+    "sharedNotifications": "Notifications",
     "errorTitle": "Error",
     "errorUnknown": "Unknown error",
     "errorConnection": "Connection error",
@@ -106,7 +107,10 @@
     "eventDeviceMoving": "Device is moving",
     "eventDeviceStopped": "Device is stopped",
     "eventDeviceOverspeed": "Device exceeds the speed",
-    "eventCommandResult": "Command result: ",
+    "eventCommandResult": "Command result",
     "eventGeofenceEnter": "Device has entered geofence",
-    "eventGeofenceExit": "Device has exited geofence"
+    "eventGeofenceExit": "Device has exited geofence",
+    "notificationType": "Type of Notification",
+    "notificationWeb": "Send via Web",
+    "notificationMail": "Send via Mail"
 }


### PR DESCRIPTION
I added sending notifications via email. Settings from Config have priority before users settings.

Added notifications settings and dialog to web-client as discussed. It is not ordinary object like device or user, it is like link, but with attributes. Id is used only for database actions. Notification with empty attributes is removed from database (like unlink).

Extended user model to get/store mail settings.

I did not add attributes to Server model because they can be requested via API without login. The mail settings should be somehow hidden from everybody.

Email Templates is hardcoded for now.

I used javamail 1.4.7 because something wrong with maven repositories and 1.5.5 couldn't be used for runtime.
Inline conditionals are very convenient, I removed AvoidInlineConditionals from checkstyle tho.
