### PR TITLE
Implement users tokens

### DIFF
--- a/schema/changelog-3.8.xml
+++ b/schema/changelog-3.8.xml
@@ -116,6 +116,11 @@
     <addColumn tableName="users">
       <column name="devicelimit" type="INT" defaultValueNumeric="0" />
     </addColumn>
+    <addColumn tableName="users">
+      <column name="token" type="VARCHAR(128)" />
+    </addColumn>
+    
+    <addUniqueConstraint tableName="users" columnNames="token" constraintName="uk_user_token" />
 
   </changeSet>
 </databaseChangeLog>

--- a/setup/default.xml
+++ b/setup/default.xml
@@ -62,8 +62,8 @@
     </entry>
 
     <entry key='database.insertUser'>
-        INSERT INTO users (name, email, hashedPassword, salt, admin, map, distanceUnit, speedUnit, latitude, longitude, zoom, twelveHourFormat, coordinateFormat, disabled, expirationTime, deviceLimit, attributes)
-        VALUES (:name, :email, :hashedPassword, :salt, :admin, :map, :distanceUnit, :speedUnit, :latitude, :longitude, :zoom, :twelveHourFormat, :coordinateFormat, :disabled, :expirationTime, :deviceLimit, :attributes)
+        INSERT INTO users (name, email, hashedPassword, salt, admin, map, distanceUnit, speedUnit, latitude, longitude, zoom, twelveHourFormat, coordinateFormat, disabled, expirationTime, deviceLimit, token, attributes)
+        VALUES (:name, :email, :hashedPassword, :salt, :admin, :map, :distanceUnit, :speedUnit, :latitude, :longitude, :zoom, :twelveHourFormat, :coordinateFormat, :disabled, :expirationTime, :deviceLimit, :token, :attributes)
     </entry>
 
     <entry key='database.updateUser'>
@@ -82,6 +82,7 @@
         disabled = :disabled,
         expirationTime = :expirationTime,
         deviceLimit = :deviceLimit,
+        token = :token,
         attributes = :attributes
         WHERE id = :id
     </entry>

--- a/src/org/traccar/api/resource/SessionResource.java
+++ b/src/org/traccar/api/resource/SessionResource.java
@@ -29,6 +29,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -48,7 +49,7 @@ public class SessionResource extends BaseResource {
 
     @PermitAll
     @GET
-    public User get() throws SQLException {
+    public User get(@QueryParam("token") String token) throws SQLException {
         Long userId = (Long) request.getSession().getAttribute(USER_ID_KEY);
         if (userId == null) {
             Cookie[] cookies = request.getCookies();
@@ -69,7 +70,7 @@ public class SessionResource extends BaseResource {
                     userId = user.getId();
                     request.getSession().setAttribute(USER_ID_KEY, userId);
                 }
-            } else if (request.getParameter("token") != null) {
+            } else if (token != null) {
                 User user = Context.getPermissionsManager().getUserByToken(request.getParameter("token"));
                 if (user != null) {
                     userId = user.getId();

--- a/src/org/traccar/api/resource/SessionResource.java
+++ b/src/org/traccar/api/resource/SessionResource.java
@@ -69,6 +69,12 @@ public class SessionResource extends BaseResource {
                     userId = user.getId();
                     request.getSession().setAttribute(USER_ID_KEY, userId);
                 }
+            } else if (request.getParameter("token") != null) {
+                User user = Context.getPermissionsManager().getUserByToken(request.getParameter("token"));
+                if (user != null) {
+                    userId = user.getId();
+                    request.getSession().setAttribute(USER_ID_KEY, userId);
+                }
             }
         }
 

--- a/src/org/traccar/api/resource/UserResource.java
+++ b/src/org/traccar/api/resource/UserResource.java
@@ -67,7 +67,8 @@ public class UserResource extends BaseResource {
                 || old.getReadonly() != entity.getReadonly()
                 || old.getDisabled() != entity.getDisabled()
                 || old.getDeviceLimit() != entity.getDeviceLimit()
-                || !old.getToken().equals(entity.getToken())) {
+                || old.getToken() == null && entity.getToken() != null
+                || old.getToken() != null && !old.getToken().equals(entity.getToken())) {
             Context.getPermissionsManager().checkAdmin(getUserId());
         } else {
             Context.getPermissionsManager().checkUser(getUserId(), entity.getId());

--- a/src/org/traccar/api/resource/UserResource.java
+++ b/src/org/traccar/api/resource/UserResource.java
@@ -66,7 +66,8 @@ public class UserResource extends BaseResource {
                 || old.getAdmin() != entity.getAdmin()
                 || old.getReadonly() != entity.getReadonly()
                 || old.getDisabled() != entity.getDisabled()
-                || old.getDeviceLimit() != entity.getDeviceLimit()) {
+                || old.getDeviceLimit() != entity.getDeviceLimit()
+                || !old.getToken().equals(entity.getToken())) {
             Context.getPermissionsManager().checkAdmin(getUserId());
         } else {
             Context.getPermissionsManager().checkUser(getUserId(), entity.getId());

--- a/src/org/traccar/model/User.java
+++ b/src/org/traccar/model/User.java
@@ -188,21 +188,13 @@ public class User extends Extensible {
 
     public void setToken(String token) {
         if (token != null && !token.isEmpty()) {
-            if (validateToken(token)) {
-                this.token = token;
-            } else {
-                throw new IllegalArgumentException("Bad token");
+            if (!token.matches("^[a-zA-Z0-9]{16,}$")) {
+                throw new IllegalArgumentException("Illegal token");
             }
+            this.token = token;
         } else {
             this.token = null;
         }
-    }
-
-    public static boolean validateToken(String token) {
-        if (token.length() < 16 || !token.matches("^[a-zA-Z0-9]+$")) {
-            return false;
-        }
-        return true;
     }
 
     public String getPassword() {

--- a/src/org/traccar/model/User.java
+++ b/src/org/traccar/model/User.java
@@ -192,8 +192,6 @@ public class User extends Extensible {
                 throw new IllegalArgumentException("Illegal token");
             }
             this.token = token;
-        } else {
-            this.token = null;
         }
     }
 

--- a/src/org/traccar/model/User.java
+++ b/src/org/traccar/model/User.java
@@ -180,6 +180,31 @@ public class User extends Extensible {
         this.deviceLimit = deviceLimit;
     }
 
+    private String token;
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        if (token != null && !token.isEmpty()) {
+            if (validateToken(token)) {
+                this.token = token;
+            } else {
+                throw new IllegalArgumentException("Bad token");
+            }
+        } else {
+            this.token = null;
+        }
+    }
+
+    public static boolean validateToken(String token) {
+        if (token.length() < 16 || !token.matches("^[a-zA-Z0-9]+$")) {
+            return false;
+        }
+        return true;
+    }
+
     public String getPassword() {
         return null;
     }


### PR DESCRIPTION
Here is nice addition to users disabling.
Main reason is to give link user to traccar site without username/password

User can have a token, that can be used to authorization via GET parameter instead of username/password:
`https://demo.traccar.org/api/session?token=s5XpfXKZ3zLi7X4A`

Only Admin can add/change token to user.

Also hardcoded minimal token length and symbols to use in token.

Security note: tokens should be used very carefully and mostly with read only users in combination with expiring. Only over HTTPS. Because `GET` parameters is absolutely unsecured and cached/logged everywhere.