### PR TITLE
Add exclusion for valid positions to CoordinatesHandler

### DIFF
--- a/src/org/traccar/CoordinatesHandler.java
+++ b/src/org/traccar/CoordinatesHandler.java
@@ -42,7 +42,7 @@ public class CoordinatesHandler extends BaseDataHandler {
         if (last != null) {
             double distance = DistanceCalculator.distance(
                     position.getLatitude(), position.getLongitude(), last.getLatitude(), last.getLongitude());
-            if (distance < coordinatesMinError || distance > coordinatesMaxError) {
+            if (distance < coordinatesMinError || distance > coordinatesMaxError && !position.getValid()) {
                 position.setLatitude(last.getLatitude());
                 position.setLongitude(last.getLongitude());
             }

--- a/src/org/traccar/CoordinatesHandler.java
+++ b/src/org/traccar/CoordinatesHandler.java
@@ -39,11 +39,12 @@ public class CoordinatesHandler extends BaseDataHandler {
     @Override
     protected Position handlePosition(Position position) {
         Position last = getLastPosition(position.getDeviceId());
-        if (last != null && last.getLatitude() != 0 && last.getLongitude() != 0) {
+        if (last != null && last.getValid() && last.getLatitude() != 0 && last.getLongitude() != 0) {
             double distance = DistanceCalculator.distance(
                     position.getLatitude(), position.getLongitude(), last.getLatitude(), last.getLongitude());
-            if (coordinatesMinError != 0 && distance < coordinatesMinError
-                    || coordinatesMaxError != 0 && distance > coordinatesMaxError && !position.getValid()) {
+            boolean satisfiesMin = coordinatesMinError == 0 || distance > coordinatesMinError;
+            boolean satisfiesMax = coordinatesMaxError == 0 || distance < coordinatesMaxError || position.getValid();
+            if (!(satisfiesMin && satisfiesMax)) {
                 position.setLatitude(last.getLatitude());
                 position.setLongitude(last.getLongitude());
             }

--- a/src/org/traccar/CoordinatesHandler.java
+++ b/src/org/traccar/CoordinatesHandler.java
@@ -25,8 +25,8 @@ public class CoordinatesHandler extends BaseDataHandler {
 
     public CoordinatesHandler() {
         Config config = Context.getConfig();
-        coordinatesMinError = config.getInteger("coordinates.minError", 50);
-        coordinatesMaxError = config.getInteger("coordinates.maxError", 1000000);
+        coordinatesMinError = config.getInteger("coordinates.minError");
+        coordinatesMaxError = config.getInteger("coordinates.maxError");
     }
 
     private Position getLastPosition(long deviceId) {
@@ -39,10 +39,11 @@ public class CoordinatesHandler extends BaseDataHandler {
     @Override
     protected Position handlePosition(Position position) {
         Position last = getLastPosition(position.getDeviceId());
-        if (last != null) {
+        if (last != null && last.getLatitude() != 0 && last.getLongitude() != 0) {
             double distance = DistanceCalculator.distance(
                     position.getLatitude(), position.getLongitude(), last.getLatitude(), last.getLongitude());
-            if (distance < coordinatesMinError || distance > coordinatesMaxError && !position.getValid()) {
+            if (coordinatesMinError != 0 && distance < coordinatesMinError
+                    || coordinatesMaxError != 0 && distance > coordinatesMaxError && !position.getValid()) {
                 position.setLatitude(last.getLatitude());
                 position.setLongitude(last.getLongitude());
             }

--- a/src/org/traccar/CoordinatesHandler.java
+++ b/src/org/traccar/CoordinatesHandler.java
@@ -44,7 +44,7 @@ public class CoordinatesHandler extends BaseDataHandler {
                     position.getLatitude(), position.getLongitude(), last.getLatitude(), last.getLongitude());
             boolean satisfiesMin = coordinatesMinError == 0 || distance > coordinatesMinError;
             boolean satisfiesMax = coordinatesMaxError == 0 || distance < coordinatesMaxError || position.getValid();
-            if (!(satisfiesMin && satisfiesMax)) {
+            if (!satisfiesMin || !satisfiesMax) {
                 position.setLatitude(last.getLatitude());
                 position.setLongitude(last.getLongitude());
             }


### PR DESCRIPTION
It should prevent problem you mention in #2480 
Valid position with "too big shift" should not be replaced with last coordinates.
