### PR TITLE
Add jpkorjar protocol support

### DIFF
--- a/debug.xml
+++ b/debug.xml
@@ -456,5 +456,6 @@
     <entry key='arknavx8.port'>5119</entry>
     <entry key='autograde.port'>5120</entry>
     <entry key='oigo.port'>5121</entry>
+    <entry key='jpkorjar.port'>5122</entry>
 
 </properties>

--- a/src/org/traccar/protocol/JpKorjarFrameDecoder.java
+++ b/src/org/traccar/protocol/JpKorjarFrameDecoder.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 nyashh (nyashh@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.protocol;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.handler.codec.frame.FrameDecoder;
+
+public class JpKorjarFrameDecoder extends FrameDecoder {
+
+    @Override
+    protected Object decode(
+            ChannelHandlerContext ctx, Channel channel, ChannelBuffer buf) throws Exception {
+
+        if (buf.readableBytes() < 80) {
+            return null;
+        }
+
+        int spaceIndex = buf.indexOf(buf.readerIndex(), buf.writerIndex(), (byte) ' ');
+        if (spaceIndex == -1) {
+            return null;
+        }
+
+        int endIndex = buf.indexOf(spaceIndex, buf.writerIndex(), (byte) ',');
+        if (endIndex == -1) {
+            return null;
+        }
+
+        return buf.readBytes(endIndex + 1);
+    }
+
+}

--- a/src/org/traccar/protocol/JpKorjarProtocol.java
+++ b/src/org/traccar/protocol/JpKorjarProtocol.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 nyashh (nyashh@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.protocol;
+
+import org.jboss.netty.bootstrap.ServerBootstrap;
+import org.jboss.netty.channel.ChannelPipeline;
+import org.jboss.netty.handler.codec.string.StringDecoder;
+import org.traccar.BaseProtocol;
+import org.traccar.TrackerServer;
+
+import java.util.List;
+
+public class JpKorjarProtocol extends BaseProtocol {
+
+    public JpKorjarProtocol() {
+        super("jpkorjar");
+    }
+
+    @Override
+    public void initTrackerServers(List<TrackerServer> serverList) {
+        serverList.add(new TrackerServer(new ServerBootstrap(), this.getName()) {
+            @Override
+            protected void addSpecificHandlers(ChannelPipeline pipeline) {
+
+                pipeline.addLast("frameDecoder", new JpKorjarFrameDecoder());
+                pipeline.addLast("stringDecoder", new StringDecoder());
+                pipeline.addLast("objectDecoder", new JpKorjarProtocolDecoder(JpKorjarProtocol.this));
+            }
+        });
+    }
+
+}

--- a/src/org/traccar/protocol/JpKorjarProtocolDecoder.java
+++ b/src/org/traccar/protocol/JpKorjarProtocolDecoder.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2016 nyashh (nyashh@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.protocol;
+
+import org.jboss.netty.channel.Channel;
+import org.traccar.BaseProtocolDecoder;
+import org.traccar.DeviceSession;
+import org.traccar.helper.DateBuilder;
+import org.traccar.model.Position;
+
+import java.net.SocketAddress;
+
+public class JpKorjarProtocolDecoder extends BaseProtocolDecoder {
+
+    public JpKorjarProtocolDecoder(JpKorjarProtocol protocol) {
+        super(protocol);
+    }
+
+    @Override
+    protected Object decode(Channel channel, SocketAddress remoteAddress, Object msg) throws Exception {
+
+        String line = (String) msg;
+
+        String[] parts = line.split(",");
+
+        if (parts.length == 0) {
+            return null;
+        }
+
+        if (!parts[0].equals("KORJAR.PL")) {
+            return null;
+        }
+
+        Long imei   = Long.parseLong(parts[1]);
+
+        int year    = Integer.parseInt(parts[2].substring(0, 2));
+        int month   = Integer.parseInt(parts[2].substring(2, 4));
+        int day     = Integer.parseInt(parts[2].substring(4, 6));
+        int hour    = Integer.parseInt(parts[2].substring(6, 8));
+        int minute  = Integer.parseInt(parts[2].substring(8, 10));
+        int second  = Integer.parseInt(parts[2].substring(10, 12));
+
+        Double latitude  = Double.parseDouble(parts[3].substring(0,
+                Math.max(0, parts[3].length() - 1)));
+
+        Double longitude = Double.parseDouble(parts[4].substring(0,
+                Math.max(0, parts[4].length() - 1)));
+
+        Double speed     = Double.parseDouble(parts[5]);
+        Double course    = Double.parseDouble(parts[6]);
+
+        String[] batteryParts = parts[7].split(":");
+
+        String batteryLevel   = batteryParts[0];
+        Double batteryVoltage = Double.parseDouble(batteryParts[1].substring(0,
+                Math.max(0, batteryParts[1].length() - 1)));
+
+        String[] codeParts    = parts[8].split(" ");
+
+        int gpsSignal         = Integer.parseInt(codeParts[0]); //0 - low, 1 - high
+        int mcc               = Integer.parseInt(codeParts[1]);
+        int mnc               = Integer.parseInt(codeParts[2]);
+        int lac               = Integer.parseInt(codeParts[3], 16);
+        int cid               = Integer.parseInt(codeParts[4], 16);
+
+        DateBuilder builder = new DateBuilder().setDate(year, month, day)
+                                               .setTime(hour, minute, second);
+
+        DeviceSession deviceSession = getDeviceSession(channel, remoteAddress, parts[1]);
+        if (deviceSession == null) {
+            return null;
+        }
+
+        Position position = new Position();
+        position.setProtocol(getProtocolName());
+        position.setDeviceId(deviceSession.getDeviceId());
+        position.setLatitude(latitude);
+        position.setLongitude(longitude);
+        position.setSpeed(speed);
+        position.setCourse(course);
+        position.set("signal", gpsSignal);
+        position.set(Position.KEY_POWER, batteryVoltage);
+        position.set(Position.KEY_MNC, mnc);
+        position.set(Position.KEY_MCC, mcc);
+        position.set(Position.KEY_LAC, lac);
+        position.set(Position.KEY_CID, cid);
+        position.setTime(builder.getDate());
+        position.setValid(true);
+
+        return position;
+    }
+}

--- a/src/org/traccar/protocol/JpKorjarProtocolDecoder.java
+++ b/src/org/traccar/protocol/JpKorjarProtocolDecoder.java
@@ -44,8 +44,6 @@ public class JpKorjarProtocolDecoder extends BaseProtocolDecoder {
             return null;
         }
 
-        Long imei   = Long.parseLong(parts[1]);
-
         int year    = Integer.parseInt(parts[2].substring(0, 2));
         int month   = Integer.parseInt(parts[2].substring(2, 4));
         int day     = Integer.parseInt(parts[2].substring(4, 6));
@@ -53,19 +51,18 @@ public class JpKorjarProtocolDecoder extends BaseProtocolDecoder {
         int minute  = Integer.parseInt(parts[2].substring(8, 10));
         int second  = Integer.parseInt(parts[2].substring(10, 12));
 
-        Double latitude  = Double.parseDouble(parts[3].substring(0,
+        double latitude  = Double.parseDouble(parts[3].substring(0,
                 Math.max(0, parts[3].length() - 1)));
 
-        Double longitude = Double.parseDouble(parts[4].substring(0,
+        double longitude = Double.parseDouble(parts[4].substring(0,
                 Math.max(0, parts[4].length() - 1)));
 
-        Double speed     = Double.parseDouble(parts[5]);
-        Double course    = Double.parseDouble(parts[6]);
+        double speed     = Double.parseDouble(parts[5]);
+        double course    = Double.parseDouble(parts[6]);
 
         String[] batteryParts = parts[7].split(":");
 
-        String batteryLevel   = batteryParts[0];
-        Double batteryVoltage = Double.parseDouble(batteryParts[1].substring(0,
+        double batteryVoltage = Double.parseDouble(batteryParts[1].substring(0,
                 Math.max(0, batteryParts[1].length() - 1)));
 
         String[] codeParts    = parts[8].split(" ");

--- a/test/org/traccar/protocol/JpKorjarProtocolDecoderTest.java
+++ b/test/org/traccar/protocol/JpKorjarProtocolDecoderTest.java
@@ -14,6 +14,12 @@ public class JpKorjarProtocolDecoderTest extends ProtocolTest {
         verifyPosition(decoder, text(
                 "KORJAR.PL,329587014519383,160910144240,52.247254N,021.013375E,0.00,1,F:4.18V,1 260 01 794B 3517,"));
 
+        verifyPosition(decoder, text(
+                "KORJAR.PL,329587014519383,160910144240,52.895515N,021.949151E,6.30,212,F:3.94V,0 260 01 794B 3519,"));
+
+        verifyPosition(decoder, text(
+                "KORJAR.PL,329587014519383,160910144240,52.895596N,021.949343E,12.46,087,L:2.18V,1 260 01 794B 3517,"));
+
     }
 
 }

--- a/test/org/traccar/protocol/JpKorjarProtocolDecoderTest.java
+++ b/test/org/traccar/protocol/JpKorjarProtocolDecoderTest.java
@@ -1,0 +1,19 @@
+package org.traccar.protocol;
+
+
+import org.junit.Test;
+import org.traccar.ProtocolTest;
+
+public class JpKorjarProtocolDecoderTest extends ProtocolTest {
+
+    @Test
+    public void testDecode() throws Exception {
+
+        JpKorjarProtocolDecoder decoder = new JpKorjarProtocolDecoder(new JpKorjarProtocol());
+
+        verifyPosition(decoder, text(
+                "KORJAR.PL,329587014519383,160910144240,52.247254N,021.013375E,0.00,1,F:4.18V,1 260 01 794B 3517,"));
+
+    }
+
+}


### PR DESCRIPTION
Hi,

I have recently been tidying up shelves in my room and I found 2 GPS devices that I bought in 2008 or so. 

They are using their own text protocol. I added support for this protocol to traccar.

So far it works fine for me, so someone might find it useful if it becomes built-in.

There isn't really any documentation for this protocol but it's pretty self explainatory. 

The only problem I see is that at least one of my devices never reports the correct course (always returns the same number) but afaik it has been like that from the beginning (presumably some bug in the device's firmware)

The code could have been more compact if it used the regexp patterns, but I am not that well versed to do it right.