### PR TITLE
Move code related to devices to DeviceManager

### DIFF
--- a/src/org/traccar/BaseProtocolDecoder.java
+++ b/src/org/traccar/BaseProtocolDecoder.java
@@ -47,7 +47,9 @@ public abstract class BaseProtocolDecoder extends ExtendedObjectDecoder {
             Device device = Context.getIdentityManager().getDeviceByUniqueId(uniqueId);
             if (device != null) {
                 deviceId = device.getId();
-                Context.getConnectionManager().addActiveDevice(deviceId, protocol, channel, remoteAddress);
+                if (Context.getConnectionManager() != null) {
+                    Context.getConnectionManager().addActiveDevice(deviceId, protocol, channel, remoteAddress);
+                }
                 return true;
             } else {
                 deviceId = 0;
@@ -78,7 +80,7 @@ public abstract class BaseProtocolDecoder extends ExtendedObjectDecoder {
     public void getLastLocation(Position position, Date deviceTime) {
         position.setOutdated(true);
 
-        Position last = Context.getConnectionManager().getLastPosition(getDeviceId());
+        Position last = Context.getIdentityManager().getLastPosition(getDeviceId());
         if (last != null) {
             position.setFixTime(last.getFixTime());
             position.setValid(last.getValid());

--- a/src/org/traccar/Context.java
+++ b/src/org/traccar/Context.java
@@ -18,6 +18,7 @@ package org.traccar;
 import com.ning.http.client.AsyncHttpClient;
 import org.traccar.database.ConnectionManager;
 import org.traccar.database.DataManager;
+import org.traccar.database.DeviceManager;
 import org.traccar.database.IdentityManager;
 import org.traccar.database.NotificationManager;
 import org.traccar.database.PermissionsManager;
@@ -65,6 +66,12 @@ public final class Context {
 
     public static DataManager getDataManager() {
         return dataManager;
+    }
+
+    private static DeviceManager deviceManager;
+
+    public static DeviceManager getDeviceManager() {
+        return deviceManager;
     }
 
     private static ConnectionManager connectionManager;
@@ -142,7 +149,12 @@ public final class Context {
         if (config.hasKey("database.url")) {
             dataManager = new DataManager(config);
         }
-        identityManager = dataManager;
+
+        if (dataManager != null) {
+            deviceManager = new DeviceManager(dataManager);
+        }
+
+        identityManager = deviceManager;
 
         if (config.getBoolean("geocoder.enable")) {
             String type = config.getString("geocoder.type", "google");
@@ -205,7 +217,7 @@ public final class Context {
 
         permissionsManager = new PermissionsManager(dataManager);
 
-        connectionManager = new ConnectionManager(dataManager);
+        connectionManager = new ConnectionManager();
 
         if (config.getBoolean("event.geofenceHandler")) {
             geofenceManager = new GeofenceManager(dataManager);
@@ -225,7 +237,6 @@ public final class Context {
 
     public static void init(IdentityManager testIdentityManager) {
         config = new Config();
-        connectionManager = new ConnectionManager(null);
         identityManager = testIdentityManager;
     }
 

--- a/src/org/traccar/DefaultDataHandler.java
+++ b/src/org/traccar/DefaultDataHandler.java
@@ -25,10 +25,7 @@ public class DefaultDataHandler extends BaseDataHandler {
 
         try {
             Context.getDataManager().addPosition(position);
-            Position lastPosition = Context.getConnectionManager().getLastPosition(position.getDeviceId());
-            if (lastPosition == null || position.getFixTime().compareTo(lastPosition.getFixTime()) > 0) {
-                Context.getDataManager().updateLatestPosition(position);
-            }
+            Context.getDeviceManager().updateLatestPosition(position);
         } catch (Exception error) {
             Log.warning(error);
         }

--- a/src/org/traccar/DistanceHandler.java
+++ b/src/org/traccar/DistanceHandler.java
@@ -25,8 +25,8 @@ import java.math.RoundingMode;
 public class DistanceHandler extends BaseDataHandler {
 
     private Position getLastPosition(long deviceId) {
-        if (Context.getConnectionManager() != null) {
-            return Context.getConnectionManager().getLastPosition(deviceId);
+        if (Context.getIdentityManager() != null) {
+            return Context.getIdentityManager().getLastPosition(deviceId);
         }
         return null;
     }

--- a/src/org/traccar/FilterHandler.java
+++ b/src/org/traccar/FilterHandler.java
@@ -57,8 +57,8 @@ public class FilterHandler extends BaseDataHandler {
     }
 
     private Position getLastPosition(long deviceId) {
-        if (Context.getConnectionManager() != null) {
-            return Context.getConnectionManager().getLastPosition(deviceId);
+        if (Context.getIdentityManager() != null) {
+            return Context.getIdentityManager().getLastPosition(deviceId);
         }
         return null;
     }

--- a/src/org/traccar/MainEventHandler.java
+++ b/src/org/traccar/MainEventHandler.java
@@ -37,7 +37,7 @@ public class MainEventHandler extends IdleStateAwareChannelHandler {
 
             Position position = (Position) e.getMessage();
 
-            String uniqueId = Context.getDataManager().getDeviceById(position.getDeviceId()).getUniqueId();
+            String uniqueId = Context.getIdentityManager().getDeviceById(position.getDeviceId()).getUniqueId();
 
             // Log position
             StringBuilder s = new StringBuilder();
@@ -54,11 +54,6 @@ public class MainEventHandler extends IdleStateAwareChannelHandler {
                 s.append(", result: ").append(cmdResult);
             }
             Log.info(s.toString());
-
-            Position lastPosition = Context.getConnectionManager().getLastPosition(position.getDeviceId());
-            if (lastPosition == null || position.getFixTime().compareTo(lastPosition.getFixTime()) > 0) {
-                Context.getConnectionManager().updatePosition(position);
-            }
         }
     }
 

--- a/src/org/traccar/api/AsyncSocket.java
+++ b/src/org/traccar/api/AsyncSocket.java
@@ -48,7 +48,7 @@ public class AsyncSocket extends WebSocketAdapter implements ConnectionManager.U
         super.onWebSocketConnect(session);
 
         Map<String, Collection<?>> data = new HashMap<>();
-        data.put(KEY_POSITIONS, Context.getConnectionManager().getInitialState(userId));
+        data.put(KEY_POSITIONS, Context.getDeviceManager().getInitialState(userId));
         sendData(data);
 
         Context.getConnectionManager().addListener(userId, this);

--- a/src/org/traccar/api/resource/DeviceResource.java
+++ b/src/org/traccar/api/resource/DeviceResource.java
@@ -44,20 +44,20 @@ public class DeviceResource extends BaseResource {
             @QueryParam("all") boolean all, @QueryParam("userId") long userId) throws SQLException {
         if (all) {
             Context.getPermissionsManager().checkAdmin(getUserId());
-            return Context.getDataManager().getAllDevicesCached();
+            return Context.getDeviceManager().getAllDevices();
         } else {
             if (userId == 0) {
                 userId = getUserId();
             }
             Context.getPermissionsManager().checkUser(getUserId(), userId);
-            return Context.getDataManager().getDevices(userId);
+            return Context.getDeviceManager().getDevices(userId);
         }
     }
 
     @POST
     public Response add(Device entity) throws SQLException {
         Context.getPermissionsManager().checkReadonly(getUserId());
-        Context.getDataManager().addDevice(entity);
+        Context.getDeviceManager().addDevice(entity);
         Context.getDataManager().linkDevice(getUserId(), entity.getId());
         Context.getPermissionsManager().refresh();
         if (Context.getGeofenceManager() != null) {
@@ -71,7 +71,7 @@ public class DeviceResource extends BaseResource {
     public Response update(@PathParam("id") long id, Device entity) throws SQLException {
         Context.getPermissionsManager().checkReadonly(getUserId());
         Context.getPermissionsManager().checkDevice(getUserId(), id);
-        Context.getDataManager().updateDevice(entity);
+        Context.getDeviceManager().updateDevice(entity);
         if (Context.getGeofenceManager() != null) {
             Context.getGeofenceManager().refresh();
         }
@@ -83,7 +83,7 @@ public class DeviceResource extends BaseResource {
     public Response remove(@PathParam("id") long id) throws SQLException {
         Context.getPermissionsManager().checkReadonly(getUserId());
         Context.getPermissionsManager().checkDevice(getUserId(), id);
-        Context.getDataManager().removeDevice(id);
+        Context.getDeviceManager().removeDevice(id);
         Context.getPermissionsManager().refresh();
         if (Context.getGeofenceManager() != null) {
             Context.getGeofenceManager().refresh();

--- a/src/org/traccar/api/resource/PositionResource.java
+++ b/src/org/traccar/api/resource/PositionResource.java
@@ -39,7 +39,7 @@ public class PositionResource extends BaseResource {
             @QueryParam("deviceId") long deviceId, @QueryParam("from") String from, @QueryParam("to") String to)
             throws SQLException {
         if (deviceId == 0) {
-            return Context.getConnectionManager().getInitialState(getUserId());
+            return Context.getDeviceManager().getInitialState(getUserId());
         } else {
             Context.getPermissionsManager().checkDevice(getUserId(), deviceId);
             return Context.getDataManager().getPositions(

--- a/src/org/traccar/database/DeviceManager.java
+++ b/src/org/traccar/database/DeviceManager.java
@@ -1,0 +1,261 @@
+package org.traccar.database;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.traccar.Config;
+import org.traccar.Context;
+import org.traccar.helper.Log;
+import org.traccar.model.Device;
+import org.traccar.model.Position;
+
+public class DeviceManager implements IdentityManager {
+
+    private final Config config;
+    private final DataManager dataManager;
+    private final long dataRefreshDelay;
+
+    private final ReadWriteLock devicesLock = new ReentrantReadWriteLock();
+    private final Map<Long, Device> devicesById = new HashMap<>();
+    private final Map<String, Device> devicesByUniqueId = new HashMap<>();
+    private long devicesLastUpdate;
+
+    private final Map<Long, Position> positions = new ConcurrentHashMap<>();
+
+    public DeviceManager(DataManager dataManager) {
+        this.dataManager = dataManager;
+        this.config = Context.getConfig();
+        dataRefreshDelay = config.getLong("database.refreshDelay", DataManager.DEFAULT_REFRESH_DELAY) * 1000;
+        if (dataManager != null) {
+            try {
+                for (Position position : dataManager.getLatestPositions()) {
+                    positions.put(position.getDeviceId(), position);
+                }
+            } catch (SQLException error) {
+                Log.warning(error);
+            }
+        }
+    }
+
+    private void updateDeviceCache(boolean force) throws SQLException {
+        boolean needWrite;
+        devicesLock.readLock().lock();
+        try {
+            needWrite = force || System.currentTimeMillis() - devicesLastUpdate > dataRefreshDelay;
+        } finally {
+            devicesLock.readLock().unlock();
+        }
+
+        if (needWrite) {
+            devicesLock.writeLock().lock();
+            try {
+                if (force || System.currentTimeMillis() - devicesLastUpdate > dataRefreshDelay) {
+                    devicesById.clear();
+                    devicesByUniqueId.clear();
+                    GeofenceManager geofenceManager = Context.getGeofenceManager();
+                    for (Device device : dataManager.getAllDevices()) {
+                        devicesById.put(device.getId(), device);
+                        devicesByUniqueId.put(device.getUniqueId(), device);
+                        if (geofenceManager != null) {
+                            Position lastPosition = getLastPosition(device.getId());
+                            if (lastPosition != null) {
+                                device.setGeofenceIds(geofenceManager.getCurrentDeviceGeofences(lastPosition));
+                            }
+                        }
+                    }
+                    devicesLastUpdate = System.currentTimeMillis();
+                }
+            } finally {
+                devicesLock.writeLock().unlock();
+            }
+        }
+    }
+
+    @Override
+    public Device getDeviceById(long id) {
+        boolean forceUpdate;
+        devicesLock.readLock().lock();
+        try {
+            forceUpdate = !devicesById.containsKey(id);
+        } finally {
+            devicesLock.readLock().unlock();
+        }
+
+        try {
+            updateDeviceCache(forceUpdate);
+        } catch (SQLException e) {
+            Log.warning(e);
+        }
+
+        devicesLock.readLock().lock();
+        try {
+            return devicesById.get(id);
+        } finally {
+            devicesLock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public Device getDeviceByUniqueId(String uniqueId) throws SQLException {
+        boolean forceUpdate;
+        devicesLock.readLock().lock();
+        try {
+            forceUpdate = !devicesByUniqueId.containsKey(uniqueId) && !config.getBoolean("database.ignoreUnknown");
+        } finally {
+            devicesLock.readLock().unlock();
+        }
+
+        updateDeviceCache(forceUpdate);
+
+        devicesLock.readLock().lock();
+        try {
+            return devicesByUniqueId.get(uniqueId);
+        } finally {
+            devicesLock.readLock().unlock();
+        }
+    }
+
+    public Collection<Device> getAllDevices() {
+        boolean forceUpdate;
+        devicesLock.readLock().lock();
+        try {
+            forceUpdate = devicesById.isEmpty();
+        } finally {
+            devicesLock.readLock().unlock();
+        }
+
+        try {
+            updateDeviceCache(forceUpdate);
+        } catch (SQLException e) {
+            Log.warning(e);
+        }
+
+        devicesLock.readLock().lock();
+        try {
+            return devicesById.values();
+        } finally {
+            devicesLock.readLock().unlock();
+        }
+    }
+
+    public Collection<Device> getDevices(long userId) throws SQLException {
+        Collection<Device> devices = new ArrayList<>();
+        devicesLock.readLock().lock();
+        try {
+            for (long id : Context.getPermissionsManager().getDevicePermissions(userId)) {
+                    devices.add(devicesById.get(id));
+            }
+        } finally {
+            devicesLock.readLock().unlock();
+        }
+        return devices;
+    }
+
+    public void addDevice(Device device) throws SQLException {
+        dataManager.addDevice(device);
+
+        devicesLock.writeLock().lock();
+        try {
+            devicesById.put(device.getId(), device);
+            devicesByUniqueId.put(device.getUniqueId(), device);
+        } finally {
+            devicesLock.writeLock().unlock();
+        }
+    }
+
+    public void updateDevice(Device device) throws SQLException {
+        dataManager.updateDevice(device);
+
+        devicesLock.writeLock().lock();
+        try {
+            devicesById.put(device.getId(), device);
+            devicesByUniqueId.put(device.getUniqueId(), device);
+        } finally {
+            devicesLock.writeLock().unlock();
+        }
+    }
+
+    public void updateDeviceStatus(Device device) throws SQLException {
+        dataManager.updateDeviceStatus(device);
+
+        devicesLock.writeLock().lock();
+        try {
+            if (devicesById.containsKey(device.getId())) {
+                Device cachedDevice = devicesById.get(device.getId());
+                cachedDevice.setStatus(device.getStatus());
+                cachedDevice.setMotion(device.getMotion());
+            }
+        } finally {
+            devicesLock.writeLock().unlock();
+        }
+    }
+
+    public void removeDevice(long deviceId) throws SQLException {
+        dataManager.removeDevice(deviceId);
+
+        devicesLock.writeLock().lock();
+        try {
+            if (devicesById.containsKey(deviceId)) {
+                String deviceUniqueId = devicesById.get(deviceId).getUniqueId();
+                devicesById.remove(deviceId);
+                devicesByUniqueId.remove(deviceUniqueId);
+            }
+        } finally {
+            devicesLock.writeLock().unlock();
+        }
+
+        positions.remove(deviceId);
+    }
+
+    public void updateLatestPosition(Position position) throws SQLException {
+
+        Position lastPosition = getLastPosition(position.getDeviceId());
+        if (lastPosition == null || position.getFixTime().compareTo(lastPosition.getFixTime()) > 0) {
+
+            dataManager.updateLatestPosition(position);
+
+            devicesLock.writeLock().lock();
+            try {
+                if (devicesById.containsKey(position.getDeviceId())) {
+                    devicesById.get(position.getDeviceId()).setPositionId(position.getId());
+                }
+            } finally {
+                devicesLock.writeLock().unlock();
+            }
+
+            positions.put(position.getDeviceId(), position);
+
+            if (Context.getConnectionManager() != null) {
+                Context.getConnectionManager().updatePosition(position);
+            }
+        }
+    }
+
+    @Override
+    public Position getLastPosition(long deviceId) {
+        return positions.get(deviceId);
+    }
+
+    public Collection<Position> getInitialState(long userId) {
+
+        List<Position> result = new LinkedList<>();
+
+        if (Context.getPermissionsManager() != null) {
+            for (long deviceId : Context.getPermissionsManager().getDevicePermissions(userId)) {
+                if (positions.containsKey(deviceId)) {
+                    result.add(positions.get(deviceId));
+                }
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/org/traccar/database/GeofenceManager.java
+++ b/src/org/traccar/database/GeofenceManager.java
@@ -173,7 +173,7 @@ public class GeofenceManager {
                             .add(deviceGeofence.getGeofenceId());
                     }
 
-                    for (Device device : dataManager.getAllDevicesCached()) {
+                    for (Device device : Context.getDeviceManager().getAllDevices()) {
                         long groupId = device.getGroupId();
                         while (groupId != 0) {
                             getDeviceGeofences(deviceGeofencesWithGroups,
@@ -190,7 +190,7 @@ public class GeofenceManager {
                         } else {
                             deviceGeofenceIds.clear();
                         }
-                        Position lastPosition = Context.getConnectionManager().getLastPosition(device.getId());
+                        Position lastPosition = Context.getIdentityManager().getLastPosition(device.getId());
                         if (lastPosition != null && deviceGeofencesWithGroups.containsKey(device.getId())) {
                             for (long geofenceId : deviceGeofencesWithGroups.get(device.getId())) {
                                 Geofence geofence = getGeofence(geofenceId);

--- a/src/org/traccar/database/IdentityManager.java
+++ b/src/org/traccar/database/IdentityManager.java
@@ -16,11 +16,14 @@
 package org.traccar.database;
 
 import org.traccar.model.Device;
+import org.traccar.model.Position;
 
 public interface IdentityManager {
 
     Device getDeviceById(long id);
 
     Device getDeviceByUniqueId(String uniqueId) throws Exception;
+
+    Position getLastPosition(long deviceId);
 
 }

--- a/src/org/traccar/database/PermissionsManager.java
+++ b/src/org/traccar/database/PermissionsManager.java
@@ -78,7 +78,7 @@ public class PermissionsManager {
                 users.put(user.getId(), user);
             }
 
-            GroupTree groupTree = new GroupTree(dataManager.getAllGroups(), dataManager.getAllDevicesCached());
+            GroupTree groupTree = new GroupTree(dataManager.getAllGroups(), Context.getDeviceManager().getAllDevices());
             for (GroupPermission permission : dataManager.getGroupPermissions()) {
                 Set<Long> userGroupPermissions = getGroupPermissions(permission.getUserId());
                 Set<Long> userDevicePermissions = getDevicePermissions(permission.getUserId());

--- a/src/org/traccar/events/GeofenceEventHandler.java
+++ b/src/org/traccar/events/GeofenceEventHandler.java
@@ -43,7 +43,7 @@ public class GeofenceEventHandler extends BaseEventHandler {
 
     @Override
     protected Collection<Event> analyzePosition(Position position) {
-        Device device = dataManager.getDeviceById(position.getDeviceId());
+        Device device = Context.getIdentityManager().getDeviceById(position.getDeviceId());
         if (device == null) {
             return null;
         }

--- a/src/org/traccar/events/MotionEventHandler.java
+++ b/src/org/traccar/events/MotionEventHandler.java
@@ -38,7 +38,7 @@ public class MotionEventHandler extends BaseEventHandler {
     @Override
     protected Collection<Event> analyzePosition(Position position) {
 
-        Device device = Context.getDataManager().getDeviceById(position.getDeviceId());
+        Device device = Context.getIdentityManager().getDeviceById(position.getDeviceId());
         if (device == null) {
             return null;
         }
@@ -53,16 +53,19 @@ public class MotionEventHandler extends BaseEventHandler {
         if (motion == null) {
             motion = Device.STATUS_STOPPED;
         }
-        if (valid && speed > SPEED_THRESHOLD && !motion.equals(Device.STATUS_MOVING)) {
-            Context.getConnectionManager().updateDevice(position.getDeviceId(), Device.STATUS_MOVING, null);
-            result = new ArrayList<>();
-            result.add(new Event(Event.TYPE_DEVICE_MOVING, position.getDeviceId(), position.getId()));
-        } else if (valid && speed < SPEED_THRESHOLD && motion.equals(Device.STATUS_MOVING)) {
-            Context.getConnectionManager().updateDevice(position.getDeviceId(), Device.STATUS_STOPPED, null);
-            result = new ArrayList<>();
-            result.add(new Event(Event.TYPE_DEVICE_STOPPED, position.getDeviceId(), position.getId()));
-        }
         try {
+            if (valid && speed > SPEED_THRESHOLD && !motion.equals(Device.STATUS_MOVING)) {
+                device.setMotion(Device.STATUS_MOVING);
+                Context.getDeviceManager().updateDeviceStatus(device);
+                result = new ArrayList<>();
+                result.add(new Event(Event.TYPE_DEVICE_MOVING, position.getDeviceId(), position.getId()));
+            } else if (valid && speed < SPEED_THRESHOLD && motion.equals(Device.STATUS_MOVING)) {
+                device.setMotion(Device.STATUS_STOPPED);
+                Context.getDeviceManager().updateDeviceStatus(device);
+                result = new ArrayList<>();
+                result.add(new Event(Event.TYPE_DEVICE_STOPPED, position.getDeviceId(), position.getId()));
+            }
+
             if (result != null && !result.isEmpty()) {
                 for (Event event : result) {
                     if (!Context.getDataManager().getLastEvents(position.getDeviceId(),

--- a/src/org/traccar/events/OverspeedEventHandler.java
+++ b/src/org/traccar/events/OverspeedEventHandler.java
@@ -40,7 +40,7 @@ public class OverspeedEventHandler extends BaseEventHandler {
     @Override
     protected Collection<Event> analyzePosition(Position position) {
 
-        Device device = Context.getDataManager().getDeviceById(position.getDeviceId());
+        Device device = Context.getIdentityManager().getDeviceById(position.getDeviceId());
         if (device == null) {
             return null;
         }

--- a/test/org/traccar/ProtocolTest.java
+++ b/test/org/traccar/ProtocolTest.java
@@ -44,6 +44,11 @@ public class ProtocolTest {
             public Device getDeviceByUniqueId(String uniqueId) {
                 return createDevice();
             }
+            
+            @Override
+            public Position getLastPosition(long deviceId) {
+                return null;
+            }
 
         });
     }


### PR DESCRIPTION
Key changes:
1. Move unusual for `DataManager` code to `DeviceManager`
2. Move `lastPositions` from `ConnectionManager`
3. Remove `ConnectionManager` from tests and extend `IdentityManager`

That allowed:
1. Decrease locks for device manipulation (removed 2 `updateDeviceCache`)
2. Decrease locks in ConnectionManager (some `synchronised` replaced to `ConcurentHashMap`, some removed)
3. LastPosition set is in one place now (DB, cached devices objects, cached last positions) that prevent  out of sync.
4. Place for future extending device objects (attributes, sensors states and others)

Note: please note that device status via websocket is updating at the level of `DefaultDataHandler` not at `MainEventHandler`. It is before `EventHandlers`. Because sometimes toast appeared earlier than device moved on map and for not split the logic.