### PR TITLE
Increment time in archive points for Granit protocol

### DIFF
--- a/src/org/traccar/protocol/GranitProtocolDecoder.java
+++ b/src/org/traccar/protocol/GranitProtocolDecoder.java
@@ -192,12 +192,13 @@ public class GranitProtocolDecoder extends BaseProtocolDecoder {
             while (nblocks > 0) {
                 nblocks--;
                 long unixTime = buf.readUnsignedInt();
+                int timeIncrement = buf.getUnsignedShort(buf.readerIndex() + 120);
                 for (int i = 0; i < 6; i++) {
                     if (buf.getUnsignedByte(buf.readerIndex()) != 0xFE) {
                         Position position = new Position();
                         position.setProtocol(getProtocolName());
                         position.setDeviceId(getDeviceId());
-                        position.setTime(new Date(unixTime * 1000));
+                        position.setTime(new Date((unixTime + i * timeIncrement) * 1000));
                         decodeStructure(buf, position);
                         positions.add(position);
                     } else {


### PR DESCRIPTION
I was looking on jumping track and think why protocols authors choose so odd format of archive points.
Six points have same time.
I've looked in documentation and in packets, and noticed that increment equals period of reporting.
Is it me who is silly or documentation writer?
> "Одинаковые блоки по 126 байт,  каждый начинается с четырёхбайтового значения времени ( unsigned long ), затем идут шесть 20-ти байтовых записей ,  затем двухбайтовое значение инкремента ( unsigned short ), каждая из записей имеет следующую структуру:"

Is it understandable that `increment` is for time?

I would not surprise if order of points in packet is backward, because of that I took a walk with device and noticed place and time. Then I started server and get archive points.
Time and place from archive seems fits to real time and place.

Sorry for this outburst. One word in documentation could make it really clearer.