### PR TITLE
Fix geofences colors and separate geofences styles

### DIFF
--- a/web/app/Style.js
+++ b/web/app/Style.js
@@ -60,13 +60,17 @@ Ext.define('Traccar.Style', {
     mapColorOnline: 'rgba(77, 250, 144, 1.0)',
     mapColorUnknown: 'rgba(250, 190, 77, 1.0)',
     mapColorOffline: 'rgba(255, 84, 104, 1.0)',
-    mapColorOverlay: 'rgba(21, 127, 204, 0.2)',
 
     mapRadiusNormal: 9,
     mapRadiusSelected: 14,
 
     mapMaxZoom: 19,
     mapDelay: 500,
+
+    mapGeofenceColor: 'rgba(21, 127, 204, 1.0)',
+    mapGeofenceOverlay: 'rgba(21, 127, 204, 0.2)',
+    mapGeofenceWidth: 5,
+    mapGeofenceRadius: 9,
 
     coordinatePrecision: 6,
     numberPrecision: 2,

--- a/web/app/view/GeofenceMap.js
+++ b/web/app/view/GeofenceMap.js
@@ -72,16 +72,16 @@ Ext.define('Traccar.view.GeofenceMap', {
             }),
             style: new ol.style.Style({
                 fill: new ol.style.Fill({
-                    color: Traccar.Style.mapColorOverlay
+                    color: Traccar.Style.mapGeofenceOverlay
                 }),
                 stroke: new ol.style.Stroke({
-                    color: Traccar.Style.mapColorReport,
-                    width: Traccar.Style.mapRouteWidth
+                    color: Traccar.Style.mapGeofenceColor,
+                    width: Traccar.Style.mapGeofenceWidth
                 }),
                 image: new ol.style.Circle({
-                    radius: Traccar.Style.mapRadiusNormal,
+                    radius: Traccar.Style.mapGeofenceRadius,
                     fill: new ol.style.Fill({
-                        color: Traccar.Style.mapColorReport
+                        color: Traccar.Style.mapGeofenceColor
                     })
                 })
             })


### PR DESCRIPTION
Sorry, I did not think that `mapColorReport` used to draw geofences. (it has "report" in name)

The quickfix was just replace `mapColorReport` to `mapRouteColor[0]` but it looks not very good and I decided to separate styles used for geofences.
It will allow some fine tuning and avoid such confuses in future.