### PR TITLE
Fixed commands for compatibility with some chinese devices

### DIFF
--- a/src/org/traccar/protocol/Gt06ProtocolEncoder.java
+++ b/src/org/traccar/protocol/Gt06ProtocolEncoder.java
@@ -56,9 +56,9 @@ public class Gt06ProtocolEncoder extends BaseProtocolEncoder {
 
         switch (command.getType()) {
             case Command.TYPE_ENGINE_STOP:
-                return encodeContent("Relay,1#");
+                return encodeContent("DYD,000000#");
             case Command.TYPE_ENGINE_RESUME:
-                return encodeContent("Relay,0#");
+                return encodeContent("HFYD,000000#");
             default:
                 Log.warning(new UnsupportedOperationException(command.getType()));
                 break;

--- a/test/org/traccar/protocol/Gt06ProtocolEncoderTest.java
+++ b/test/org/traccar/protocol/Gt06ProtocolEncoderTest.java
@@ -15,7 +15,7 @@ public class Gt06ProtocolEncoderTest extends ProtocolTest {
         command.setDeviceId(1);
         command.setType(Command.TYPE_ENGINE_STOP);
 
-        verifyCommand(encoder, command, binary("787812800c0000000052656c61792c312300009dee0d0a"));
+        verifyCommand(encoder, command, binary("787815800f000000004459442c303030303030230000e6c40d0a"));
 
     }
 


### PR DESCRIPTION
Some chinese devices as BW08, not receive the "Relay,1#" command and not cut the engine.
From communication protocol, I change the command for "DYD,000000#".
Regards.