### PR TITLE
Granit: Analog input values tuning

### DIFF
--- a/src/org/traccar/protocol/GranitProtocolDecoder.java
+++ b/src/org/traccar/protocol/GranitProtocolDecoder.java
@@ -19,6 +19,7 @@ import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBuffers;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
+import org.traccar.Context;
 import org.traccar.DeviceSession;
 import org.traccar.helper.BitUtil;
 import org.traccar.helper.Checksum;
@@ -36,8 +37,17 @@ public class GranitProtocolDecoder extends BaseProtocolDecoder {
 
     private static final int HEADER_LENGTH = 6;
 
+    private static double adc1Ratio;
+    private static double adc2Ratio;
+    private static double adc3Ratio;
+    private static double adc4Ratio;
+
     public GranitProtocolDecoder(GranitProtocol protocol) {
         super(protocol);
+        adc1Ratio = Context.getConfig().getDouble("granit.adc1Ratio", 1);
+        adc2Ratio = Context.getConfig().getDouble("granit.adc2Ratio", 1);
+        adc3Ratio = Context.getConfig().getDouble("granit.adc3Ratio", 1);
+        adc4Ratio = Context.getConfig().getDouble("granit.adc4Ratio", 1);
     }
 
     public static void appendChecksum(ChannelBuffer buffer, int length) {
@@ -118,10 +128,10 @@ public class GranitProtocolDecoder extends BaseProtocolDecoder {
         analogIn3 = analogInHi << 4 & 0x300 | analogIn3;
         analogIn4 = analogInHi << 2 & 0x300 | analogIn4;
 
-        position.set(Position.PREFIX_ADC + 1, analogIn1);
-        position.set(Position.PREFIX_ADC + 2, analogIn2);
-        position.set(Position.PREFIX_ADC + 3, analogIn3);
-        position.set(Position.PREFIX_ADC + 4, analogIn4);
+        position.set(Position.PREFIX_ADC + 1, analogIn1 * adc1Ratio);
+        position.set(Position.PREFIX_ADC + 2, analogIn2 * adc2Ratio);
+        position.set(Position.PREFIX_ADC + 3, analogIn3 * adc3Ratio);
+        position.set(Position.PREFIX_ADC + 4, analogIn4 * adc4Ratio);
 
         position.setAltitude(buf.readUnsignedByte() * 10);
 

--- a/src/org/traccar/protocol/GranitProtocolDecoder.java
+++ b/src/org/traccar/protocol/GranitProtocolDecoder.java
@@ -37,10 +37,10 @@ public class GranitProtocolDecoder extends BaseProtocolDecoder {
 
     private static final int HEADER_LENGTH = 6;
 
-    private static double adc1Ratio;
-    private static double adc2Ratio;
-    private static double adc3Ratio;
-    private static double adc4Ratio;
+    private double adc1Ratio;
+    private double adc2Ratio;
+    private double adc3Ratio;
+    private double adc4Ratio;
 
     public GranitProtocolDecoder(GranitProtocol protocol) {
         super(protocol);
@@ -78,7 +78,7 @@ public class GranitProtocolDecoder extends BaseProtocolDecoder {
         channel.write(response);
     }
 
-    private static void decodeStructure(ChannelBuffer buf, Position position) {
+    private void decodeStructure(ChannelBuffer buf, Position position) {
         short flags = buf.readUnsignedByte();
         position.setValid(BitUtil.check(flags, 7));
         if (BitUtil.check(flags, 1)) {


### PR DESCRIPTION
From devices documentation:

> Ain0  - аналоговый вход прибора (оранжевый провод), по умолчанию запрограммированный на измерение внутреннего напряжения прибора. При измерении внутреннего напряжения прибора значения входного напряжения колеблются в диапазоне от 0 до 40В. При перепрограммировании, на измерения аналогового входа, значения воспринимаются в диапазоне от 0 до 5В.
Ain1 - аналоговый вход прибора (бело-оранжевый провод), принимающий измерения в диапазоне от 0 до 5 В.
Ain2 - аналоговый вход прибора (коричневый провод), принимающий измерения в диапазоне от 0 до 30 В.
Ain3 - аналоговый вход прибора (бело-коричневый провод), принимающий измерения в диапазоне от 0 до 30 В.


Here is small improvement to allow users convert this values to volts.

If the configuration is default `adc1Ratio` = 0.0391 will show internal battery voltage (in volts).

Also if fuel sensor is connected, user can set such ratio to show fuel volume even in percents. 