### PR TITLE
For JT600c - added engine start/stop, set timezone and reboot commands implementations

### DIFF
--- a/src/org/traccar/protocol/Jt600Protocol.java
+++ b/src/org/traccar/protocol/Jt600Protocol.java
@@ -17,6 +17,7 @@ package org.traccar.protocol;
 
 import org.jboss.netty.bootstrap.ServerBootstrap;
 import org.jboss.netty.channel.ChannelPipeline;
+import org.jboss.netty.handler.codec.string.StringEncoder;
 import org.traccar.BaseProtocol;
 import org.traccar.TrackerServer;
 import org.traccar.model.Command;
@@ -39,6 +40,7 @@ public class Jt600Protocol extends BaseProtocol {
             @Override
             protected void addSpecificHandlers(ChannelPipeline pipeline) {
                 pipeline.addLast("frameDecoder", new Jt600FrameDecoder());
+                pipeline.addLast("stringEncoder", new StringEncoder());
                 pipeline.addLast("objectEncoder", new Jt600ProtocolEncoder());
                 pipeline.addLast("objectDecoder", new Jt600ProtocolDecoder(Jt600Protocol.this));
             }

--- a/src/org/traccar/protocol/Jt600Protocol.java
+++ b/src/org/traccar/protocol/Jt600Protocol.java
@@ -19,6 +19,7 @@ import org.jboss.netty.bootstrap.ServerBootstrap;
 import org.jboss.netty.channel.ChannelPipeline;
 import org.traccar.BaseProtocol;
 import org.traccar.TrackerServer;
+import org.traccar.model.Command;
 
 import java.util.List;
 
@@ -26,6 +27,10 @@ public class Jt600Protocol extends BaseProtocol {
 
     public Jt600Protocol() {
         super("jt600");
+        setSupportedCommands(Command.TYPE_ENGINE_RESUME,
+                             Command.TYPE_ENGINE_STOP,
+                             Command.TYPE_SET_TIMEZONE,
+                             Command.TYPE_REBOOT_DEVICE);
     }
 
     @Override
@@ -34,6 +39,7 @@ public class Jt600Protocol extends BaseProtocol {
             @Override
             protected void addSpecificHandlers(ChannelPipeline pipeline) {
                 pipeline.addLast("frameDecoder", new Jt600FrameDecoder());
+                pipeline.addLast("objectEncoder", new Jt600ProtocolEncoder());
                 pipeline.addLast("objectDecoder", new Jt600ProtocolDecoder(Jt600Protocol.this));
             }
         });

--- a/src/org/traccar/protocol/Jt600Protocol.java
+++ b/src/org/traccar/protocol/Jt600Protocol.java
@@ -28,10 +28,11 @@ public class Jt600Protocol extends BaseProtocol {
 
     public Jt600Protocol() {
         super("jt600");
-        setSupportedCommands(Command.TYPE_ENGINE_RESUME,
-                             Command.TYPE_ENGINE_STOP,
-                             Command.TYPE_SET_TIMEZONE,
-                             Command.TYPE_REBOOT_DEVICE);
+        setSupportedCommands(
+                Command.TYPE_ENGINE_RESUME,
+                Command.TYPE_ENGINE_STOP,
+                Command.TYPE_SET_TIMEZONE,
+                Command.TYPE_REBOOT_DEVICE);
     }
 
     @Override

--- a/src/org/traccar/protocol/Jt600ProtocolEncoder.java
+++ b/src/org/traccar/protocol/Jt600ProtocolEncoder.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 Anton Tananaev (anton.tananaev@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.protocol;
+
+import org.traccar.StringProtocolEncoder;
+import org.traccar.helper.Log;
+import org.traccar.model.Command;
+
+public class Jt600ProtocolEncoder extends StringProtocolEncoder {
+    @Override
+    protected Object encodeCommand(Command command) {
+
+        switch (command.getType()) {
+            case Command.TYPE_ENGINE_STOP:
+                return "(S07,0)";
+            case Command.TYPE_ENGINE_RESUME:
+                return "(S07,1)";
+            case Command.TYPE_SET_TIMEZONE:
+                int offset = ((Number) command.getAttributes().get(Command.KEY_TIMEZONE)).intValue() / 60;
+                return "(S09,1," + offset + ")";
+            case Command.TYPE_REBOOT_DEVICE:
+                return "(S17)";
+            default:
+                Log.warning(new UnsupportedOperationException(command.getType()));
+                break;
+        }
+
+        return null;
+    }
+}

--- a/test/org/traccar/protocol/Jt600ProtocolEncoderTest.java
+++ b/test/org/traccar/protocol/Jt600ProtocolEncoderTest.java
@@ -1,0 +1,37 @@
+package org.traccar.protocol;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.traccar.ProtocolTest;
+import org.traccar.model.Command;
+
+public class Jt600ProtocolEncoderTest extends ProtocolTest {
+    Jt600ProtocolEncoder encoder = new Jt600ProtocolEncoder();
+    Command command = new Command();
+
+    @Test
+    public void testEngineStop() throws Exception {
+        command.setType(Command.TYPE_ENGINE_STOP);
+        assertEquals("(S07,0)", encoder.encodeCommand(command));
+    }
+
+    @Test
+    public void testEngineResume() throws Exception {
+        command.setType(Command.TYPE_ENGINE_RESUME);
+        assertEquals("(S07,1)", encoder.encodeCommand(command));
+    }
+
+    @Test
+    public void testSetTimezone() throws Exception {
+        command.setType(Command.TYPE_SET_TIMEZONE);
+        command.set(Command.KEY_TIMEZONE, 240 * 60);
+        assertEquals("(S09,1,240)", encoder.encodeCommand(command));
+    }
+
+    @Test
+    public void testReboot() throws Exception {
+        command.setType(Command.TYPE_REBOOT_DEVICE);
+        assertEquals("(S17)", encoder.encodeCommand(command));
+    }
+}


### PR DESCRIPTION
I have added following commands implementations:

* Engine start
* Ending stop
* Set Timezone
* Reboot device

Also tests were added. All commands are sent via text, so I am not sure that it is acceptable for the binary version of protocol.