### PR TITLE
Adding location parameter to OsmAnd protocol

### DIFF
--- a/src/org/traccar/protocol/OsmAndProtocolDecoder.java
+++ b/src/org/traccar/protocol/OsmAndProtocolDecoder.java
@@ -106,9 +106,9 @@ public class OsmAndProtocolDecoder extends BaseProtocolDecoder {
                     position.setLongitude(Double.parseDouble(value));
                     break;
                 case "location":
-                    List<String> location = Arrays.asList(value.split(","));
-                    position.setLatitude(Double.parseDouble(location.get(0)));
-                    position.setLongitude(Double.parseDouble(location.get(1)));
+                    String[] location = value.split(",");
+                    position.setLatitude(Double.parseDouble(location[0]));
+                    position.setLongitude(Double.parseDouble(location[1]));
                     break;
                 case "speed":
                     position.setSpeed(Double.parseDouble(value));

--- a/src/org/traccar/protocol/OsmAndProtocolDecoder.java
+++ b/src/org/traccar/protocol/OsmAndProtocolDecoder.java
@@ -32,6 +32,7 @@ import java.net.SocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -103,6 +104,11 @@ public class OsmAndProtocolDecoder extends BaseProtocolDecoder {
                     break;
                 case "lon":
                     position.setLongitude(Double.parseDouble(value));
+                    break;
+                case "location":
+                    List<String> location = Arrays.asList(value.split(","));
+                    position.setLatitude(Double.parseDouble(location.get(0)));
+                    position.setLongitude(Double.parseDouble(location.get(1)));
                     break;
                 case "speed":
                     position.setSpeed(Double.parseDouble(value));

--- a/src/org/traccar/protocol/OsmAndProtocolDecoder.java
+++ b/src/org/traccar/protocol/OsmAndProtocolDecoder.java
@@ -32,7 +32,6 @@ import java.net.SocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;

--- a/test/org/traccar/protocol/OsmAndProtocolDecoderTest.java
+++ b/test/org/traccar/protocol/OsmAndProtocolDecoderTest.java
@@ -34,6 +34,9 @@ public class OsmAndProtocolDecoderTest extends ProtocolTest {
         verifyPosition(decoder, request(
                 "/?id=861001000719969&lat=41.666667&lon=-0.883333&altitude=350.059479&speed=0.000000&batt=87"));
 
+        verifyPosition(decoder, request(
+                "/?id=123456&timestamp=1377177267&location=60.0,30.0"));
+
     }
 
 }


### PR DESCRIPTION
As exposed on forum thread - https://www.traccar.org/forums/topic/tracking-through-http-url-request/ - add location parameter to OsmAnd protocol for coma separated lat & lon (“&location=60.0,30.0”).