### PR TITLE
Add attributes aliases

### DIFF
--- a/debug.xml
+++ b/debug.xml
@@ -331,6 +331,27 @@
     <entry key='database.deletePositions'>
         DELETE FROM positions WHERE serverTime &lt; :serverTime AND id NOT IN (SELECT positionId FROM devices);
     </entry>
+    
+    <entry key='database.selectAttributeAliases'>
+        SELECT * FROM device_aliases;
+    </entry>
+
+    <entry key='database.insertAttributeAlias'>
+        INSERT INTO device_aliases (deviceId, attribute, alias)
+        VALUES (:deviceId, :attribute, :alias);
+    </entry>
+
+    <entry key='database.updateAttributeAlias'>
+        UPDATE device_aliases SET
+        deviceId = :deviceId,
+        attribute = :attribute,
+        alias = :alias
+        WHERE id = :id;
+    </entry>
+
+    <entry key='database.deleteAttributeAlias'>
+        DELETE FROM device_aliases WHERE id = :id;
+    </entry>
 
     <!-- PROTOCOL CONFIG -->
 

--- a/debug.xml
+++ b/debug.xml
@@ -333,16 +333,16 @@
     </entry>
     
     <entry key='database.selectAttributeAliases'>
-        SELECT * FROM device_aliases;
+        SELECT * FROM attribute_aliases;
     </entry>
 
     <entry key='database.insertAttributeAlias'>
-        INSERT INTO device_aliases (deviceId, attribute, alias)
+        INSERT INTO attribute_aliases (deviceId, attribute, alias)
         VALUES (:deviceId, :attribute, :alias);
     </entry>
 
     <entry key='database.updateAttributeAlias'>
-        UPDATE device_aliases SET
+        UPDATE attribute_aliases SET
         deviceId = :deviceId,
         attribute = :attribute,
         alias = :alias
@@ -350,7 +350,7 @@
     </entry>
 
     <entry key='database.deleteAttributeAlias'>
-        DELETE FROM device_aliases WHERE id = :id;
+        DELETE FROM attribute_aliases WHERE id = :id;
     </entry>
 
     <!-- PROTOCOL CONFIG -->

--- a/schema/changelog-3.8.xml
+++ b/schema/changelog-3.8.xml
@@ -8,7 +8,7 @@
 
   <changeSet author="author" id="changelog-3.8">
 
-    <createTable tableName="device_aliases">
+    <createTable tableName="attribute_aliases">
       <column name="id" type="INT" autoIncrement="true">
         <constraints primaryKey="true" />
       </column>
@@ -23,8 +23,8 @@
       </column>
     </createTable>
     
-    <addForeignKeyConstraint baseTableName="device_aliases" baseColumnNames="deviceid" constraintName="fk_device_aliases_deviceid" referencedTableName="devices" referencedColumnNames="id" onDelete="CASCADE" />
-    <addUniqueConstraint tableName="device_aliases" columnNames="deviceid, attribute" constraintName="un_deviceid_attribute" />
+    <addForeignKeyConstraint baseTableName="attribute_aliases" baseColumnNames="deviceid" constraintName="fk_attribute_aliases_deviceid" referencedTableName="devices" referencedColumnNames="id" onDelete="CASCADE" />
+    <addUniqueConstraint tableName="attribute_aliases" columnNames="deviceid, attribute" constraintName="uk_deviceid_attribute" />
 
     <update tableName="users">
       <column name="map" type="VARCHAR(128)"/>

--- a/schema/changelog-3.8.xml
+++ b/schema/changelog-3.8.xml
@@ -8,6 +8,24 @@
 
   <changeSet author="author" id="changelog-3.8">
 
+    <createTable tableName="device_aliases">
+      <column name="id" type="INT" autoIncrement="true">
+        <constraints primaryKey="true" />
+      </column>
+      <column name="deviceid" type="INT">
+        <constraints nullable="false" />
+      </column>
+      <column name="attribute" type="VARCHAR(128)">
+        <constraints nullable="false" />
+      </column>
+      <column name="alias" type="VARCHAR(128)">
+        <constraints nullable="false" />
+      </column>
+    </createTable>
+    
+    <addForeignKeyConstraint baseTableName="device_aliases" baseColumnNames="deviceid" constraintName="fk_device_aliases_deviceid" referencedTableName="devices" referencedColumnNames="id" onDelete="CASCADE" />
+    <addUniqueConstraint tableName="device_aliases" columnNames="deviceid, attribute" constraintName="un_deviceid_attribute" />
+
     <update tableName="users">
       <column name="map" type="VARCHAR(128)"/>
       <where>map = 'osm'</where>

--- a/src/org/traccar/Context.java
+++ b/src/org/traccar/Context.java
@@ -16,6 +16,8 @@
 package org.traccar;
 
 import com.ning.http.client.AsyncHttpClient;
+
+import org.traccar.database.AliasesManager;
 import org.traccar.database.ConnectionManager;
 import org.traccar.database.DataManager;
 import org.traccar.database.DeviceManager;
@@ -134,6 +136,12 @@ public final class Context {
         return eventForwarder;
     }
 
+    private static AliasesManager aliasesManager;
+
+    public static AliasesManager getAliasesManager() {
+        return aliasesManager;
+    }
+
     public static void init(String[] arguments) throws Exception {
 
         config = new Config();
@@ -232,6 +240,8 @@ public final class Context {
         if (config.getBoolean("event.forward.enable")) {
             eventForwarder = new EventForwarder();
         }
+
+        aliasesManager = new AliasesManager(dataManager);
 
     }
 

--- a/src/org/traccar/api/resource/AttributeAliasResource.java
+++ b/src/org/traccar/api/resource/AttributeAliasResource.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2016 Anton Tananaev (anton.tananaev@gmail.com)
+ * Copyright 2016 Andrey Kunitsyn (abyss@fox5.ru)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.api.resource;
+
+import java.sql.SQLException;
+import java.util.Collection;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.traccar.Context;
+import org.traccar.api.BaseResource;
+import org.traccar.model.AttributeAlias;
+
+@Path("devices/aliases")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class AttributeAliasResource extends BaseResource {
+
+    @GET
+    public Collection<AttributeAlias> get(@QueryParam("deviceId") long deviceId) throws SQLException {
+        if (deviceId != 0) {
+            if (!Context.getPermissionsManager().isAdmin(getUserId())) {
+                Context.getPermissionsManager().checkDevice(getUserId(), deviceId);
+            }
+            return Context.getAliasesManager().getDeviceAttributeAliases(deviceId);
+        } else {
+            return Context.getAliasesManager().getUserDevicesAttributeAliases(getUserId());
+        }
+    }
+
+    @POST
+    public Response add(AttributeAlias entity) throws SQLException {
+        Context.getPermissionsManager().checkReadonly(getUserId());
+        if (!Context.getPermissionsManager().isAdmin(getUserId())) {
+            Context.getPermissionsManager().checkDevice(getUserId(), entity.getDeviceId());
+        }
+        Context.getAliasesManager().addAttributeAlias(entity);
+        return Response.ok(entity).build();
+    }
+
+    @Path("{id}")
+    @PUT
+    public Response update(@PathParam("id") long id, AttributeAlias entity) throws SQLException {
+        Context.getPermissionsManager().checkReadonly(getUserId());
+        if (!Context.getPermissionsManager().isAdmin(getUserId())) {
+            AttributeAlias oldAttrbuteAlias = Context.getAliasesManager().getAttributeAliasById(entity.getId());
+            if (oldAttrbuteAlias != null && oldAttrbuteAlias.getDeviceId() != entity.getDeviceId()) {
+                Context.getPermissionsManager().checkDevice(getUserId(), oldAttrbuteAlias.getDeviceId());
+            }
+            Context.getPermissionsManager().checkDevice(getUserId(), entity.getDeviceId());
+        }
+        Context.getAliasesManager().updateAttributeAlias(entity);
+        return Response.ok(entity).build();
+    }
+
+    @Path("{id}")
+    @DELETE
+    public Response remove(@PathParam("id") long id) throws SQLException {
+        Context.getPermissionsManager().checkReadonly(getUserId());
+        if (!Context.getPermissionsManager().isAdmin(getUserId())) {
+            AttributeAlias attrbuteAlias = Context.getAliasesManager().getAttributeAliasById(id);
+            Context.getPermissionsManager().checkDevice(getUserId(),
+                    attrbuteAlias != null ? attrbuteAlias.getDeviceId() : 0);
+        }
+        Context.getAliasesManager().removeArrtibuteAlias(id);
+        return Response.noContent().build();
+    }
+
+}

--- a/src/org/traccar/api/resource/AttributeAliasResource.java
+++ b/src/org/traccar/api/resource/AttributeAliasResource.java
@@ -46,9 +46,9 @@ public class AttributeAliasResource extends BaseResource {
             if (!Context.getPermissionsManager().isAdmin(getUserId())) {
                 Context.getPermissionsManager().checkDevice(getUserId(), deviceId);
             }
-            return Context.getAliasesManager().getDeviceAttributeAliases(deviceId);
+            return Context.getAliasesManager().getAttributeAliases(deviceId);
         } else {
-            return Context.getAliasesManager().getUserDevicesAttributeAliases(getUserId());
+            return Context.getAliasesManager().getAllAttributeAliases(getUserId());
         }
     }
 
@@ -67,10 +67,8 @@ public class AttributeAliasResource extends BaseResource {
     public Response update(@PathParam("id") long id, AttributeAlias entity) throws SQLException {
         Context.getPermissionsManager().checkReadonly(getUserId());
         if (!Context.getPermissionsManager().isAdmin(getUserId())) {
-            AttributeAlias oldAttrbuteAlias = Context.getAliasesManager().getAttributeAliasById(entity.getId());
-            if (oldAttrbuteAlias != null && oldAttrbuteAlias.getDeviceId() != entity.getDeviceId()) {
-                Context.getPermissionsManager().checkDevice(getUserId(), oldAttrbuteAlias.getDeviceId());
-            }
+            AttributeAlias oldEntity = Context.getAliasesManager().getAttributeAlias(entity.getId());
+            Context.getPermissionsManager().checkDevice(getUserId(), oldEntity.getDeviceId());
             Context.getPermissionsManager().checkDevice(getUserId(), entity.getDeviceId());
         }
         Context.getAliasesManager().updateAttributeAlias(entity);
@@ -82,9 +80,8 @@ public class AttributeAliasResource extends BaseResource {
     public Response remove(@PathParam("id") long id) throws SQLException {
         Context.getPermissionsManager().checkReadonly(getUserId());
         if (!Context.getPermissionsManager().isAdmin(getUserId())) {
-            AttributeAlias attrbuteAlias = Context.getAliasesManager().getAttributeAliasById(id);
-            Context.getPermissionsManager().checkDevice(getUserId(),
-                    attrbuteAlias != null ? attrbuteAlias.getDeviceId() : 0);
+            AttributeAlias entity = Context.getAliasesManager().getAttributeAlias(id);
+            Context.getPermissionsManager().checkDevice(getUserId(), entity.getDeviceId());
         }
         Context.getAliasesManager().removeArrtibuteAlias(id);
         return Response.noContent().build();

--- a/src/org/traccar/api/resource/DeviceResource.java
+++ b/src/org/traccar/api/resource/DeviceResource.java
@@ -88,6 +88,7 @@ public class DeviceResource extends BaseResource {
         if (Context.getGeofenceManager() != null) {
             Context.getGeofenceManager().refresh();
         }
+        Context.getAliasesManager().removeDevice(id);
         return Response.noContent().build();
     }
 

--- a/src/org/traccar/database/AliasesManager.java
+++ b/src/org/traccar/database/AliasesManager.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2016 Anton Tananaev (anton.tananaev@gmail.com)
+ * Copyright 2016 Andrey Kunitsyn (abyss@fox5.ru)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.database;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.traccar.Context;
+import org.traccar.helper.Log;
+import org.traccar.model.AttributeAlias;
+
+public class AliasesManager {
+
+    private final DataManager dataManager;
+
+    private final Map<Long, Set<AttributeAlias>> deviceAliases = new ConcurrentHashMap<>();
+    private final Map<Long, AttributeAlias> aliasesById = new ConcurrentHashMap<>();
+
+
+    public AliasesManager(DataManager dataManager) {
+        this.dataManager = dataManager;
+        refresh();
+    }
+
+    public Set<AttributeAlias> getDeviceAttributeAliases(long deviceId) {
+        if (!deviceAliases.containsKey(deviceId)) {
+            deviceAliases.put(deviceId, new HashSet<AttributeAlias>());
+        }
+        return deviceAliases.get(deviceId);
+    }
+
+    public final void refresh() {
+        if (dataManager != null) {
+            try {
+                deviceAliases.clear();
+                for (AttributeAlias attributeAlias : dataManager.getAttributeAliases()) {
+                    getDeviceAttributeAliases(attributeAlias.getDeviceId())
+                            .add(attributeAlias);
+                    aliasesById.put(attributeAlias.getId(), attributeAlias);
+                }
+            } catch (SQLException error) {
+                Log.warning(error);
+            }
+        }
+    }
+
+    public void removeDevice(long deviceId) {
+        for (AttributeAlias attributeAlias : getDeviceAttributeAliases(deviceId)) {
+            aliasesById.remove(attributeAlias.getId());
+        }
+        deviceAliases.remove(deviceId);
+    }
+
+    public void addAttributeAlias(AttributeAlias attributeAlias) throws SQLException {
+        dataManager.addAttributeAlias(attributeAlias);
+        aliasesById.put(attributeAlias.getId(), attributeAlias);
+        getDeviceAttributeAliases(attributeAlias.getDeviceId()).add(attributeAlias);
+    }
+
+    public void updateAttributeAlias(AttributeAlias attributeAlias) throws SQLException {
+        dataManager.updateAttributeAlias(attributeAlias);
+        AttributeAlias cachedAlias = aliasesById.get(attributeAlias.getId());
+        if (cachedAlias.getDeviceId() != attributeAlias.getDeviceId()) {
+            getDeviceAttributeAliases(cachedAlias.getDeviceId()).remove(cachedAlias);
+            cachedAlias.setDeviceId(attributeAlias.getDeviceId());
+            getDeviceAttributeAliases(cachedAlias.getDeviceId()).add(cachedAlias);
+        }
+        cachedAlias.setAttribute(attributeAlias.getAttribute());
+        cachedAlias.setAlias(attributeAlias.getAlias());
+    }
+
+    public void removeArrtibuteAlias(long attributeAliasId) throws SQLException {
+        dataManager.removeAttributeAlias(attributeAliasId);
+        AttributeAlias cachedAlias = aliasesById.get(attributeAliasId);
+        getDeviceAttributeAliases(cachedAlias.getDeviceId()).remove(cachedAlias);
+        aliasesById.remove(attributeAliasId);
+    }
+
+    public AttributeAlias getDeviceAliasByAttribute(long deviceId, String attribute) {
+        for (AttributeAlias alias : getDeviceAttributeAliases(deviceId)) {
+            if (alias.getAttribute().equals(attribute)) {
+                return alias;
+            }
+        }
+        return null;
+    }
+
+    public Collection<AttributeAlias> getUserDevicesAttributeAliases(long userId) {
+        Collection<AttributeAlias> userDevicesAliases = new ArrayList<>();
+        for (long deviceId : Context.getPermissionsManager().getDevicePermissions(userId)) {
+            userDevicesAliases.addAll(getDeviceAttributeAliases(deviceId));
+        }
+        return userDevicesAliases;
+    }
+
+    public AttributeAlias getAttributeAliasById(long id) {
+        return aliasesById.get(id);
+    }
+
+}

--- a/src/org/traccar/database/AliasesManager.java
+++ b/src/org/traccar/database/AliasesManager.java
@@ -35,25 +35,12 @@ public class AliasesManager {
     private final Map<Long, Set<AttributeAlias>> deviceAliases = new ConcurrentHashMap<>();
     private final Map<Long, AttributeAlias> aliasesById = new ConcurrentHashMap<>();
 
-
     public AliasesManager(DataManager dataManager) {
         this.dataManager = dataManager;
-        refresh();
-    }
-
-    public Set<AttributeAlias> getDeviceAttributeAliases(long deviceId) {
-        if (!deviceAliases.containsKey(deviceId)) {
-            deviceAliases.put(deviceId, new HashSet<AttributeAlias>());
-        }
-        return deviceAliases.get(deviceId);
-    }
-
-    public final void refresh() {
         if (dataManager != null) {
             try {
-                deviceAliases.clear();
                 for (AttributeAlias attributeAlias : dataManager.getAttributeAliases()) {
-                    getDeviceAttributeAliases(attributeAlias.getDeviceId())
+                    getAttributeAliases(attributeAlias.getDeviceId())
                             .add(attributeAlias);
                     aliasesById.put(attributeAlias.getId(), attributeAlias);
                 }
@@ -63,8 +50,15 @@ public class AliasesManager {
         }
     }
 
+    public Set<AttributeAlias> getAttributeAliases(long deviceId) {
+        if (!deviceAliases.containsKey(deviceId)) {
+            deviceAliases.put(deviceId, new HashSet<AttributeAlias>());
+        }
+        return deviceAliases.get(deviceId);
+    }
+
     public void removeDevice(long deviceId) {
-        for (AttributeAlias attributeAlias : getDeviceAttributeAliases(deviceId)) {
+        for (AttributeAlias attributeAlias : getAttributeAliases(deviceId)) {
             aliasesById.remove(attributeAlias.getId());
         }
         deviceAliases.remove(deviceId);
@@ -73,16 +67,16 @@ public class AliasesManager {
     public void addAttributeAlias(AttributeAlias attributeAlias) throws SQLException {
         dataManager.addAttributeAlias(attributeAlias);
         aliasesById.put(attributeAlias.getId(), attributeAlias);
-        getDeviceAttributeAliases(attributeAlias.getDeviceId()).add(attributeAlias);
+        getAttributeAliases(attributeAlias.getDeviceId()).add(attributeAlias);
     }
 
     public void updateAttributeAlias(AttributeAlias attributeAlias) throws SQLException {
         dataManager.updateAttributeAlias(attributeAlias);
         AttributeAlias cachedAlias = aliasesById.get(attributeAlias.getId());
         if (cachedAlias.getDeviceId() != attributeAlias.getDeviceId()) {
-            getDeviceAttributeAliases(cachedAlias.getDeviceId()).remove(cachedAlias);
+            getAttributeAliases(cachedAlias.getDeviceId()).remove(cachedAlias);
             cachedAlias.setDeviceId(attributeAlias.getDeviceId());
-            getDeviceAttributeAliases(cachedAlias.getDeviceId()).add(cachedAlias);
+            getAttributeAliases(cachedAlias.getDeviceId()).add(cachedAlias);
         }
         cachedAlias.setAttribute(attributeAlias.getAttribute());
         cachedAlias.setAlias(attributeAlias.getAlias());
@@ -91,12 +85,12 @@ public class AliasesManager {
     public void removeArrtibuteAlias(long attributeAliasId) throws SQLException {
         dataManager.removeAttributeAlias(attributeAliasId);
         AttributeAlias cachedAlias = aliasesById.get(attributeAliasId);
-        getDeviceAttributeAliases(cachedAlias.getDeviceId()).remove(cachedAlias);
+        getAttributeAliases(cachedAlias.getDeviceId()).remove(cachedAlias);
         aliasesById.remove(attributeAliasId);
     }
 
-    public AttributeAlias getDeviceAliasByAttribute(long deviceId, String attribute) {
-        for (AttributeAlias alias : getDeviceAttributeAliases(deviceId)) {
+    public AttributeAlias getAttributeAlias(long deviceId, String attribute) {
+        for (AttributeAlias alias : getAttributeAliases(deviceId)) {
             if (alias.getAttribute().equals(attribute)) {
                 return alias;
             }
@@ -104,15 +98,15 @@ public class AliasesManager {
         return null;
     }
 
-    public Collection<AttributeAlias> getUserDevicesAttributeAliases(long userId) {
+    public Collection<AttributeAlias> getAllAttributeAliases(long userId) {
         Collection<AttributeAlias> userDevicesAliases = new ArrayList<>();
         for (long deviceId : Context.getPermissionsManager().getDevicePermissions(userId)) {
-            userDevicesAliases.addAll(getDeviceAttributeAliases(deviceId));
+            userDevicesAliases.addAll(getAttributeAliases(deviceId));
         }
         return userDevicesAliases;
     }
 
-    public AttributeAlias getAttributeAliasById(long id) {
+    public AttributeAlias getAttributeAlias(long id) {
         return aliasesById.get(id);
     }
 

--- a/src/org/traccar/database/DataManager.java
+++ b/src/org/traccar/database/DataManager.java
@@ -37,6 +37,7 @@ import liquibase.resource.ResourceAccessor;
 
 import org.traccar.Config;
 import org.traccar.helper.Log;
+import org.traccar.model.AttributeAlias;
 import org.traccar.model.Device;
 import org.traccar.model.DevicePermission;
 import org.traccar.model.Event;
@@ -458,6 +459,29 @@ public class DataManager {
     public void removeNotification(Notification notification) throws SQLException {
         QueryBuilder.create(dataSource, getQuery("database.deleteNotification"))
                 .setLong("id", notification.getId())
+                .executeUpdate();
+    }
+
+    public Collection<AttributeAlias> getAttributeAliases() throws SQLException {
+        return QueryBuilder.create(dataSource, getQuery("database.selectAttributeAliases"))
+                .executeQuery(AttributeAlias.class);
+    }
+
+    public void addAttributeAlias(AttributeAlias attributeAlias) throws SQLException {
+        attributeAlias.setId(QueryBuilder.create(dataSource, getQuery("database.insertAttributeAlias"), true)
+                .setObject(attributeAlias)
+                .executeUpdate());
+    }
+
+    public void updateAttributeAlias(AttributeAlias attributeAlias) throws SQLException {
+        QueryBuilder.create(dataSource, getQuery("database.updateAttributeAlias"))
+                .setObject(attributeAlias)
+                .executeUpdate();
+    }
+
+    public void removeAttributeAlias(long attributeAliasId) throws SQLException {
+        QueryBuilder.create(dataSource, getQuery("database.deleteAttributeAlias"))
+                .setLong("id", attributeAliasId)
                 .executeUpdate();
     }
 }

--- a/src/org/traccar/model/AttributeAlias.java
+++ b/src/org/traccar/model/AttributeAlias.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 Anton Tananaev (anton.tananaev@gmail.com)
+ * Copyright 2016 Andrey Kunitsyn (abyss@fox5.ru)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.model;
+
+public class AttributeAlias {
+
+    private long id;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    private long deviceId;
+
+    public long getDeviceId() {
+        return deviceId;
+    }
+
+    public void setDeviceId(long deviceId) {
+        this.deviceId = deviceId;
+    }
+
+    private String attribute;
+
+    public String getAttribute() {
+        return attribute;
+    }
+
+    public void setAttribute(String attribute) {
+        this.attribute = attribute;
+    }
+
+    private String alias;
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+}

--- a/src/org/traccar/web/WebServer.java
+++ b/src/org/traccar/web/WebServer.java
@@ -34,6 +34,7 @@ import org.traccar.api.CorsResponseFilter;
 import org.traccar.api.ObjectMapperProvider;
 import org.traccar.api.ResourceErrorHandler;
 import org.traccar.api.SecurityRequestFilter;
+import org.traccar.api.resource.AttributeAliasResource;
 import org.traccar.api.resource.CommandResource;
 import org.traccar.api.resource.GroupPermissionResource;
 import org.traccar.api.resource.ServerResource;
@@ -161,7 +162,7 @@ public class WebServer {
                 GroupResource.class, DeviceResource.class, PositionResource.class,
                 CommandTypeResource.class, EventResource.class, GeofenceResource.class,
                 DeviceGeofenceResource.class, GeofencePermissionResource.class, GroupGeofenceResource.class,
-                NotificationResource.class, ReportResource.class);
+                NotificationResource.class, ReportResource.class, AttributeAliasResource.class);
         servletHandler.addServlet(new ServletHolder(new ServletContainer(resourceConfig)), "/*");
 
         handlers.addHandler(servletHandler);


### PR DESCRIPTION
Added attributes aliases (server part)

- It is just cache, proxy functions and API resources
- Used `id` to simplify update and remove
- Added unique constraint to deviceId-attribute to exclude duplicate attributes per device

Sometimes I used `alias` instead of `attributeAlias` just not to do long names.