### PR TITLE
Fixed Protocol Logic

### DIFF
--- a/src/org/traccar/protocol/GlobalSatProtocolDecoder.java
+++ b/src/org/traccar/protocol/GlobalSatProtocolDecoder.java
@@ -37,7 +37,7 @@ public class GlobalSatProtocolDecoder extends BaseProtocolDecoder {
         super(protocol);
 
         format0 = Context.getConfig().getString(getProtocolName() + ".format0", "TSPRXAB27GHKLMnaicz*U!");
-        format1 = Context.getConfig().getString(getProtocolName() + ".format1", "SARY*U!");
+        format1 = Context.getConfig().getString(getProtocolName() + ".format1", "TSARY*U!");
     }
 
     public void setFormat0(String format) {
@@ -79,7 +79,7 @@ public class GlobalSatProtocolDecoder extends BaseProtocolDecoder {
         Position position = new Position();
         position.setProtocol(getProtocolName());
 
-        for (int formatIndex = 0, valueIndex = 1; formatIndex < format.length()
+        for (int formatIndex = 0, valueIndex = 0; formatIndex < format.length()
                 && valueIndex < values.length; formatIndex++) {
             String value = values[valueIndex];
 


### PR DESCRIPTION
Protocol decoder is incorrectly reading the third field as the IMEI, rather than the second field as specified in GlobalSat's TR-313 Documentation v0.3 and TR-206 Documentation v.7_110111.