### PR TITLE
Remove explicit JSON conversion from reports

### DIFF
--- a/src/org/traccar/api/resource/PositionResource.java
+++ b/src/org/traccar/api/resource/PositionResource.java
@@ -17,10 +17,10 @@ package org.traccar.api.resource;
 
 import org.traccar.Context;
 import org.traccar.api.BaseResource;
+import org.traccar.helper.DateUtil;
 import org.traccar.model.Position;
 import org.traccar.web.CsvBuilder;
 import org.traccar.web.GpxBuilder;
-import org.traccar.web.JsonConverter;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -53,7 +53,7 @@ public class PositionResource extends BaseResource {
         } else {
             Context.getPermissionsManager().checkDevice(getUserId(), deviceId);
             return Context.getDataManager().getPositions(
-                    deviceId, JsonConverter.parseDate(from), JsonConverter.parseDate(to));
+                    deviceId, DateUtil.parseDate(from), DateUtil.parseDate(to));
         }
     }
 
@@ -66,7 +66,7 @@ public class PositionResource extends BaseResource {
         CsvBuilder csv = new CsvBuilder();
         csv.addHeaderLine(new Position());
         csv.addArray(Context.getDataManager().getPositions(
-                deviceId, JsonConverter.parseDate(from), JsonConverter.parseDate(to)));
+                deviceId, DateUtil.parseDate(from), DateUtil.parseDate(to)));
         return Response.ok(csv.build()).header(HttpHeaders.CONTENT_DISPOSITION, CONTENT_DISPOSITION_VALUE_CSV).build();
     }
 
@@ -78,7 +78,7 @@ public class PositionResource extends BaseResource {
         Context.getPermissionsManager().checkDevice(getUserId(), deviceId);
         GpxBuilder gpx = new GpxBuilder(Context.getIdentityManager().getDeviceById(deviceId).getName());
         gpx.addPositions(Context.getDataManager().getPositions(
-                deviceId, JsonConverter.parseDate(from), JsonConverter.parseDate(to)));
+                deviceId, DateUtil.parseDate(from), DateUtil.parseDate(to)));
         return Response.ok(gpx.build()).header(HttpHeaders.CONTENT_DISPOSITION, CONTENT_DISPOSITION_VALUE_GPX).build();
     }
 

--- a/src/org/traccar/api/resource/ReportResource.java
+++ b/src/org/traccar/api/resource/ReportResource.java
@@ -16,6 +16,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.traccar.api.BaseResource;
+import org.traccar.helper.DateUtil;
 import org.traccar.model.Event;
 import org.traccar.model.Position;
 import org.traccar.reports.Events;
@@ -24,7 +25,6 @@ import org.traccar.reports.Trips;
 import org.traccar.reports.model.SummaryReport;
 import org.traccar.reports.model.TripReport;
 import org.traccar.reports.Route;
-import org.traccar.web.JsonConverter;
 
 @Path("reports")
 @Consumes(MediaType.APPLICATION_JSON)
@@ -40,7 +40,7 @@ public class ReportResource extends BaseResource {
             @QueryParam("deviceId") final List<Long> deviceIds, @QueryParam("groupId") final List<Long> groupIds,
             @QueryParam("from") String from, @QueryParam("to") String to) throws SQLException {
         return Route.getObjects(getUserId(), deviceIds, groupIds,
-                JsonConverter.parseDate(from), JsonConverter.parseDate(to));
+                DateUtil.parseDate(from), DateUtil.parseDate(to));
     }
 
     @Path("route")
@@ -51,7 +51,7 @@ public class ReportResource extends BaseResource {
             @QueryParam("from") String from, @QueryParam("to") String to) throws SQLException, IOException {
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
         Route.getExcel(stream, getUserId(), deviceIds, groupIds,
-                    JsonConverter.parseDate(from), JsonConverter.parseDate(to));
+                    DateUtil.parseDate(from), DateUtil.parseDate(to));
 
         return Response.ok(stream.toByteArray())
                 .header(HttpHeaders.CONTENT_DISPOSITION, CONTENT_DISPOSITION_VALUE_XLSX).build();
@@ -65,7 +65,7 @@ public class ReportResource extends BaseResource {
             @QueryParam("type") final List<String> types,
             @QueryParam("from") String from, @QueryParam("to") String to) throws SQLException {
         return Events.getObjects(getUserId(), deviceIds, groupIds, types,
-                JsonConverter.parseDate(from), JsonConverter.parseDate(to));
+                DateUtil.parseDate(from), DateUtil.parseDate(to));
     }
 
     @Path("events")
@@ -77,7 +77,7 @@ public class ReportResource extends BaseResource {
             @QueryParam("from") String from, @QueryParam("to") String to) throws SQLException, IOException {
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
         Events.getExcel(stream, getUserId(), deviceIds, groupIds, types,
-                    JsonConverter.parseDate(from), JsonConverter.parseDate(to));
+                    DateUtil.parseDate(from), DateUtil.parseDate(to));
 
         return Response.ok(stream.toByteArray())
                 .header(HttpHeaders.CONTENT_DISPOSITION, CONTENT_DISPOSITION_VALUE_XLSX).build();
@@ -90,7 +90,7 @@ public class ReportResource extends BaseResource {
             @QueryParam("deviceId") final List<Long> deviceIds, @QueryParam("groupId") final List<Long> groupIds,
             @QueryParam("from") String from, @QueryParam("to") String to) throws SQLException {
         return Summary.getObjects(getUserId(), deviceIds, groupIds,
-                JsonConverter.parseDate(from), JsonConverter.parseDate(to));
+                DateUtil.parseDate(from), DateUtil.parseDate(to));
     }
 
     @Path("summary")
@@ -101,7 +101,7 @@ public class ReportResource extends BaseResource {
             @QueryParam("from") String from, @QueryParam("to") String to) throws SQLException, IOException {
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
         Summary.getExcel(stream, getUserId(), deviceIds, groupIds,
-                    JsonConverter.parseDate(from), JsonConverter.parseDate(to));
+                    DateUtil.parseDate(from), DateUtil.parseDate(to));
 
         return Response.ok(stream.toByteArray())
                 .header(HttpHeaders.CONTENT_DISPOSITION, CONTENT_DISPOSITION_VALUE_XLSX).build();
@@ -114,7 +114,7 @@ public class ReportResource extends BaseResource {
             @QueryParam("deviceId") final List<Long> deviceIds, @QueryParam("groupId") final List<Long> groupIds,
             @QueryParam("from") String from, @QueryParam("to") String to) throws SQLException {
         return Trips.getObjects(getUserId(), deviceIds, groupIds,
-                JsonConverter.parseDate(from), JsonConverter.parseDate(to));
+                DateUtil.parseDate(from), DateUtil.parseDate(to));
     }
 
     @Path("trips")
@@ -125,7 +125,7 @@ public class ReportResource extends BaseResource {
             @QueryParam("from") String from, @QueryParam("to") String to) throws SQLException, IOException {
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
         Trips.getExcel(stream, getUserId(), deviceIds, groupIds,
-                    JsonConverter.parseDate(from), JsonConverter.parseDate(to));
+                    DateUtil.parseDate(from), DateUtil.parseDate(to));
 
         return Response.ok(stream.toByteArray())
                 .header(HttpHeaders.CONTENT_DISPOSITION, CONTENT_DISPOSITION_VALUE_XLSX).build();

--- a/src/org/traccar/api/resource/ReportResource.java
+++ b/src/org/traccar/api/resource/ReportResource.java
@@ -3,6 +3,7 @@ package org.traccar.api.resource;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.Collection;
 import java.util.List;
 
 import javax.ws.rs.Consumes;
@@ -15,9 +16,13 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.traccar.api.BaseResource;
+import org.traccar.model.Event;
+import org.traccar.model.Position;
 import org.traccar.reports.Events;
 import org.traccar.reports.Summary;
 import org.traccar.reports.Trips;
+import org.traccar.reports.model.SummaryReport;
+import org.traccar.reports.model.TripReport;
 import org.traccar.reports.Route;
 import org.traccar.web.JsonConverter;
 
@@ -31,11 +36,11 @@ public class ReportResource extends BaseResource {
     @Path("route")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getRouteJson(
+    public Collection<Position> getRoute(
             @QueryParam("deviceId") final List<Long> deviceIds, @QueryParam("groupId") final List<Long> groupIds,
             @QueryParam("from") String from, @QueryParam("to") String to) throws SQLException {
-        return Response.ok(Route.getJson(getUserId(), deviceIds, groupIds,
-                JsonConverter.parseDate(from), JsonConverter.parseDate(to))).build();
+        return Route.getObjects(getUserId(), deviceIds, groupIds,
+                JsonConverter.parseDate(from), JsonConverter.parseDate(to));
     }
 
     @Path("route")
@@ -55,12 +60,12 @@ public class ReportResource extends BaseResource {
     @Path("events")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getEventsJson(
+    public Collection<Event> getEvents(
             @QueryParam("deviceId") final List<Long> deviceIds, @QueryParam("groupId") final List<Long> groupIds,
             @QueryParam("type") final List<String> types,
             @QueryParam("from") String from, @QueryParam("to") String to) throws SQLException {
-        return Response.ok(Events.getJson(getUserId(), deviceIds, groupIds, types,
-                JsonConverter.parseDate(from), JsonConverter.parseDate(to))).build();
+        return Events.getObjects(getUserId(), deviceIds, groupIds, types,
+                JsonConverter.parseDate(from), JsonConverter.parseDate(to));
     }
 
     @Path("events")
@@ -81,11 +86,11 @@ public class ReportResource extends BaseResource {
     @Path("summary")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getSummaryJson(
+    public Collection<SummaryReport> getSummary(
             @QueryParam("deviceId") final List<Long> deviceIds, @QueryParam("groupId") final List<Long> groupIds,
             @QueryParam("from") String from, @QueryParam("to") String to) throws SQLException {
-        return Response.ok(Summary.getJson(getUserId(), deviceIds, groupIds,
-                JsonConverter.parseDate(from), JsonConverter.parseDate(to))).build();
+        return Summary.getObjects(getUserId(), deviceIds, groupIds,
+                JsonConverter.parseDate(from), JsonConverter.parseDate(to));
     }
 
     @Path("summary")
@@ -105,11 +110,11 @@ public class ReportResource extends BaseResource {
     @Path("trips")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getTripsJson(
+    public Collection<TripReport> getTrips(
             @QueryParam("deviceId") final List<Long> deviceIds, @QueryParam("groupId") final List<Long> groupIds,
             @QueryParam("from") String from, @QueryParam("to") String to) throws SQLException {
-        return Response.ok(Trips.getJson(getUserId(), deviceIds, groupIds,
-                JsonConverter.parseDate(from), JsonConverter.parseDate(to))).build();
+        return Trips.getObjects(getUserId(), deviceIds, groupIds,
+                JsonConverter.parseDate(from), JsonConverter.parseDate(to));
     }
 
     @Path("trips")

--- a/src/org/traccar/api/resource/StatisticsResource.java
+++ b/src/org/traccar/api/resource/StatisticsResource.java
@@ -17,8 +17,8 @@ package org.traccar.api.resource;
 
 import org.traccar.Context;
 import org.traccar.api.BaseResource;
+import org.traccar.helper.DateUtil;
 import org.traccar.model.Statistics;
-import org.traccar.web.JsonConverter;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -38,7 +38,7 @@ public class StatisticsResource extends BaseResource {
     public Collection<Statistics> get(
             @QueryParam("from") String from, @QueryParam("to") String to) throws SQLException {
         Context.getPermissionsManager().checkAdmin(getUserId());
-        return Context.getDataManager().getStatistics(JsonConverter.parseDate(from), JsonConverter.parseDate(to));
+        return Context.getDataManager().getStatistics(DateUtil.parseDate(from), DateUtil.parseDate(to));
     }
 
 }

--- a/src/org/traccar/helper/DateUtil.java
+++ b/src/org/traccar/helper/DateUtil.java
@@ -18,7 +18,12 @@ package org.traccar.helper;
 import java.util.Calendar;
 import java.util.Date;
 
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+
 public final class DateUtil {
+
+    private static final DateTimeFormatter DATE_FORMAT = ISODateTimeFormat.dateTime();
 
     private DateUtil() {
     }
@@ -53,6 +58,10 @@ public final class DateUtil {
         calendar.setTime(guess);
         calendar.add(field, amount);
         return calendar.getTime();
+    }
+
+    public static Date parseDate(String value) {
+        return DATE_FORMAT.parseDateTime(value).toDate();
     }
 
 }

--- a/src/org/traccar/reports/Events.java
+++ b/src/org/traccar/reports/Events.java
@@ -28,9 +28,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 
-import javax.json.Json;
-import javax.json.JsonArrayBuilder;
-
 import org.jxls.area.Area;
 import org.jxls.builder.xls.XlsCommentAreaBuilder;
 import org.jxls.common.CellRef;
@@ -44,16 +41,15 @@ import org.traccar.model.Event;
 import org.traccar.model.Geofence;
 import org.traccar.model.Group;
 import org.traccar.reports.model.DeviceReport;
-import org.traccar.web.JsonConverter;
 
 public final class Events {
 
     private Events() {
     }
 
-    public static String getJson(long userId, Collection<Long> deviceIds, Collection<Long> groupIds,
+    public static Collection<Event> getObjects(long userId, Collection<Long> deviceIds, Collection<Long> groupIds,
             Collection<String> types, Date from, Date to) throws SQLException {
-        JsonArrayBuilder json = Json.createArrayBuilder();
+        ArrayList<Event> result = new ArrayList<>();
         for (long deviceId: ReportUtils.getDeviceList(deviceIds, groupIds)) {
             Context.getPermissionsManager().checkDevice(userId, deviceId);
             Collection<Event> events = Context.getDataManager().getEvents(deviceId, from, to);
@@ -62,12 +58,12 @@ public final class Events {
                 if (all || types.contains(event.getType())) {
                     long geofenceId = event.getGeofenceId();
                     if (geofenceId == 0 || Context.getGeofenceManager().checkGeofence(userId, geofenceId)) {
-                       json.add(JsonConverter.objectToJson(event));
+                       result.add(event);
                     }
                 }
             }
         }
-        return json.build().toString();
+        return result;
     }
 
     public static void getExcel(OutputStream outputStream,

--- a/src/org/traccar/reports/Route.java
+++ b/src/org/traccar/reports/Route.java
@@ -26,9 +26,6 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
-import javax.json.Json;
-import javax.json.JsonArrayBuilder;
-
 import org.jxls.area.Area;
 import org.jxls.builder.xls.XlsCommentAreaBuilder;
 import org.jxls.common.CellRef;
@@ -41,23 +38,20 @@ import org.traccar.model.Device;
 import org.traccar.model.Group;
 import org.traccar.model.Position;
 import org.traccar.reports.model.DeviceReport;
-import org.traccar.web.JsonConverter;
 
 public final class Route {
 
     private Route() {
     }
 
-    public static String getJson(long userId, Collection<Long> deviceIds, Collection<Long> groupIds,
+    public static Collection<Position> getObjects(long userId, Collection<Long> deviceIds, Collection<Long> groupIds,
             Date from, Date to) throws SQLException {
-        JsonArrayBuilder json = Json.createArrayBuilder();
+        ArrayList<Position> result = new ArrayList<>();
         for (long deviceId: ReportUtils.getDeviceList(deviceIds, groupIds)) {
             Context.getPermissionsManager().checkDevice(userId, deviceId);
-            for (Position position : Context.getDataManager().getPositions(deviceId, from, to)) {
-                json.add(JsonConverter.objectToJson(position));
-            }
+            result.addAll(Context.getDataManager().getPositions(deviceId, from, to));
         }
-        return json.build().toString();
+        return result;
     }
 
     public static void getExcel(OutputStream outputStream,

--- a/src/org/traccar/reports/Summary.java
+++ b/src/org/traccar/reports/Summary.java
@@ -25,15 +25,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 
-import javax.json.Json;
-import javax.json.JsonArrayBuilder;
-
 import org.jxls.transform.poi.PoiTransformer;
 import org.jxls.util.JxlsHelper;
 import org.traccar.Context;
 import org.traccar.model.Position;
 import org.traccar.reports.model.SummaryReport;
-import org.traccar.web.JsonConverter;
 
 public final class Summary {
 
@@ -74,24 +70,20 @@ public final class Summary {
         return result;
     }
 
-    public static String getJson(long userId, Collection<Long> deviceIds, Collection<Long> groupIds,
-            Date from, Date to) throws SQLException {
-        JsonArrayBuilder json = Json.createArrayBuilder();
+    public static Collection<SummaryReport> getObjects(long userId, Collection<Long> deviceIds,
+            Collection<Long> groupIds, Date from, Date to) throws SQLException {
+        ArrayList<SummaryReport> result = new ArrayList<>();
         for (long deviceId: ReportUtils.getDeviceList(deviceIds, groupIds)) {
             Context.getPermissionsManager().checkDevice(userId, deviceId);
-            json.add(JsonConverter.objectToJson(calculateSummaryResult(deviceId, from, to)));
+            result.add(calculateSummaryResult(deviceId, from, to));
         }
-        return json.build().toString();
+        return result;
     }
 
     public static void getExcel(OutputStream outputStream,
             long userId, Collection<Long> deviceIds, Collection<Long> groupIds,
             Date from, Date to) throws SQLException, IOException {
-        ArrayList<SummaryReport> summaries = new ArrayList<>();
-        for (long deviceId: ReportUtils.getDeviceList(deviceIds, groupIds)) {
-            Context.getPermissionsManager().checkDevice(userId, deviceId);
-            summaries.add(calculateSummaryResult(deviceId, from, to));
-        }
+        Collection<SummaryReport> summaries = getObjects(userId, deviceIds, groupIds, from, to);
         String templatePath = Context.getConfig().getString("report.templatesPath",
                 "templates/export/");
         try (InputStream inputStream = new FileInputStream(templatePath + "/summary.xlsx")) {

--- a/src/org/traccar/reports/Trips.java
+++ b/src/org/traccar/reports/Trips.java
@@ -26,9 +26,6 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
-import javax.json.Json;
-import javax.json.JsonArrayBuilder;
-
 import org.jxls.area.Area;
 import org.jxls.builder.xls.XlsCommentAreaBuilder;
 import org.jxls.common.CellRef;
@@ -42,7 +39,6 @@ import org.traccar.model.Group;
 import org.traccar.model.Position;
 import org.traccar.reports.model.DeviceReport;
 import org.traccar.reports.model.TripReport;
-import org.traccar.web.JsonConverter;
 
 public final class Trips {
 
@@ -167,16 +163,14 @@ public final class Trips {
         return result;
     }
 
-    public static String getJson(long userId, Collection<Long> deviceIds, Collection<Long> groupIds,
+    public static Collection<TripReport> getObjects(long userId, Collection<Long> deviceIds, Collection<Long> groupIds,
             Date from, Date to) throws SQLException {
-        JsonArrayBuilder json = Json.createArrayBuilder();
+        ArrayList<TripReport> result = new ArrayList<>();
         for (long deviceId: ReportUtils.getDeviceList(deviceIds, groupIds)) {
             Context.getPermissionsManager().checkDevice(userId, deviceId);
-            for (TripReport tripReport : detectTrips(deviceId, from, to)) {
-                json.add(JsonConverter.objectToJson(tripReport));
-            }
+            result.addAll(detectTrips(deviceId, from, to));
         }
-        return json.build().toString();
+        return result;
     }
 
     public static void getExcel(OutputStream outputStream,


### PR DESCRIPTION
There are two commits:

- Removed explicit conversion to JSON from reports
- Move `parseDate` to `DateUtil`

`JsonConverter` leaved as is.