### PR TITLE
Fix current user for alpine in Dockerfile

### DIFF
--- a/setup/docker/Dockerfile
+++ b/setup/docker/Dockerfile
@@ -2,6 +2,8 @@ FROM java:8-alpine
 
 MAINTAINER Danilo Recchia <danilo.recchia@vortus.solutions>
 
+USER root
+
 RUN apk upgrade --update && \
     apk add --update curl bash && \
     rm -rf /var/cache/apk/* && \


### PR DESCRIPTION
Non-root user causes build error on Docker.

When user is non-root, Docker build stops:

```
Sending build context to Docker daemon 19.27 MB
Step 1 : FROM java:8-alpine
 ---> 7c2c8f354ab3
Step 2 : MAINTAINER Danilo Recchia <danilo.recchia@vortus.solutions>
 ---> Running in d7ca8033cd63
 ---> fb9b743ad434
Removing intermediate container d7ca8033cd63
Step 3 : RUN apk upgrade --update &&     apk add --update curl bash &&     rm -rf /var/cache/apk/* &&     mkdir -p /opt/traccar/logs &&     mkdir -p /opt/traccar/data
 ---> Running in ba377d2489aa
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/APKINDEX.tar.gz
(1/6) Upgrading libcrypto1.0 (1.0.2i-r0 -> 1.0.2j-r0)
(2/6) Upgrading libssl1.0 (1.0.2i-r0 -> 1.0.2j-r0)
(3/6) Upgrading libx11 (1.6.3-r2 -> 1.6.4-r0)
(4/6) Upgrading libxi (1.7.6-r0 -> 1.7.7-r0)
(5/6) Upgrading libxrender (0.9.9-r1 -> 0.9.10-r0)
(6/6) Upgrading libxtst (1.2.2-r0 -> 1.2.3-r0)
Executing busybox-1.24.2-r11.trigger
OK: 140 MiB in 35 packages
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/APKINDEX.tar.gz
(1/8) Installing ncurses-terminfo-base (6.0-r7)
ERROR: ncurses-terminfo-base-6.0-r7: temporary error (try again later)
(2/8) Installing ncurses-terminfo (6.0-r7)
(3/8) Installing ncurses-libs (6.0-r7)
(4/8) Installing readline (6.3.008-r4)
(5/8) Installing bash (4.3.42-r3)
Executing bash-4.3.42-r3.post-install
(6/8) Installing libssh2 (1.7.0-r0)
(7/8) Installing libcurl (7.50.3-r0)
(8/8) Installing curl (7.50.3-r0)
Executing busybox-1.24.2-r11.trigger
1 errors; 149 MiB in 42 packages
The command '/bin/sh -c apk upgrade --update &&     apk add --update curl bash &&     rm -rf /var/cache/apk/* &&     mkdir -p /opt/traccar/logs &&     mkdir -p /opt/traccar/data' returned a non-zero code: 1
```

Further inspection by going into the partially built container leads to this error:

```
bash-4.3# apk upgrade --update && \                                                                                                                                                                                                                                                
>     apk add --update curl bash && \
>     rm -rf /var/cache/apk/* && \
>     mkdir -p /opt/traccar/logs && \
>     mkdir -p /opt/traccar/data
ERROR: Unable to lock database: Resource temporarily unavailable
ERROR: Failed to open apk database: temporary error (try again later)
```

Changing current user to root in the Dockerfile results to a clean build:

```
Sending build context to Docker daemon 19.27 MB
Step 1 : FROM java:8-alpine
 ---> 7c2c8f354ab3
Step 2 : MAINTAINER Danilo Recchia <danilo.recchia@vortus.solutions>
 ---> Using cache
 ---> fb9b743ad434
Step 3 : USER root
 ---> Running in 63b40d5c2e66
 ---> c484a1fcf3f6
Removing intermediate container 63b40d5c2e66
Step 4 : RUN apk upgrade --update &&     apk add --update curl bash &&     rm -rf /var/cache/apk/* &&     mkdir -p /opt/traccar/logs &&     mkdir -p /opt/traccar/data
 ---> Running in d1987c761f47
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/main/x86_64/APKINDEX.tar.gz
ERROR: http://dl-cdn.alpinelinux.org/alpine/v3.4/main: temporary error (try again later)
WARNING: Ignoring APKINDEX.167438ca.tar.gz: No such file or directory
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/APKINDEX.tar.gz
OK: 140 MiB in 35 packages
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/APKINDEX.tar.gz
(1/8) Installing ncurses-terminfo-base (6.0-r7)
(2/8) Installing ncurses-terminfo (6.0-r7)
(3/8) Installing ncurses-libs (6.0-r7)
(4/8) Installing readline (6.3.008-r4)
(5/8) Installing bash (4.3.42-r3)
Executing bash-4.3.42-r3.post-install
(6/8) Installing libssh2 (1.7.0-r0)
(7/8) Installing libcurl (7.50.3-r0)
(8/8) Installing curl (7.50.3-r0)
Executing busybox-1.24.2-r11.trigger
OK: 149 MiB in 43 packages
 ---> aac351d644cd
Removing intermediate container d1987c761f47
Step 5 : ENV JAVA_OPTS -Xms256m -Xmx1024m
 ---> Running in e2869cea6f41
 ---> 0f89c8bcda33
Removing intermediate container e2869cea6f41
Step 6 : COPY ./tmp/traccar.xml /opt/traccar/traccar.xml
 ---> a26ccef14b75
Removing intermediate container d897b82bcbec
Step 7 : COPY ./tmp/schema /opt/traccar/schema
 ---> 3f187dc85836
Removing intermediate container 2cf342c8177c
Step 8 : COPY ./tmp/web /opt/traccar/web
 ---> 0381162425d7
Removing intermediate container 18ae7141af50
Step 9 : COPY ./tmp/lib /opt/traccar/lib
 ---> beaf28a518dc
Removing intermediate container 81cd63778c26
Step 10 : COPY ./tmp/traccar-server.jar /opt/traccar/traccar-server.jar
 ---> 87994e1b2ecd
Removing intermediate container fd59fc02b59e
Step 11 : EXPOSE 8082
 ---> Running in a88636e9d8e1
 ---> dd5cabb90588
Removing intermediate container a88636e9d8e1
Step 12 : EXPOSE 5000-5150
 ---> Running in 27ff9147309a
 ---> 549f32b22b09
Removing intermediate container 27ff9147309a
Step 13 : WORKDIR /opt/traccar
 ---> Running in 5b4e2fecbfa4
 ---> 2ede661d8b05
Removing intermediate container 5b4e2fecbfa4
Step 14 : ENTRYPOINT java -jar traccar-server.jar traccar.xml
 ---> Running in 76f596a44c66
 ---> 8f5522f79a9c
Removing intermediate container 76f596a44c66
Successfully built 8f5522f79a9c
```

