### PR TITLE
Adds unknown devices automatically.

### DIFF
--- a/debug.xml
+++ b/debug.xml
@@ -82,6 +82,9 @@
     <entry key='database.password'></entry>
 
     <entry key='database.ignoreUnknown'>true</entry>
+    
+    <!-- Automatically registers unknown devices. -->
+    <entry key='database.registerUnknown'>false</entry>
 
     <entry key='database.xml'>false</entry>
     <entry key='database.saveOriginal'>true</entry>


### PR DESCRIPTION
The feature is automatic adding of unknown devices.  To make this happen, I had to fix the name of the default group.  I chose "The default group".  If I choose an ID, such as ID=1, then this change would not merge well with existing installations.

Here's a SUNTECH meeting the server for the first time.  Server is glad to meet the new device and annotates that in the log.  Other than that, everything flows as if the device was already known.
```
2016-09-20 11:43:02  INFO: [33C73632] connected
2016-09-20 11:43:02 DEBUG: [33C73632: 5011 < 192.168.0.49] HEX: 5354333030414c543b3230353535363535313b30353b3436393b32303136303931333b31383a34393a35373b3136626431343b2d32322e3839363536313b2d3034332e3132323036343b3031302e3532313b3038342e36303b303b303b373236363b32342e33393b3030303030303b393b3030303134393b332e383b300d
2016-09-20 11:43:02  INFO: Nice meeting new device 205556551.
2016-09-20 11:43:02  INFO: [33C73632] disconnected
2016-09-20 11:43:03  INFO: [33C73632] id: 205556551, time: 2016-09-13 15:49:57, lat: -22.89656, lon: -43.12206, speed: 5.7, course: 84.6
```