### PR TITLE
Revert GranitFrameDecoder

### DIFF
--- a/src/org/traccar/protocol/GranitFrameDecoder.java
+++ b/src/org/traccar/protocol/GranitFrameDecoder.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 Anton Tananaev (anton.tananaev@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.protocol;
+
+import java.nio.charset.StandardCharsets;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.ChannelBuffers;
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.handler.codec.frame.FrameDecoder;
+import org.traccar.helper.StringFinder;
+
+public class GranitFrameDecoder extends FrameDecoder {
+
+    private static final int HEADER_LENGTH = 6;
+    private static final int CHECKSUM_LENGTH = 3;
+    private static final int SHORT_LENGTH = 2;
+
+    @Override
+    protected Object decode(
+            ChannelHandlerContext ctx, Channel channel, ChannelBuffer buf) throws Exception {
+
+        if (buf.readableBytes() > HEADER_LENGTH + SHORT_LENGTH) {
+            ChannelBuffer frame = ChannelBuffers.dynamicBuffer();
+            buf.getBytes(buf.readerIndex(), frame, HEADER_LENGTH);
+            String headerString = frame.toString(StandardCharsets.US_ASCII);
+            if (headerString.equals("+RRCB~") || headerString.equals("+DDAT~")) {
+                int length = buf.getUnsignedShort(buf.readerIndex() + HEADER_LENGTH);
+                if (buf.readableBytes() >= HEADER_LENGTH + SHORT_LENGTH + length + CHECKSUM_LENGTH) {
+                    frame = buf.readBytes(HEADER_LENGTH + SHORT_LENGTH + length + CHECKSUM_LENGTH);
+                    if (buf.readableBytes() > 2) {
+                        buf.skipBytes(2); //skip \r\n
+                    }
+                    return frame;
+                } else {
+                    return null; //damaged packet
+                }
+            }
+        }
+
+        int index = buf.indexOf(buf.readerIndex(), buf.writerIndex(), new StringFinder("\r\n"));
+        if (index != -1) {
+            ChannelBuffer frame = buf.readBytes(index - buf.readerIndex());
+            buf.skipBytes(2);
+            return frame;
+        }
+
+        return null;
+    }
+
+}

--- a/src/org/traccar/protocol/GranitProtocol.java
+++ b/src/org/traccar/protocol/GranitProtocol.java
@@ -17,7 +17,6 @@ package org.traccar.protocol;
 
 import org.jboss.netty.bootstrap.ServerBootstrap;
 import org.jboss.netty.channel.ChannelPipeline;
-import org.jboss.netty.handler.codec.frame.LineBasedFrameDecoder;
 import org.traccar.BaseProtocol;
 import org.traccar.TrackerServer;
 import org.traccar.model.Command;
@@ -40,7 +39,7 @@ public class GranitProtocol extends BaseProtocol {
         TrackerServer server = new TrackerServer(new ServerBootstrap(), this.getName()) {
             @Override
             protected void addSpecificHandlers(ChannelPipeline pipeline) {
-                pipeline.addLast("frameDecoder", new LineBasedFrameDecoder(1024));
+                pipeline.addLast("frameDecoder", new GranitFrameDecoder());
                 pipeline.addLast("objectEncoder", new GranitProtocolEncoder());
                 pipeline.addLast("objectDecoder", new GranitProtocolDecoder(GranitProtocol.this));
             }

--- a/test/org/traccar/protocol/GranitFrameDecoderTest.java
+++ b/test/org/traccar/protocol/GranitFrameDecoderTest.java
@@ -1,0 +1,48 @@
+package org.traccar.protocol;
+
+import java.nio.ByteOrder;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.traccar.ProtocolTest;
+
+public class GranitFrameDecoderTest extends ProtocolTest {
+
+    @Test
+    public void testDecode() throws Exception {
+
+        GranitFrameDecoder decoder = new GranitFrameDecoder();
+
+        Assert.assertEquals(
+                binary("2b525243427e1a003e2934757c57b8b03c38d279b4e61e9bd7006b000000001c00002a4533"),
+                decoder.decode(null, null, binary(ByteOrder.LITTLE_ENDIAN, "2b525243427e1a003e2934757c57b8b03c38d279b4e61e9bd7006b000000001c00002a45330d0a")));
+
+        Assert.assertEquals(
+                binary("2b525243427e1a000d0a34757c57b8b03c38d279b4e61e9bd7006b000000001c00002a4533"),
+                decoder.decode(null, null, binary(ByteOrder.LITTLE_ENDIAN, "2b525243427e1a000d0a34757c57b8b03c38d279b4e61e9bd7006b000000001c00002a45330d0a")));
+
+        Assert.assertEquals(
+                binary("4f4b"),
+                decoder.decode(null, null, binary(ByteOrder.LITTLE_ENDIAN, "4f4b0d0a2b525243427e1a000d0a34757c57b8b03c38d279b4e61e9bd7006b000000001c00002a45330d0a")));
+
+        Assert.assertEquals(
+                binary("2b444441547e84003e290401d01690737c57b8903c383c7fa0e5081b64006b000000001c0000b8803c388e7fe7e5102197006c000000001c0000b8813c38ad7f02e6042035006c000000001d0000b8813c38bf7f13e6001d1e006c000000001d0000b8813c38bf7f13e6001d00006c000000001d0000b8903c38977f34e6091065006c000000001e000014002a3932"),
+                decoder.decode(null, null, binary(ByteOrder.LITTLE_ENDIAN,
+                        "2b444441547e84003e290401d01690737c57b8903c383c7fa0e5081b64006b000000001c0000b8803c388e7fe7e5102197006c000000001c0000b8813c38ad7f02e6042035006c000000001d0000b8813c38bf7f13e6001d1e006c000000001d0000b8813c38bf7f13e6001d00006c000000001d0000b8903c38977f34e6091065006c000000001e000014002a39320d0a")));
+
+        Assert.assertEquals(
+                binary("2b444441547e84003e290401d41680747c57f8a03c38987f50e6005300006c000000001c0000f8b03c38987f50e6005300006c000000001c0000fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe14002a4346"),
+                decoder.decode(null, null, binary(ByteOrder.LITTLE_ENDIAN,
+                        "2b444441547e84003e290401d41680747c57f8a03c38987f50e6005300006c000000001c0000f8b03c38987f50e6005300006c000000001c0000fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe14002a43460d0a")));
+
+        Assert.assertEquals(
+                binary("2b49444e543a204e6176696761746f722e30347820204669726d776172652076657273696f6e202030373132474c4e202a3231"),
+                decoder.decode(null, null, binary(ByteOrder.LITTLE_ENDIAN, "2b49444e543a204e6176696761746f722e30347820204669726d776172652076657273696f6e202030373132474c4e202a32310d0a")));
+
+        Assert.assertEquals(
+                binary("4552524f522057524f4e4720434845434b53554d5f31"),
+                decoder.decode(null, null, binary(ByteOrder.LITTLE_ENDIAN, "4552524f522057524f4e4720434845434b53554d5f310d0a")));
+
+    }
+
+}

--- a/test/org/traccar/protocol/GranitProtocolDecoderTest.java
+++ b/test/org/traccar/protocol/GranitProtocolDecoderTest.java
@@ -13,21 +13,21 @@ public class GranitProtocolDecoderTest extends ProtocolTest {
         GranitProtocolDecoder decoder = new GranitProtocolDecoder(new GranitProtocol());
 
         verifyPosition(decoder, binary(ByteOrder.LITTLE_ENDIAN,
-                "2b525243427e1a003e2934757c57b8b03c38d279b4e61e9bd7006b000000001c00002a45330d0a"));
-        
+                "2b525243427e1a003e2934757c57b8b03c38d279b4e61e9bd7006b000000001c00002a4533"));
+
         verifyPositions(decoder, binary(ByteOrder.LITTLE_ENDIAN,
-                "2b444441547e84003e290401d01690737c57b8903c383c7fa0e5081b64006b000000001c0000b8803c388e7fe7e5102197006c000000001c0000b8813c38ad7f02e6042035006c000000001d0000b8813c38bf7f13e6001d1e006c000000001d0000b8813c38bf7f13e6001d00006c000000001d0000b8903c38977f34e6091065006c000000001e000014002a39320d0a"));
-        
+                "2b444441547e84003e290401d01690737c57b8903c383c7fa0e5081b64006b000000001c0000b8803c388e7fe7e5102197006c000000001c0000b8813c38ad7f02e6042035006c000000001d0000b8813c38bf7f13e6001d1e006c000000001d0000b8813c38bf7f13e6001d00006c000000001d0000b8903c38977f34e6091065006c000000001e000014002a3932"));
+
         verifyPositions(decoder, binary(ByteOrder.LITTLE_ENDIAN,
-                "2b444441547e84003e290401d41680747c57f8a03c38987f50e6005300006c000000001c0000f8b03c38987f50e6005300006c000000001c0000fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe14002a43460d0a"));
-        
+                "2b444441547e84003e290401d41680747c57f8a03c38987f50e6005300006c000000001c0000f8b03c38987f50e6005300006c000000001c0000fefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefe14002a4346"));
+
         //+IDNT: Navigator.04x  Firmware version  0712GLN *21
         verifyAttributes(decoder, binary(ByteOrder.LITTLE_ENDIAN,
-                "2b49444e543a204e6176696761746f722e30347820204669726d776172652076657273696f6e202030373132474c4e202a32310d0a"));
-        
+                "2b49444e543a204e6176696761746f722e30347820204669726d776172652076657273696f6e202030373132474c4e202a3231"));
+
         //ERROR WRONG CHECKSUM_1
         verifyAttributes(decoder, binary(ByteOrder.LITTLE_ENDIAN,
-                "4552524f522057524f4e4720434845434b53554d5f310d0a"));
+                "4552524f522057524f4e4720434845434b53554d5f31"));
     }
 
 }


### PR DESCRIPTION
`LineBasedFrameDecoder` did not fit at all, It handles both \n and \r\n. 0x0a appears rather frequently in binary data.
`DelimiterBasedFrameDecoder` is better but we can't exclude appearing 0x0d0a in binary data, for example I can set deviceId to 2537 and never handle any position. 

Because of that I've added reading frame based on `length` field of packet. Not binary packets handled as usual with \r\n delimiter.