### PR TITLE
Implement limiting list of users to be notified

### DIFF
--- a/src/org/traccar/database/NotificationManager.java
+++ b/src/org/traccar/database/NotificationManager.java
@@ -55,7 +55,7 @@ public class NotificationManager {
             Log.warning(error);
         }
 
-        Set<Long> users = Context.getPermissionsManager().getDeviceUsers(event.getDeviceId());
+        Set<Long> users = new HashSet<Long>(Context.getPermissionsManager().getDeviceUsers(event.getDeviceId()));
         String notifyOnly = Context.getDeviceManager().lookupConfigString(event.getDeviceId(),
                 "event.notifyOnly", null);
         if (notifyOnly != null) {

--- a/src/org/traccar/database/NotificationManager.java
+++ b/src/org/traccar/database/NotificationManager.java
@@ -18,9 +18,11 @@ package org.traccar.database;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -28,6 +30,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.traccar.Context;
 import org.traccar.helper.Log;
+import org.traccar.model.Device;
 import org.traccar.model.Event;
 import org.traccar.model.Notification;
 import org.traccar.model.Position;
@@ -54,6 +57,15 @@ public class NotificationManager {
         }
 
         Set<Long> users = Context.getPermissionsManager().getDeviceUsers(event.getDeviceId());
+        Device device = Context.getIdentityManager().getDeviceById(event.getDeviceId());
+        if (device != null && device.getAttributes().containsKey("notifyOnly")) {
+            List<String> notifyOnly = Arrays.asList(device.getAttributes().get("notifyOnly").toString().split(" "));
+            for (long userId : users) {
+                if (!notifyOnly.contains(Context.getPermissionsManager().getUser(userId).getEmail())) {
+                    users.remove(userId);
+                }
+            }
+        }
         for (long userId : users) {
             if (event.getGeofenceId() == 0 || Context.getGeofenceManager() != null
                     && Context.getGeofenceManager().checkGeofence(userId, event.getGeofenceId())) {

--- a/src/org/traccar/database/NotificationManager.java
+++ b/src/org/traccar/database/NotificationManager.java
@@ -30,7 +30,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.traccar.Context;
 import org.traccar.helper.Log;
-import org.traccar.model.Device;
 import org.traccar.model.Event;
 import org.traccar.model.Notification;
 import org.traccar.model.Position;
@@ -57,11 +56,12 @@ public class NotificationManager {
         }
 
         Set<Long> users = Context.getPermissionsManager().getDeviceUsers(event.getDeviceId());
-        Device device = Context.getIdentityManager().getDeviceById(event.getDeviceId());
-        if (device != null && device.getAttributes().containsKey("notifyOnly")) {
-            List<String> notifyOnly = Arrays.asList(device.getAttributes().get("notifyOnly").toString().split(" "));
+        String notifyOnly = Context.getDeviceManager().lookupConfigString(event.getDeviceId(),
+                "event.notifyOnly", null);
+        if (notifyOnly != null) {
+            List<String> notifyOnlyList = Arrays.asList(notifyOnly.split(" "));
             for (long userId : users) {
-                if (!notifyOnly.contains(Context.getPermissionsManager().getUser(userId).getEmail())) {
+                if (!notifyOnlyList.contains(Context.getPermissionsManager().getUser(userId).getEmail())) {
                     users.remove(userId);
                 }
             }

--- a/src/org/traccar/database/NotificationManager.java
+++ b/src/org/traccar/database/NotificationManager.java
@@ -55,7 +55,7 @@ public class NotificationManager {
             Log.warning(error);
         }
 
-        Set<Long> users = new HashSet<Long>(Context.getPermissionsManager().getDeviceUsers(event.getDeviceId()));
+        Set<Long> users = new HashSet<>(Context.getPermissionsManager().getDeviceUsers(event.getDeviceId()));
         String notifyOnly = Context.getDeviceManager().lookupConfigString(event.getDeviceId(),
                 "event.notifyOnly", null);
         if (notifyOnly != null) {


### PR DESCRIPTION
fix #2061 
User can specify `notifyOnly` device attribute with list of emails separated by space.
Emails must be of existed users and that users must have access to the device.
