### PR TITLE
Revert back groups cache and split GeofenceManager.refresh() on 3 functions

### DIFF
--- a/src/org/traccar/api/resource/GeofencePermissionResource.java
+++ b/src/org/traccar/api/resource/GeofencePermissionResource.java
@@ -39,7 +39,7 @@ public class GeofencePermissionResource extends BaseResource {
         Context.getPermissionsManager().checkUser(getUserId(), entity.getUserId());
         Context.getPermissionsManager().checkGeofence(getUserId(), entity.getGeofenceId());
         Context.getDataManager().linkGeofence(entity.getUserId(), entity.getGeofenceId());
-        Context.getGeofenceManager().refresh();
+        Context.getGeofenceManager().refreshUserGeofences();
         return Response.ok(entity).build();
     }
 
@@ -49,7 +49,7 @@ public class GeofencePermissionResource extends BaseResource {
         Context.getPermissionsManager().checkUser(getUserId(), entity.getUserId());
         Context.getPermissionsManager().checkGeofence(getUserId(), entity.getGeofenceId());
         Context.getDataManager().unlinkGeofence(entity.getUserId(), entity.getGeofenceId());
-        Context.getGeofenceManager().refresh();
+        Context.getGeofenceManager().refreshUserGeofences();
         return Response.noContent().build();
     }
 

--- a/src/org/traccar/api/resource/GeofenceResource.java
+++ b/src/org/traccar/api/resource/GeofenceResource.java
@@ -78,7 +78,7 @@ public class GeofenceResource extends BaseResource {
         Context.getPermissionsManager().checkReadonly(getUserId());
         Context.getDataManager().addGeofence(entity);
         Context.getDataManager().linkGeofence(getUserId(), entity.getId());
-        Context.getGeofenceManager().refresh();
+        Context.getGeofenceManager().refreshGeofences();
         return Response.ok(entity).build();
     }
 
@@ -97,7 +97,7 @@ public class GeofenceResource extends BaseResource {
         Context.getPermissionsManager().checkReadonly(getUserId());
         Context.getPermissionsManager().checkGeofence(getUserId(), id);
         Context.getDataManager().removeGeofence(id);
-        Context.getGeofenceManager().refresh();
+        Context.getGeofenceManager().refreshGeofences();
         return Response.noContent().build();
     }
 

--- a/src/org/traccar/database/DataManager.java
+++ b/src/org/traccar/database/DataManager.java
@@ -241,7 +241,7 @@ public class DataManager implements IdentityManager {
     }
 
     public Group getGroupById(long id) {
-        /*boolean forceUpdate;
+        boolean forceUpdate;
         groupsLock.readLock().lock();
         try {
             forceUpdate = !groupsById.containsKey(id);
@@ -253,7 +253,7 @@ public class DataManager implements IdentityManager {
             updateGroupCache(forceUpdate);
         } catch (SQLException e) {
             Log.warning(e);
-        }*/
+        }
 
         groupsLock.readLock().lock();
         try {


### PR DESCRIPTION
- Split geofence refresh on 3 functions
- Enable back groupsCache

For now groupsCache have unwanted update only if device(group) linked to deleted group.

I'm researching foreign keys, but have some issues (null and not null incompatibility I think)

For demo servers you can null dead links via sql, it can help for a while.
