### PR TITLE
Fixes for new foreign key constraints 

### DIFF
--- a/debug.xml
+++ b/debug.xml
@@ -187,7 +187,7 @@
     </entry>
 
     <entry key='database.insertGroup'>
-        INSERT INTO groups (name) VALUES (:name);
+        INSERT INTO groups (name, groupId) VALUES (:name, :groupId);
     </entry>
 
     <entry key='database.updateGroup'>

--- a/setup/unix/traccar.xml
+++ b/setup/unix/traccar.xml
@@ -139,7 +139,7 @@
     </entry>
 
     <entry key='database.insertGroup'>
-        INSERT INTO groups (name) VALUES (:name);
+        INSERT INTO groups (name, groupId) VALUES (:name, :groupId);
     </entry>
 
     <entry key='database.updateGroup'>

--- a/setup/windows/traccar.xml
+++ b/setup/windows/traccar.xml
@@ -139,7 +139,7 @@
     </entry>
 
     <entry key='database.insertGroup'>
-        INSERT INTO groups (name) VALUES (:name);
+        INSERT INTO groups (name, groupId) VALUES (:name, :groupId);
     </entry>
 
     <entry key='database.updateGroup'>

--- a/src/org/traccar/database/QueryBuilder.java
+++ b/src/org/traccar/database/QueryBuilder.java
@@ -175,7 +175,11 @@ public final class QueryBuilder {
     public QueryBuilder setLong(String name, long value) throws SQLException {
         for (int i : indexes(name)) {
             try {
-                statement.setLong(i, value);
+                if (value == 0) {
+                    statement.setNull(i, Types.INTEGER);
+                } else {
+                	statement.setLong(i, value);
+                }
             } catch (SQLException error) {
                 statement.close();
                 connection.close();

--- a/src/org/traccar/database/QueryBuilder.java
+++ b/src/org/traccar/database/QueryBuilder.java
@@ -178,7 +178,7 @@ public final class QueryBuilder {
                 if (value == 0) {
                     statement.setNull(i, Types.INTEGER);
                 } else {
-                	statement.setLong(i, value);
+                    statement.setLong(i, value);
                 }
             } catch (SQLException error) {
                 statement.close();

--- a/src/org/traccar/database/QueryBuilder.java
+++ b/src/org/traccar/database/QueryBuilder.java
@@ -173,16 +173,7 @@ public final class QueryBuilder {
     }
 
     public QueryBuilder setLong(String name, long value) throws SQLException {
-        for (int i : indexes(name)) {
-            try {
-                statement.setLong(i, value);
-            } catch (SQLException error) {
-                statement.close();
-                connection.close();
-                throw error;
-            }
-        }
-        return this;
+        return setLong(name, value, false);
     }
 
     public QueryBuilder setLong(String name, long value, boolean nullIfZero) throws SQLException {
@@ -262,11 +253,7 @@ public final class QueryBuilder {
                     } else if (method.getReturnType().equals(int.class)) {
                         setInteger(name, (Integer) method.invoke(object));
                     } else if (method.getReturnType().equals(long.class)) {
-                        if (name.endsWith("Id")) {
-                            setLong(name, (Long) method.invoke(object), true);
-                        } else {
-                            setLong(name, (Long) method.invoke(object));
-                        }
+                        setLong(name, (Long) method.invoke(object), name.endsWith("Id"));
                     } else if (method.getReturnType().equals(double.class)) {
                         setDouble(name, (Double) method.invoke(object));
                     } else if (method.getReturnType().equals(String.class)) {

--- a/src/org/traccar/database/QueryBuilder.java
+++ b/src/org/traccar/database/QueryBuilder.java
@@ -175,7 +175,20 @@ public final class QueryBuilder {
     public QueryBuilder setLong(String name, long value) throws SQLException {
         for (int i : indexes(name)) {
             try {
-                if (value == 0) {
+                statement.setLong(i, value);
+            } catch (SQLException error) {
+                statement.close();
+                connection.close();
+                throw error;
+            }
+        }
+        return this;
+    }
+
+    public QueryBuilder setLong(String name, long value, boolean nullIfZero) throws SQLException {
+        for (int i : indexes(name)) {
+            try {
+                if (value == 0 && nullIfZero) {
                     statement.setNull(i, Types.INTEGER);
                 } else {
                     statement.setLong(i, value);
@@ -249,7 +262,11 @@ public final class QueryBuilder {
                     } else if (method.getReturnType().equals(int.class)) {
                         setInteger(name, (Integer) method.invoke(object));
                     } else if (method.getReturnType().equals(long.class)) {
-                        setLong(name, (Long) method.invoke(object));
+                        if (name.endsWith("Id")) {
+                            setLong(name, (Long) method.invoke(object), true);
+                        } else {
+                            setLong(name, (Long) method.invoke(object));
+                        }
                     } else if (method.getReturnType().equals(double.class)) {
                         setDouble(name, (Double) method.invoke(object));
                     } else if (method.getReturnType().equals(String.class)) {

--- a/web/app/view/GroupsController.js
+++ b/web/app/view/GroupsController.js
@@ -19,6 +19,7 @@ Ext.define('Traccar.view.GroupsController', {
     alias: 'controller.groups',
 
     requires: [
+        'Traccar.view.GroupDialog',
         'Traccar.view.GroupGeofences'
     ],
 


### PR DESCRIPTION
Solution to store `long == 0` as `NULL` in DB is not very nice, but simple. The other one is create "Zero-Group" but I do not like it, to many unpredictable side effects and changes.

 I tested a bit, but did not see any regressions in other places we store `long`s.

Also there was bug in SQL request and warning in browser when editing groups

PS: also I can replace `if (value == 0)` to `if (value == 0 && name.toLowerCase().equals("groupid"))`. It will minimize side effects (if they exist)