### PR TITLE
Add lib for Microsoft JDBC Drivers with maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
-            <version>6.1.0.jre8</version> <!-- Newer versions require Java 8 -->
+            <version>6.1.0.jre7</version> <!-- edit to 6.1.0.jre8 if you used jre8 -->
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,11 @@
             <artifactId>jxls-poi</artifactId>
             <version>1.0.11</version>
         </dependency>
+        <dependency>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
+            <version>6.1.0.jre8</version> <!-- Newer versions require Java 8 -->
+        </dependency>
 
     </dependencies>
 


### PR DESCRIPTION
[INFO] Copying mssql-jdbc-6.1.0.jre8.jar to /root/traccar/target/lib/mssql-jdbc-6.1.0.jre8.jar

sample config for mssql

```
<entry key='database.driverFile'>lib/mssql-jdbc-6.1.0.jre8.jar</entry>
<entry key='database.driver'>com.microsoft.sqlserver.jdbc.SQLServerDriver</entry>
<entry key='database.url'>jdbc:sqlserver://[serverName][\instanceName];user=[userName];password=[password];databaseName=[database];</entry>
<entry key='database.user'>[userName]</entry>
<entry key='database.password'>[password]</entry>
```