### PR TITLE
Fixed optional odometer for wondex protocol and exclusion for 0.0 odometers

### DIFF
--- a/src/org/traccar/protocol/WondexProtocolDecoder.java
+++ b/src/org/traccar/protocol/WondexProtocolDecoder.java
@@ -115,7 +115,9 @@ public class WondexProtocolDecoder extends BaseProtocolDecoder {
 
             position.set(Position.KEY_EVENT, parser.next());
             position.set(Position.KEY_BATTERY, parser.next());
-            position.set(Position.KEY_ODOMETER, parser.nextDouble() * 1000);
+            if (parser.hasNext()) {
+                position.set(Position.KEY_ODOMETER, parser.nextDouble() * 1000);
+            }
             position.set(Position.KEY_INPUT, parser.next());
             position.set(Position.PREFIX_ADC + 1, parser.next());
             position.set(Position.PREFIX_ADC + 2, parser.next());

--- a/src/org/traccar/reports/ReportUtils.java
+++ b/src/org/traccar/reports/ReportUtils.java
@@ -45,10 +45,16 @@ public final class ReportUtils {
 
     public static double calculateDistance(Position firstPosition, Position lastPosition, boolean useOdometer) {
         double distance = 0.0;
-        if (useOdometer && firstPosition.getAttributes().containsKey(Position.KEY_ODOMETER)
-                && lastPosition.getAttributes().containsKey(Position.KEY_ODOMETER)) {
-            distance = (((Number) lastPosition.getAttributes().get(Position.KEY_ODOMETER)).doubleValue()
-                    - ((Number) firstPosition.getAttributes().get(Position.KEY_ODOMETER)).doubleValue());
+        double firstOdometer = 0.0;
+        double lastOdometer = 0.0;
+        if (firstPosition.getAttributes().containsKey(Position.KEY_ODOMETER)) {
+            firstOdometer = ((Number) firstPosition.getAttributes().get(Position.KEY_ODOMETER)).doubleValue();
+        }
+        if (lastPosition.getAttributes().containsKey(Position.KEY_ODOMETER)) {
+            lastOdometer = ((Number) lastPosition.getAttributes().get(Position.KEY_ODOMETER)).doubleValue();
+        }
+        if (useOdometer && (firstOdometer != 0.0 || lastOdometer != 0.0)) {
+            distance = lastOdometer - firstOdometer;
         } else if (firstPosition.getAttributes().containsKey(Position.KEY_TOTAL_DISTANCE)
                 && lastPosition.getAttributes().containsKey(Position.KEY_TOTAL_DISTANCE)) {
             distance = ((Number) lastPosition.getAttributes().get(Position.KEY_TOTAL_DISTANCE)).doubleValue()


### PR DESCRIPTION
Only wondex has optional odometer.

Anyway I've added check if both odometer values are zero they are not used to calculate distance.
There are a lot of "0.0" odometers in unit tests in different protocols. I think it is not rare case that it is zero.
