### PR TITLE
Implement reset total distance API

### DIFF
--- a/src/org/traccar/api/resource/DeviceResource.java
+++ b/src/org/traccar/api/resource/DeviceResource.java
@@ -18,6 +18,7 @@ package org.traccar.api.resource;
 import org.traccar.Context;
 import org.traccar.api.BaseResource;
 import org.traccar.model.Device;
+import org.traccar.model.DeviceTotalDistance;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -89,6 +90,14 @@ public class DeviceResource extends BaseResource {
             Context.getGeofenceManager().refresh();
         }
         Context.getAliasesManager().removeDevice(id);
+        return Response.noContent().build();
+    }
+
+    @Path("{id}/totaldistance")
+    @PUT
+    public Response updateTotalDistance(@PathParam("id") long id, DeviceTotalDistance entity) throws SQLException {
+        Context.getPermissionsManager().checkAdmin(getUserId());
+        Context.getDeviceManager().resetTotalDistance(entity);
         return Response.noContent().build();
     }
 

--- a/src/org/traccar/api/resource/DeviceResource.java
+++ b/src/org/traccar/api/resource/DeviceResource.java
@@ -93,7 +93,7 @@ public class DeviceResource extends BaseResource {
         return Response.noContent().build();
     }
 
-    @Path("{id}/totaldistance")
+    @Path("{id}/distance")
     @PUT
     public Response updateTotalDistance(@PathParam("id") long id, DeviceTotalDistance entity) throws SQLException {
         Context.getPermissionsManager().checkAdmin(getUserId());

--- a/src/org/traccar/database/DeviceManager.java
+++ b/src/org/traccar/database/DeviceManager.java
@@ -30,6 +30,7 @@ import org.traccar.Config;
 import org.traccar.Context;
 import org.traccar.helper.Log;
 import org.traccar.model.Device;
+import org.traccar.model.DeviceTotalDistance;
 import org.traccar.model.Group;
 import org.traccar.model.Position;
 import org.traccar.model.Server;
@@ -427,5 +428,16 @@ public class DeviceManager implements IdentityManager {
             }
         }
         return result;
+    }
+
+    public void resetTotalDistance(DeviceTotalDistance deviceTotalDistance)  throws SQLException {
+        Position last = positions.get(deviceTotalDistance.getDeviceId());
+        if (last != null) {
+            last.getAttributes().put(Position.KEY_TOTAL_DISTANCE, deviceTotalDistance.getTotalDistance());
+            dataManager.addPosition(last);
+            updateLatestPosition(last);
+        } else {
+            throw new IllegalArgumentException();
+        }
     }
 }

--- a/src/org/traccar/database/DeviceManager.java
+++ b/src/org/traccar/database/DeviceManager.java
@@ -430,7 +430,7 @@ public class DeviceManager implements IdentityManager {
         return result;
     }
 
-    public void resetTotalDistance(DeviceTotalDistance deviceTotalDistance)  throws SQLException {
+    public void resetTotalDistance(DeviceTotalDistance deviceTotalDistance) throws SQLException {
         Position last = positions.get(deviceTotalDistance.getDeviceId());
         if (last != null) {
             last.getAttributes().put(Position.KEY_TOTAL_DISTANCE, deviceTotalDistance.getTotalDistance());

--- a/src/org/traccar/model/DeviceTotalDistance.java
+++ b/src/org/traccar/model/DeviceTotalDistance.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 Anton Tananaev (anton.tananaev@gmail.com)
+ * Copyright 2016 Andrey Kunitsyn (abyss@fox5.ru)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.model;
+
+public class DeviceTotalDistance {
+
+    private long deviceId;
+
+    public long getDeviceId() {
+        return deviceId;
+    }
+
+    public void setDeviceId(long deviceId) {
+        this.deviceId = deviceId;
+    }
+
+    private double totalDistance;
+
+    public double getTotalDistance() {
+        return totalDistance;
+    }
+
+    public void setTotalDistance(double totalDistance) {
+        this.totalDistance = totalDistance;
+    }
+
+}


### PR DESCRIPTION
I have some doubts about API path, leaved `{id}` for consistency.
Only admins are allowed to reset `totalDistance`.
Just re-add  last position with corrected attribute. If there is no last position do nothing (and throw exception to notify user)

Will be thankful for advice where to place it to web-interface. I'm thinking of placing `textfield` and `button` in device edit dialog. Or make new dialog and call it from settings menu?