### PR TITLE
fix #2182

### DIFF
--- a/src/org/traccar/notification/NotificationMail.java
+++ b/src/org/traccar/notification/NotificationMail.java
@@ -55,9 +55,19 @@ public final class NotificationMail {
             result.put("mail.smtp.ssl.trust", config.getBoolean("mail.smtp.ssl.trust"));
 
             result.put("mail.smtp.auth", config.getBoolean("mail.smtp.auth"));
-            result.put("mail.smtp.user", config.getString("mail.smtp.username", null));
-            result.put("mail.smtp.password", config.getString("mail.smtp.password", null));
-            result.put("mail.smtp.from", config.getString("mail.smtp.from", null));
+
+            String username = config.getString("mail.smtp.username");
+            if (username != null) {
+                result.put("mail.smtp.user", username);
+            }
+            String password = config.getString("mail.smtp.password");
+            if (password != null) {
+                result.put("mail.smtp.password", password);
+            }
+            String from = config.getString("mail.smtp.from");
+            if (from != null) {
+                result.put("mail.smtp.from", from);
+            }
         }
         return result;
     }


### PR DESCRIPTION
Fix NullPointer exception without `mail.smtp.username` in config.

I do not have excuses for me. This checks was in some commits of pull request, but why I decided to remove them... and why I decided that `put` allow `null` value...