### PR TITLE
GL200: Password for commands and heartbeat authentication

### DIFF
--- a/src/org/traccar/protocol/Gl200Protocol.java
+++ b/src/org/traccar/protocol/Gl200Protocol.java
@@ -35,6 +35,7 @@ public class Gl200Protocol extends BaseProtocol {
                 Command.TYPE_POSITION_SINGLE,
                 Command.TYPE_ENGINE_STOP,
                 Command.TYPE_ENGINE_RESUME,
+                Command.TYPE_IDENTIFICATION,
                 Command.TYPE_REBOOT_DEVICE);
     }
 

--- a/src/org/traccar/protocol/Gl200ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gl200ProtocolDecoder.java
@@ -39,7 +39,7 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN_HBD = new PatternBuilder()
             .text("+ACK:GTHBD,")
-            .number("([0-9A-Z]{2}xxxx),")          // protocol version
+            .number("([0-9A-Z]{2}xxxx),")        // protocol version
             .number("(d{15}),")                  // imei
             .any().text(",")
             .number("(xxxx)")

--- a/src/org/traccar/protocol/Gl200ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gl200ProtocolDecoder.java
@@ -39,7 +39,8 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN_HBD = new PatternBuilder()
             .text("+ACK:GTHBD,")
-            .number("([0-9A-Z]{2}xxxx),")
+            .number("([0-9A-Z]{2}xxxx),")          // protocol version
+            .number("(d{15}),")                  // imei
             .any().text(",")
             .number("(xxxx)")
             .text("$").optional()
@@ -245,7 +246,11 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
     private Object decodeHbd(Channel channel, SocketAddress remoteAddress, String sentence) {
         Parser parser = new Parser(PATTERN_HBD, sentence);
         if (parser.matches() && channel != null) {
-            channel.write("+SACK:GTHBD," + parser.next() + "," + parser.next() + "$", remoteAddress);
+            String protocolVersion = parser.next();
+            DeviceSession deviceSession = getDeviceSession(channel, remoteAddress, parser.next());
+            if (deviceSession != null) {
+                channel.write("+SACK:GTHBD," + protocolVersion + "," + parser.next() + "$", remoteAddress);
+            }
         }
         return null;
     }

--- a/src/org/traccar/protocol/Gl200ProtocolEncoder.java
+++ b/src/org/traccar/protocol/Gl200ProtocolEncoder.java
@@ -24,15 +24,21 @@ public class Gl200ProtocolEncoder extends StringProtocolEncoder {
     @Override
     protected Object encodeCommand(Command command) {
 
+        initDevicePassword(command, "");
+
         switch (command.getType()) {
             case Command.TYPE_POSITION_SINGLE:
-                return "AT+GTRTO=gv300,1,,,,,,FFFF$";
+                return formatCommand(command, "AT+GTRTO={%s},1,,,,,,FFFF$", Command.KEY_DEVICE_PASSWORD);
             case Command.TYPE_ENGINE_STOP:
-                return "AT+GTOUT=gv300,1,,,0,0,0,0,0,0,0,,,,,,,FFFF$";
+                return formatCommand(command, "AT+GTOUT={%s},1,,,0,0,0,0,0,0,0,,,,,,,FFFF$",
+                        Command.KEY_DEVICE_PASSWORD);
             case Command.TYPE_ENGINE_RESUME:
-                return "AT+GTOUT=gv300,0,,,0,0,0,0,0,0,0,,,,,,,FFFF$";
+                return formatCommand(command, "AT+GTOUT={%s},0,,,0,0,0,0,0,0,0,,,,,,,FFFF$",
+                        Command.KEY_DEVICE_PASSWORD);
+            case Command.TYPE_IDENTIFICATION:
+                return formatCommand(command, "AT+GTRTO={%s},8,,,,,,FFFF$", Command.KEY_DEVICE_PASSWORD);
             case Command.TYPE_REBOOT_DEVICE:
-                return "AT+GTRTO=gv300,3,,,,,,FFFF$";
+                return formatCommand(command, "AT+GTRTO={%s},3,,,,,,FFFF$", Command.KEY_DEVICE_PASSWORD);
             default:
                 Log.warning(new UnsupportedOperationException(command.getType()));
                 break;


### PR DESCRIPTION
- Remove hardcoded password from commands, there is no default one, it depends on device model.
- Authenticate a device on heartbeat stage and reply only to registered devices. It will make the device online and allow send commands before a position received