### PR TITLE
Copy some attributes from last position

### DIFF
--- a/debug.xml
+++ b/debug.xml
@@ -45,6 +45,8 @@
 
     <entry key='decoder.ignoreSessionCache'>false</entry>
 
+    <entry key='processing.copyAttributes.enable'>false</entry>
+
     <entry key='event.enable'>true</entry>
     <entry key='event.overspeedHandler'>true</entry>
     <entry key='event.overspeed.notRepeat'>true</entry>

--- a/debug.xml
+++ b/debug.xml
@@ -46,6 +46,7 @@
     <entry key='decoder.ignoreSessionCache'>false</entry>
 
     <entry key='processing.copyAttributes.enable'>false</entry>
+    <entry key='processing.copyAttributes'>power ignition battery</entry>
 
     <entry key='event.enable'>true</entry>
     <entry key='event.overspeedHandler'>true</entry>

--- a/src/org/traccar/BasePipelineFactory.java
+++ b/src/org/traccar/BasePipelineFactory.java
@@ -50,6 +50,7 @@ public abstract class BasePipelineFactory implements ChannelPipelineFactory {
     private ReverseGeocoderHandler reverseGeocoderHandler;
     private LocationProviderHandler locationProviderHandler;
     private HemisphereHandler hemisphereHandler;
+    private CopyAttributesHandler copyAttributesHandler;
 
     private CommandResultEventHandler commandResultEventHandler;
     private OverspeedEventHandler overspeedEventHandler;
@@ -139,6 +140,10 @@ public abstract class BasePipelineFactory implements ChannelPipelineFactory {
             hemisphereHandler = new HemisphereHandler();
         }
 
+        if (Context.getConfig().getBoolean("processing.copyAttributes.enable")) {
+            copyAttributesHandler = new CopyAttributesHandler();
+        }
+
         if (Context.getConfig().getBoolean("event.enable")) {
             commandResultEventHandler = new CommandResultEventHandler();
 
@@ -199,6 +204,10 @@ public abstract class BasePipelineFactory implements ChannelPipelineFactory {
 
         if (distanceHandler != null) {
             pipeline.addLast("distance", distanceHandler);
+        }
+
+        if (copyAttributesHandler != null) {
+            pipeline.addLast("copyAttributes", copyAttributesHandler);
         }
 
         if (Context.getDataManager() != null) {

--- a/src/org/traccar/CopyAttributesHandler.java
+++ b/src/org/traccar/CopyAttributesHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 Anton Tananaev (anton.tananaev@gmail.com)
+ * Copyright 2016 Andrey Kunitsyn (abyss@fox5.ru)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar;
+
+import org.traccar.model.Position;
+
+public class CopyAttributesHandler extends BaseDataHandler {
+
+    private Position getLastPosition(long deviceId) {
+        if (Context.getIdentityManager() != null) {
+            return Context.getIdentityManager().getLastPosition(deviceId);
+        }
+        return null;
+    }
+
+    @Override
+    protected Position handlePosition(Position position) {
+        String attributesString = Context.getDeviceManager().lookupConfigString(position.getDeviceId(),
+                "processing.copyAttributes", null);
+        Position last = getLastPosition(position.getDeviceId());
+        if (attributesString != null && last != null) {
+            for (String attribute : attributesString.split(" ")) {
+                if (last.getAttributes().containsKey(attribute) && !position.getAttributes().containsKey(attribute)) {
+                    position.getAttributes().put(attribute, last.getAttributes().get(attribute));
+                }
+            }
+        }
+        return position;
+    }
+
+}


### PR DESCRIPTION
Base simple version without expiration
User can enable it by setting `<entry key='processing.copyAttributes.enable'>true</entry>`
and set list of attributes separated by space in `processing.copyAttributes` (device->group->config)

fix #2325