### PR TITLE
Some fuel attributes organization

### DIFF
--- a/src/org/traccar/model/Position.java
+++ b/src/org/traccar/model/Position.java
@@ -39,6 +39,8 @@ public class Position extends Message {
     public static final String KEY_LAC = "lac";
     public static final String KEY_CID = "cid";
     public static final String KEY_FUEL = "fuel";
+    public static final String KEY_FUEL_CONSUMPTION = "fuelConsumption";
+    public static final String KEY_FUEL_INSTANT_CONSUMPTION = "fuelInstantConsumption";
     public static final String KEY_RFID = "rfid";
     public static final String KEY_VERSION = "version";
     public static final String KEY_TYPE = "type";

--- a/src/org/traccar/model/Position.java
+++ b/src/org/traccar/model/Position.java
@@ -40,7 +40,6 @@ public class Position extends Message {
     public static final String KEY_CID = "cid";
     public static final String KEY_FUEL = "fuel";
     public static final String KEY_FUEL_CONSUMPTION = "fuelConsumption";
-    public static final String KEY_FUEL_INSTANT_CONSUMPTION = "fuelInstantConsumption";
     public static final String KEY_RFID = "rfid";
     public static final String KEY_VERSION = "version";
     public static final String KEY_TYPE = "type";

--- a/src/org/traccar/protocol/Gl200ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gl200ProtocolDecoder.java
@@ -329,7 +329,7 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
         position.set(Position.KEY_RPM, parser.next());
         position.set(Position.KEY_OBD_SPEED, parser.next());
         position.set(Position.PREFIX_TEMP + 1, parser.next());
-        position.set("fuelConsumption", parser.next());
+        position.set(Position.KEY_FUEL_CONSUMPTION, parser.next());
         position.set("dtcsClearedDistance", parser.next());
         position.set("odbConnect", parser.next());
         position.set("dtcsNumber", parser.next());

--- a/src/org/traccar/protocol/Gps103ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gps103ProtocolDecoder.java
@@ -87,7 +87,7 @@ public class Gps103ProtocolDecoder extends BaseProtocolDecoder {
             .number("(dd)(dd)(dd),")             // time
             .number("(d+),")                     // odometer
             .number("(d+.d+)?,")                 // fuel instant
-            .number("(?:d+.d+)?,")               // fuel average
+            .number("(d+.d+)?,")                 // fuel average
             .number("(d+),")                     // hours
             .number("(d+),")                     // speed
             .number("d+.?d*%,")                  // power load
@@ -189,7 +189,8 @@ public class Gps103ProtocolDecoder extends BaseProtocolDecoder {
             getLastLocation(position, dateBuilder.getDate());
 
             position.set(Position.KEY_ODOMETER, parser.nextInt());
-            position.set(Position.KEY_FUEL, parser.next());
+            position.set(Position.KEY_FUEL_INSTANT_CONSUMPTION, parser.next());
+            position.set(Position.KEY_FUEL_CONSUMPTION, parser.next());
             position.set(Position.KEY_HOURS, parser.next());
             position.set(Position.KEY_OBD_SPEED, parser.next());
             position.set(Position.PREFIX_TEMP + 1, parser.next());

--- a/src/org/traccar/protocol/Gps103ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gps103ProtocolDecoder.java
@@ -189,7 +189,7 @@ public class Gps103ProtocolDecoder extends BaseProtocolDecoder {
             getLastLocation(position, dateBuilder.getDate());
 
             position.set(Position.KEY_ODOMETER, parser.nextInt());
-            position.set(Position.KEY_FUEL_INSTANT_CONSUMPTION, parser.next());
+            parser.next();                                                          // instant fuel consumption
             position.set(Position.KEY_FUEL_CONSUMPTION, parser.next());
             position.set(Position.KEY_HOURS, parser.next());
             position.set(Position.KEY_OBD_SPEED, parser.next());

--- a/src/org/traccar/protocol/Gps103ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gps103ProtocolDecoder.java
@@ -189,7 +189,7 @@ public class Gps103ProtocolDecoder extends BaseProtocolDecoder {
             getLastLocation(position, dateBuilder.getDate());
 
             position.set(Position.KEY_ODOMETER, parser.nextInt());
-            parser.next();                                                          // instant fuel consumption
+            parser.next(); // instant fuel consumption
             position.set(Position.KEY_FUEL_CONSUMPTION, parser.next());
             position.set(Position.KEY_HOURS, parser.next());
             position.set(Position.KEY_OBD_SPEED, parser.next());

--- a/src/org/traccar/protocol/IntellitracProtocolDecoder.java
+++ b/src/org/traccar/protocol/IntellitracProtocolDecoder.java
@@ -109,7 +109,7 @@ public class IntellitracProtocolDecoder extends BaseProtocolDecoder {
         position.set(Position.KEY_RPM, parser.next());
         position.set("coolant", parser.next());
         position.set(Position.KEY_FUEL, parser.next());
-        position.set("consumption", parser.next());
+        position.set(Position.KEY_FUEL_CONSUMPTION, parser.next());
         position.set(Position.PREFIX_TEMP + 1, parser.next());
         position.set(Position.KEY_CHARGE, parser.next());
         position.set("tpl", parser.next());

--- a/src/org/traccar/protocol/Mta6ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Mta6ProtocolDecoder.java
@@ -159,7 +159,8 @@ public class Mta6ProtocolDecoder extends BaseProtocolDecoder {
                 }
 
                 if (BitUtil.check(flags, 4)) {
-                    position.set(Position.KEY_FUEL, buf.readUnsignedInt() + "|" + buf.readUnsignedInt());
+                    position.set(Position.KEY_FUEL_CONSUMPTION + "Accumulator1", buf.readUnsignedInt());
+                    position.set(Position.KEY_FUEL_CONSUMPTION + "Accumulator2", buf.readUnsignedInt());
                     position.set("hours1", buf.readUnsignedShort());
                     position.set("hours2", buf.readUnsignedShort());
                 }

--- a/src/org/traccar/protocol/Mta6ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Mta6ProtocolDecoder.java
@@ -231,7 +231,7 @@ public class Mta6ProtocolDecoder extends BaseProtocolDecoder {
         }
 
         if (BitUtil.check(flags, 1)) {
-            new FloatReader().readFloat(buf); // fuel consumtion
+            position.set(Position.KEY_FUEL_CONSUMPTION, new FloatReader().readFloat(buf));
             position.set("hours", new FloatReader().readFloat(buf));
             position.set("tank", buf.readUnsignedByte() * 0.4);
         }

--- a/src/org/traccar/protocol/XirgoProtocolDecoder.java
+++ b/src/org/traccar/protocol/XirgoProtocolDecoder.java
@@ -75,7 +75,7 @@ public class XirgoProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+),")                     // satellites
             .number("(d+.?d*),")                 // hdop
             .number("(d+.?d*),")                 // odometer
-            .number("d+.?d*,")                   // fuel consumption
+            .number("(d+.?d*),")                 // fuel consumption
             .number("(d+.d+),")                  // battery
             .number("(d+),")                     // gsm
             .number("(d+),")                     // gps
@@ -134,6 +134,7 @@ public class XirgoProtocolDecoder extends BaseProtocolDecoder {
 
         if (newFormat) {
             position.set(Position.KEY_ODOMETER, parser.next());
+            position.set(Position.KEY_FUEL_CONSUMPTION, parser.next());
         }
 
         position.set(Position.KEY_BATTERY, parser.next());


### PR DESCRIPTION
- Added `KEY_FUEL_CONSUMPTION` and `KEY_FUEL_INSTANT_CONSUMPTION`
- Fixed wrong using of `KEY_FUEL` 

About Mta6: I'm not sure what means "Fuel consumption accumulator", but pretty sure it is not `KEY_FUEL`