### PR TITLE
Prevent Device tagfield growing too much

### DIFF
--- a/web/app/Style.js
+++ b/web/app/Style.js
@@ -69,5 +69,8 @@ Ext.define('Traccar.Style', {
     mapDelay: 500,
 
     coordinatePrecision: 6,
-    numberPrecision: 2
+    numberPrecision: 2,
+
+    maxTagfieldWidth: 200,
+    maxTagfieldGrow: 1
 });

--- a/web/app/view/Report.js
+++ b/web/app/view/Report.js
@@ -45,6 +45,8 @@ Ext.define('Traccar.view.Report', {
         html: Strings.reportDevice
     }, {
         xtype: 'tagfield',
+        maxWidth: Traccar.Style.maxTagfieldWidth,
+        growMax: Traccar.Style.maxTagfieldGrow,
         reference: 'deviceField',
         store: 'Devices',
         valueField: 'id',


### PR DESCRIPTION
By default it grows indefinitely to right.
And it will grow down if limited only width.


