### PR TITLE
OverspeedEventHandler enhancement to use attributes

### DIFF
--- a/debug.xml
+++ b/debug.xml
@@ -45,6 +45,7 @@
     <entry key='event.suppressRepeated'>60</entry>
     <entry key='event.overspeedHandler'>true</entry>
     <entry key='event.overspeed.groupsEnabled'>true</entry>
+    <entry key='event.overspeed.riseOnce'>true</entry>
     <entry key='event.motionHandler'>true</entry>
     <entry key='event.geofenceHandler'>true</entry>
     <entry key='event.alertHandler'>true</entry>

--- a/debug.xml
+++ b/debug.xml
@@ -45,7 +45,7 @@
 
     <entry key='event.enable'>true</entry>
     <entry key='event.overspeedHandler'>true</entry>
-    <entry key='event.overspeed.riseOnce'>true</entry>
+    <entry key='event.overspeed.notRepeat'>true</entry>
     <entry key='event.motionHandler'>true</entry>
     <entry key='event.geofenceHandler'>true</entry>
     <entry key='event.alertHandler'>true</entry>

--- a/debug.xml
+++ b/debug.xml
@@ -42,7 +42,6 @@
     <entry key='logger.file'>target/tracker-server.log</entry>
 
     <entry key='event.enable'>true</entry>
-    <entry key='event.suppressRepeated'>60</entry>
     <entry key='event.overspeedHandler'>true</entry>
     <entry key='event.overspeed.groupsEnabled'>true</entry>
     <entry key='event.overspeed.riseOnce'>true</entry>

--- a/debug.xml
+++ b/debug.xml
@@ -41,9 +41,10 @@
     <entry key='logger.level'>all</entry>
     <entry key='logger.file'>target/tracker-server.log</entry>
 
+    <entry key='deviceManager.lookupGroupsAttribute'>true</entry>
+
     <entry key='event.enable'>true</entry>
     <entry key='event.overspeedHandler'>true</entry>
-    <entry key='event.overspeed.groupsEnabled'>true</entry>
     <entry key='event.overspeed.riseOnce'>true</entry>
     <entry key='event.motionHandler'>true</entry>
     <entry key='event.geofenceHandler'>true</entry>

--- a/debug.xml
+++ b/debug.xml
@@ -171,7 +171,7 @@
     </entry>
 
     <entry key='database.updateDeviceStatus'>
-        UPDATE devices SET status = :status, lastUpdate = :lastUpdate WHERE id = :id;
+        UPDATE devices SET lastUpdate = :lastUpdate WHERE id = :id;
     </entry>
 
     <entry key='database.deleteDevice'>

--- a/debug.xml
+++ b/debug.xml
@@ -44,7 +44,7 @@
     <entry key='event.enable'>true</entry>
     <entry key='event.suppressRepeated'>60</entry>
     <entry key='event.overspeedHandler'>true</entry>
-    <entry key='event.globalSpeedLimit'>90</entry>
+    <entry key='event.overspeed.groupsEnabled'>true</entry>
     <entry key='event.motionHandler'>true</entry>
     <entry key='event.geofenceHandler'>true</entry>
     <entry key='event.alertHandler'>true</entry>

--- a/schema/changelog-3.7.xml
+++ b/schema/changelog-3.7.xml
@@ -26,6 +26,8 @@
 
     <dropColumn tableName="devices" columnName="motion" />
 
+    <dropColumn tableName="devices" columnName="status" />
+
     <addColumn tableName="groups">
       <column name="attributes" type="VARCHAR(4096)" />
     </addColumn>

--- a/setup/unix/traccar.xml
+++ b/setup/unix/traccar.xml
@@ -120,7 +120,7 @@
     </entry>
 
     <entry key='database.updateDeviceStatus'>
-        UPDATE devices SET status = :status, lastUpdate = :lastUpdate WHERE id = :id;
+        UPDATE devices SET lastUpdate = :lastUpdate WHERE id = :id;
     </entry>
 
     <entry key='database.deleteDevice'>

--- a/setup/windows/traccar.xml
+++ b/setup/windows/traccar.xml
@@ -120,7 +120,7 @@
     </entry>
 
     <entry key='database.updateDeviceStatus'>
-        UPDATE devices SET status = :status, lastUpdate = :lastUpdate WHERE id = :id;
+        UPDATE devices SET lastUpdate = :lastUpdate WHERE id = :id;
     </entry>
 
     <entry key='database.deleteDevice'>

--- a/src/org/traccar/api/resource/ServerResource.java
+++ b/src/org/traccar/api/resource/ServerResource.java
@@ -37,14 +37,13 @@ public class ServerResource extends BaseResource {
     @PermitAll
     @GET
     public Server get() throws SQLException {
-        return Context.getDataManager().getServer();
+        return Context.getPermissionsManager().getServer();
     }
 
     @PUT
     public Response update(Server entity) throws SQLException {
         Context.getPermissionsManager().checkAdmin(getUserId());
-        Context.getDataManager().updateServer(entity);
-        Context.getPermissionsManager().refresh();
+        Context.getPermissionsManager().updateServer(entity);
         return Response.ok(entity).build();
     }
 

--- a/src/org/traccar/database/DeviceManager.java
+++ b/src/org/traccar/database/DeviceManager.java
@@ -32,6 +32,7 @@ import org.traccar.helper.Log;
 import org.traccar.model.Device;
 import org.traccar.model.Group;
 import org.traccar.model.Position;
+import org.traccar.model.Server;
 
 public class DeviceManager implements IdentityManager {
 
@@ -40,6 +41,7 @@ public class DeviceManager implements IdentityManager {
     private final Config config;
     private final DataManager dataManager;
     private final long dataRefreshDelay;
+    private boolean lookupGroupsAttribute;
 
     private Map<Long, Device> devicesById;
     private Map<String, Device> devicesByUniqueId;
@@ -54,6 +56,7 @@ public class DeviceManager implements IdentityManager {
         this.dataManager = dataManager;
         this.config = Context.getConfig();
         dataRefreshDelay = config.getLong("database.refreshDelay", DEFAULT_REFRESH_DELAY) * 1000;
+        lookupGroupsAttribute = config.getBoolean("deviceManager.lookupGroupsAttribute");
         if (dataManager != null) {
             try {
                 updateGroupCache(true);
@@ -311,5 +314,34 @@ public class DeviceManager implements IdentityManager {
     public void removeGroup(long groupId) throws SQLException {
         dataManager.removeGroup(groupId);
         groupsById.remove(groupId);
+    }
+
+    public String lookupAttribute(long deviceId, String attributeName) {
+        String result = null;
+        Device device = getDeviceById(deviceId);
+        if (device != null) {
+            if (device.getAttributes().containsKey(attributeName)) {
+                result = (String) device.getAttributes().get(attributeName);
+            }
+            if (result == null && lookupGroupsAttribute) {
+                long groupId = device.getGroupId();
+                while (groupId != 0) {
+                    if (getGroupById(groupId) != null) {
+                        result = (String)  getGroupById(groupId).getAttributes().get(attributeName);
+                        if (result != null) {
+                            break;
+                        }
+                        groupId = getGroupById(groupId).getGroupId();
+                    } else {
+                        groupId = 0;
+                    }
+                }
+            }
+            if (result == null) {
+                Server server = Context.getPermissionsManager().getServer();
+                result = (String) server.getAttributes().get(attributeName);
+            }
+        }
+        return result;
     }
 }

--- a/src/org/traccar/database/PermissionsManager.java
+++ b/src/org/traccar/database/PermissionsManager.java
@@ -34,7 +34,7 @@ public class PermissionsManager {
 
     private final DataManager dataManager;
 
-    private Server server;
+    private volatile Server server;
 
     private final Map<Long, User> users = new HashMap<>();
 
@@ -151,6 +151,15 @@ public class PermissionsManager {
         if (!Context.getGeofenceManager().checkGeofence(userId, geofenceId) && !isAdmin(userId)) {
             throw new SecurityException("Geofence access denied");
         }
+    }
+
+    public Server getServer() {
+        return server;
+    }
+
+    public void updateServer(Server server) throws SQLException {
+        dataManager.updateServer(server);
+        this.server = server;
     }
 
 }

--- a/src/org/traccar/events/GeofenceEventHandler.java
+++ b/src/org/traccar/events/GeofenceEventHandler.java
@@ -15,30 +15,23 @@
  */
 package org.traccar.events;
 
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 import org.traccar.BaseEventHandler;
 import org.traccar.Context;
-import org.traccar.database.DataManager;
 import org.traccar.database.GeofenceManager;
-import org.traccar.helper.Log;
 import org.traccar.model.Device;
 import org.traccar.model.Event;
 import org.traccar.model.Position;
 
 public class GeofenceEventHandler extends BaseEventHandler {
 
-    private int suppressRepeated;
     private GeofenceManager geofenceManager;
-    private DataManager dataManager;
 
     public GeofenceEventHandler() {
-        suppressRepeated = Context.getConfig().getInteger("event.suppressRepeated", 60);
         geofenceManager = Context.getGeofenceManager();
-        dataManager = Context.getDataManager();
     }
 
     @Override
@@ -63,29 +56,15 @@ public class GeofenceEventHandler extends BaseEventHandler {
         device.setGeofenceIds(currentGeofences);
 
         Collection<Event> events = new ArrayList<>();
-        try {
-            if (dataManager.getLastEvents(position.getDeviceId(),
-                    Event.TYPE_GEOFENCE_ENTER, suppressRepeated).isEmpty()) {
-                for (long geofenceId : newGeofences) {
-                    Event event = new Event(Event.TYPE_GEOFENCE_ENTER, position.getDeviceId(), position.getId());
-                    event.setGeofenceId(geofenceId);
-                    events.add(event);
-                }
-            }
-        } catch (SQLException error) {
-            Log.warning(error);
+        for (long geofenceId : newGeofences) {
+            Event event = new Event(Event.TYPE_GEOFENCE_ENTER, position.getDeviceId(), position.getId());
+            event.setGeofenceId(geofenceId);
+            events.add(event);
         }
-        try {
-            if (dataManager.getLastEvents(position.getDeviceId(),
-                    Event.TYPE_GEOFENCE_EXIT, suppressRepeated).isEmpty()) {
-                for (long geofenceId : oldGeofences) {
-                    Event event = new Event(Event.TYPE_GEOFENCE_EXIT, position.getDeviceId(), position.getId());
-                    event.setGeofenceId(geofenceId);
-                    events.add(event);
-                }
-            }
-        } catch (SQLException error) {
-            Log.warning(error);
+        for (long geofenceId : oldGeofences) {
+            Event event = new Event(Event.TYPE_GEOFENCE_EXIT, position.getDeviceId(), position.getId());
+            event.setGeofenceId(geofenceId);
+            events.add(event);
         }
         return events;
     }

--- a/src/org/traccar/events/MotionEventHandler.java
+++ b/src/org/traccar/events/MotionEventHandler.java
@@ -15,13 +15,11 @@
  */
 package org.traccar.events;
 
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 
 import org.traccar.BaseEventHandler;
 import org.traccar.Context;
-import org.traccar.helper.Log;
 import org.traccar.model.Device;
 import org.traccar.model.Event;
 import org.traccar.model.Position;
@@ -29,11 +27,6 @@ import org.traccar.model.Position;
 public class MotionEventHandler extends BaseEventHandler {
 
     private static final double SPEED_THRESHOLD = 0.01;
-    private int suppressRepeated;
-
-    public MotionEventHandler() {
-        suppressRepeated = Context.getConfig().getInteger("event.suppressRepeated", 60);
-    }
 
     @Override
     protected Collection<Event> analyzePosition(Position position) {
@@ -53,25 +46,12 @@ public class MotionEventHandler extends BaseEventHandler {
         if (lastPosition != null) {
             oldSpeed = lastPosition.getSpeed();
         }
-        try {
-            if (speed > SPEED_THRESHOLD && oldSpeed <= SPEED_THRESHOLD) {
-                result = new ArrayList<>();
-                result.add(new Event(Event.TYPE_DEVICE_MOVING, position.getDeviceId(), position.getId()));
-            } else if (speed <= SPEED_THRESHOLD && oldSpeed > SPEED_THRESHOLD) {
-                result = new ArrayList<>();
-                result.add(new Event(Event.TYPE_DEVICE_STOPPED, position.getDeviceId(), position.getId()));
-            }
-
-            if (result != null && !result.isEmpty()) {
-                for (Event event : result) {
-                    if (!Context.getDataManager().getLastEvents(position.getDeviceId(),
-                            event.getType(), suppressRepeated).isEmpty()) {
-                        event = null;
-                    }
-                }
-            }
-        } catch (SQLException error) {
-            Log.warning(error);
+        if (speed > SPEED_THRESHOLD && oldSpeed <= SPEED_THRESHOLD) {
+            result = new ArrayList<>();
+            result.add(new Event(Event.TYPE_DEVICE_MOVING, position.getDeviceId(), position.getId()));
+        } else if (speed <= SPEED_THRESHOLD && oldSpeed > SPEED_THRESHOLD) {
+            result = new ArrayList<>();
+            result.add(new Event(Event.TYPE_DEVICE_STOPPED, position.getDeviceId(), position.getId()));
         }
         return result;
     }

--- a/src/org/traccar/events/OverspeedEventHandler.java
+++ b/src/org/traccar/events/OverspeedEventHandler.java
@@ -53,7 +53,7 @@ public class OverspeedEventHandler extends BaseEventHandler {
 
         Collection<Event> events = new ArrayList<>();
         double speed = position.getSpeed();
-        Double speedLimit = new Double(0);
+        double speedLimit = 0;
 
         if (device.getAttributes().containsKey(ATTRIBUTE_SPEED_LIMIT)) {
             speedLimit = Double.parseDouble((String) device.getAttributes().get(ATTRIBUTE_SPEED_LIMIT));

--- a/src/org/traccar/events/OverspeedEventHandler.java
+++ b/src/org/traccar/events/OverspeedEventHandler.java
@@ -34,12 +34,10 @@ public class OverspeedEventHandler extends BaseEventHandler {
 
     private boolean checkGroups;
     private boolean riseOnce;
-    private int suppressRepeated;
 
     public OverspeedEventHandler() {
         checkGroups = Context.getConfig().getBoolean("event.overspeed.groupsEnabled");
         riseOnce = Context.getConfig().getBoolean("event.overspeed.riseOnce");
-        suppressRepeated = Context.getConfig().getInteger("event.suppressRepeated", 60);
     }
 
     @Override
@@ -97,14 +95,7 @@ public class OverspeedEventHandler extends BaseEventHandler {
         }
         speedLimit = UnitsConverter.knotsFromKph(speedLimit);
         if (speedLimit != 0 && speed > speedLimit && oldSpeed <= speedLimit) {
-            try {
-                if (Context.getDataManager().getLastEvents(
-                        position.getDeviceId(), Event.TYPE_DEVICE_OVERSPEED, suppressRepeated).isEmpty()) {
-                    events.add(new Event(Event.TYPE_DEVICE_OVERSPEED, position.getDeviceId(), position.getId()));
-                }
-            } catch (SQLException error) {
-                Log.warning(error);
-            }
+            events.add(new Event(Event.TYPE_DEVICE_OVERSPEED, position.getDeviceId(), position.getId()));
         }
         return events;
     }

--- a/src/org/traccar/events/OverspeedEventHandler.java
+++ b/src/org/traccar/events/OverspeedEventHandler.java
@@ -29,10 +29,10 @@ public class OverspeedEventHandler extends BaseEventHandler {
 
     public static final String ATTRIBUTE_SPEED_LIMIT = "speedLimit";
 
-    private boolean riseOnce;
+    private boolean notRepeat;
 
     public OverspeedEventHandler() {
-        riseOnce = Context.getConfig().getBoolean("event.overspeed.riseOnce");
+        notRepeat = Context.getConfig().getBoolean("event.overspeed.notRepeat");
     }
 
     @Override
@@ -57,7 +57,7 @@ public class OverspeedEventHandler extends BaseEventHandler {
             return null;
         }
         double oldSpeed = 0;
-        if (riseOnce) {
+        if (notRepeat) {
             Position lastPosition = Context.getDeviceManager().getLastPosition(position.getDeviceId());
             if (lastPosition != null) {
                 oldSpeed = lastPosition.getSpeed();

--- a/src/org/traccar/events/OverspeedEventHandler.java
+++ b/src/org/traccar/events/OverspeedEventHandler.java
@@ -24,16 +24,19 @@ import org.traccar.Context;
 import org.traccar.model.Device;
 import org.traccar.model.Event;
 import org.traccar.model.Position;
+import org.traccar.model.Server;
 import org.traccar.helper.Log;
 import org.traccar.helper.UnitsConverter;
 
 public class OverspeedEventHandler extends BaseEventHandler {
 
-    private double globalSpeedLimit;
+    public static final String ATTRIBUTE_SPEED_LIMIT = "speedLimit";
+
+    private boolean checkGroups;
     private int suppressRepeated;
 
     public OverspeedEventHandler() {
-        globalSpeedLimit = UnitsConverter.knotsFromKph(Context.getConfig().getInteger("event.globalSpeedLimit", 0));
+        checkGroups = Context.getConfig().getBoolean("event.overspeed.groupsEnabled");
         suppressRepeated = Context.getConfig().getInteger("event.suppressRepeated", 60);
     }
 
@@ -50,8 +53,40 @@ public class OverspeedEventHandler extends BaseEventHandler {
 
         Collection<Event> events = new ArrayList<>();
         double speed = position.getSpeed();
+        Double speedLimit = new Double(0);
 
-        if (globalSpeedLimit != 0 && speed > globalSpeedLimit) {
+        if (device.getAttributes().containsKey(ATTRIBUTE_SPEED_LIMIT)) {
+            speedLimit = Double.parseDouble((String) device.getAttributes().get(ATTRIBUTE_SPEED_LIMIT));
+        }
+        if (speedLimit == 0 && checkGroups) {
+            long groupId = device.getGroupId();
+            while (groupId != 0) {
+                if (Context.getDeviceManager().getGroupById(groupId).getAttributes()
+                        .containsKey(ATTRIBUTE_SPEED_LIMIT)) {
+                    speedLimit = Double.parseDouble((String) Context.getDeviceManager().getGroupById(groupId)
+                            .getAttributes().get(ATTRIBUTE_SPEED_LIMIT));
+                    if (speedLimit != 0) {
+                        break;
+                    }
+                }
+                if (Context.getDeviceManager().getGroupById(groupId) != null) {
+                    groupId = Context.getDeviceManager().getGroupById(groupId).getGroupId();
+                } else {
+                    groupId = 0;
+                }
+            }
+        }
+        if (speedLimit == 0) {
+            try {
+                Server server = Context.getDataManager().getServer();
+                if (server.getAttributes().containsKey(ATTRIBUTE_SPEED_LIMIT)) {
+                    speedLimit = Double.parseDouble((String) server.getAttributes().get(ATTRIBUTE_SPEED_LIMIT));
+                }
+            } catch (SQLException error) {
+                Log.warning(error);
+            }
+        }
+        if (speedLimit != 0 && speed > UnitsConverter.knotsFromKph(speedLimit)) {
             try {
                 if (Context.getDataManager().getLastEvents(
                         position.getDeviceId(), Event.TYPE_DEVICE_OVERSPEED, suppressRepeated).isEmpty()) {


### PR DESCRIPTION
I've changed OverspeedEventHandler to use speed limit from attributes. Attribute name is `speedLimit`
Attribute lookup starts from Device -> Groups -> Server and Device has higher priority

Because lookup groups is expensive, I've added `event.overspeed.groupsEnabled` config to enable it.
There is two idea: rise event on every "overspeeding" point (by default) or only once during period.
`event.overspeed.riseOnce` enables it.

Also I've removed Device.status from DB. It is really small commit to separate it.

Tested for a two days. Works OK. 