### PR TITLE
Fix "from" in mail notifications

### DIFF
--- a/src/org/traccar/notification/NotificationMail.java
+++ b/src/org/traccar/notification/NotificationMail.java
@@ -87,9 +87,15 @@ public final class NotificationMail {
             boolean auth = Boolean.parseBoolean((String) object.getAttributes().get("mail.smtp.auth"));
             result.put("mail.smtp.auth", auth);
 
-            result.put("mail.smtp.username", object.getAttributes().get("mail.smtp.username"));
-            result.put("mail.smtp.password", object.getAttributes().get("mail.smtp.password"));
-            result.put("mail.smtp.from", object.getAttributes().get("mail.smtp.from"));
+            if (object.getAttributes().containsKey("mail.smtp.username")) {
+                result.put("mail.smtp.username", object.getAttributes().get("mail.smtp.username"));
+            }
+            if (object.getAttributes().containsKey("mail.smtp.password")) {
+                result.put("mail.smtp.password", object.getAttributes().get("mail.smtp.password"));
+            }
+            if (object.getAttributes().containsKey("mail.smtp.from")) {
+                result.put("mail.smtp.from", object.getAttributes().get("mail.smtp.from"));
+            }
         }
         return result;
     }
@@ -114,6 +120,10 @@ public final class NotificationMail {
             mailSession = Session.getDefaultInstance(mailServerProperties, null);
 
             mailMessage = new MimeMessage(mailSession);
+
+            if (mailServerProperties.getProperty("mail.smtp.from") != null) {
+                mailMessage.setFrom(new InternetAddress(mailServerProperties.getProperty("mail.smtp.from")));
+            }
 
             mailMessage.addRecipient(Message.RecipientType.TO, new InternetAddress(
                     Context.getDataManager().getUser(userId).getEmail()));

--- a/web/app/view/AttributesController.js
+++ b/web/app/view/AttributesController.js
@@ -40,17 +40,22 @@ Ext.define('Traccar.view.AttributesController', {
         store.addListener('add', function (store, records, index, eOpts) {
             for (i = 0; i < records.length; i++) {
                 this.getView().record.get('attributes')[records[i].get('name')] = records[i].get('value');
-                this.getView().record.dirty = true;
             }
+            this.getView().record.dirty = true;
         }, this);
         store.addListener('update', function (store, record, operation, modifiedFieldNames, details, eOpts) {
             if (operation === Ext.data.Model.EDIT) {
+                if (record.modified.name !== record.get('name')) {
+                    delete this.getView().record.get('attributes')[record.modified.name];
+                }
                 this.getView().record.get('attributes')[record.get('name')] = record.get('value');
                 this.getView().record.dirty = true;
             }
         }, this);
         store.addListener('remove', function (store, records, index, isMove, eOpts) {
-            delete this.getView().record.get('attributes')[records[index].get('name')];
+            for (var i = 0; i < records.length; i++) {
+                delete this.getView().record.get('attributes')[records[i].get('name')];
+            }
             this.getView().record.dirty = true;
         }, this);
 


### PR DESCRIPTION
According to https://javamail.java.net/nonav/docs/api/com/sun/mail/smtp/package-summary.html

> mail.smtp.from	
> Email address to use for SMTP MAIL command. This sets the envelope return address. Defaults to msg.getFrom() or InternetAddress.getLocalAddress(). NOTE: mail.smtp.user was previously used for this.

Should work and my local server on Zimbra and Gmail understand this, but mail.ru even did not accept mails until I set it via `mailMessage.setFrom`

Hope should fix this https://www.traccar.org/forums/topic/smtp-config-for-notifications/#post-6870

Other changes:
- better handle empty mail user attributes

- fix deleting attribute in attribute editor
- fix duplicating attribute if name changed

PS: sorry for duplicated commits, there was conflict and git solved it like this.