### PR TITLE
Maintenance events

### DIFF
--- a/setup/default.xml
+++ b/setup/default.xml
@@ -24,6 +24,8 @@
     <entry key='event.geofenceHandler'>true</entry>
     <entry key='event.alertHandler'>true</entry>
     <entry key='event.ignitionHandler'>true</entry>
+    <entry key='event.statusHandler'>true</entry>
+    <entry key='event.maintenanceHandler'>true</entry>
 
     <!-- DATABASE CONFIG -->
 

--- a/src/org/traccar/BasePipelineFactory.java
+++ b/src/org/traccar/BasePipelineFactory.java
@@ -32,6 +32,7 @@ import org.jboss.netty.handler.timeout.IdleStateHandler;
 import org.traccar.events.CommandResultEventHandler;
 import org.traccar.events.GeofenceEventHandler;
 import org.traccar.events.IgnitionEventHandler;
+import org.traccar.events.MaintenanceEventHandler;
 import org.traccar.events.MotionEventHandler;
 import org.traccar.events.OverspeedEventHandler;
 import org.traccar.events.AlertEventHandler;
@@ -58,6 +59,7 @@ public abstract class BasePipelineFactory implements ChannelPipelineFactory {
     private GeofenceEventHandler geofenceEventHandler;
     private AlertEventHandler alertEventHandler;
     private IgnitionEventHandler ignitionEventHandler;
+    private MaintenanceEventHandler maintenanceEventHandler;
 
     private static final class OpenChannelHandler extends SimpleChannelHandler {
 
@@ -164,6 +166,9 @@ public abstract class BasePipelineFactory implements ChannelPipelineFactory {
         if (Context.getConfig().getBoolean("event.ignitionHandler")) {
             ignitionEventHandler = new IgnitionEventHandler();
         }
+        if (Context.getConfig().getBoolean("event.maintenanceHandler")) {
+            maintenanceEventHandler = new MaintenanceEventHandler();
+        }
     }
 
     protected abstract void addSpecificHandlers(ChannelPipeline pipeline);
@@ -240,6 +245,10 @@ public abstract class BasePipelineFactory implements ChannelPipelineFactory {
 
         if (ignitionEventHandler != null) {
             pipeline.addLast("IgnitionEventHandler", ignitionEventHandler);
+        }
+
+        if (maintenanceEventHandler != null) {
+            pipeline.addLast("MaintenanceEventHandler", maintenanceEventHandler);
         }
 
         pipeline.addLast("mainHandler", new MainEventHandler());

--- a/src/org/traccar/events/MaintenanceEventHandler.java
+++ b/src/org/traccar/events/MaintenanceEventHandler.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2016 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.events;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.traccar.BaseEventHandler;
+import org.traccar.Context;
+import org.traccar.model.Device;
+import org.traccar.model.Event;
+import org.traccar.model.Position;
+
+public class MaintenanceEventHandler extends BaseEventHandler {
+
+    public static final String ATTRIBUTE_MAINTENANCE_START = "device.maintenanceStart";
+    public static final String ATTRIBUTE_MAINTENANCE_INTERVAL = "device.maintenanceInterval";
+
+    @Override
+    protected Collection<Event> analyzePosition(Position position) {
+        Device device = Context.getIdentityManager().getDeviceById(position.getDeviceId());
+        if (device == null || !Context.getIdentityManager().isLatestPosition(position)) {
+            return null;
+        }
+
+        double maintenanceInterval = Context.getDeviceManager()
+                .lookupServerDouble(device.getId(), ATTRIBUTE_MAINTENANCE_INTERVAL, 0);
+        if (maintenanceInterval == 0) {
+            return null;
+        }
+        double maintenanceStart = Context.getDeviceManager()
+                .lookupServerDouble(device.getId(), ATTRIBUTE_MAINTENANCE_START, 0);
+
+        Collection<Event> events = new ArrayList<>();
+        double oldTotalDistance = 0.0;
+        double newTotalDistance = 0.0;
+
+        Position lastPosition = Context.getIdentityManager().getLastPosition(position.getDeviceId());
+        if (lastPosition != null && lastPosition.getAttributes().containsKey(Position.KEY_TOTAL_DISTANCE)) {
+            oldTotalDistance = ((Number) lastPosition.getAttributes().get(Position.KEY_TOTAL_DISTANCE)).doubleValue();
+        }
+
+        if (position.getAttributes().containsKey(Position.KEY_TOTAL_DISTANCE)) {
+            newTotalDistance = ((Number) position.getAttributes().get(Position.KEY_TOTAL_DISTANCE)).doubleValue();
+        }
+
+        oldTotalDistance -= maintenanceStart;
+        newTotalDistance -= maintenanceStart;
+        if ((long) (oldTotalDistance / maintenanceInterval) < (long) (newTotalDistance / maintenanceInterval)) {
+            events.add(new Event(Event.TYPE_MAINTENANCE_NEED, position.getDeviceId(), position.getId()));
+        }
+
+        return events;
+    }
+
+}

--- a/src/org/traccar/events/MaintenanceEventHandler.java
+++ b/src/org/traccar/events/MaintenanceEventHandler.java
@@ -27,8 +27,8 @@ import org.traccar.model.Position;
 
 public class MaintenanceEventHandler extends BaseEventHandler {
 
-    public static final String ATTRIBUTE_MAINTENANCE_START = "device.maintenanceStart";
-    public static final String ATTRIBUTE_MAINTENANCE_INTERVAL = "device.maintenanceInterval";
+    public static final String ATTRIBUTE_MAINTENANCE_START = "maintenance.start";
+    public static final String ATTRIBUTE_MAINTENANCE_INTERVAL = "maintenance.interval";
 
     @Override
     protected Collection<Event> analyzePosition(Position position) {
@@ -61,7 +61,7 @@ public class MaintenanceEventHandler extends BaseEventHandler {
         oldTotalDistance -= maintenanceStart;
         newTotalDistance -= maintenanceStart;
         if ((long) (oldTotalDistance / maintenanceInterval) < (long) (newTotalDistance / maintenanceInterval)) {
-            events.add(new Event(Event.TYPE_MAINTENANCE_NEED, position.getDeviceId(), position.getId()));
+            events.add(new Event(Event.TYPE_MAINTENANCE_NEEDED, position.getDeviceId(), position.getId()));
         }
 
         return events;

--- a/src/org/traccar/model/Event.java
+++ b/src/org/traccar/model/Event.java
@@ -56,7 +56,7 @@ public class Event extends Message {
     public static final String TYPE_IGNITION_ON = "ignitionOn";
     public static final String TYPE_IGNITION_OFF = "ignitionOff";
 
-    public static final String TYPE_MAINTENANCE_NEED = "maintenanceNeed";
+    public static final String TYPE_MAINTENANCE_NEEDED = "maintenanceNeeded";
 
     private Date serverTime;
 

--- a/src/org/traccar/model/Event.java
+++ b/src/org/traccar/model/Event.java
@@ -55,6 +55,8 @@ public class Event extends Message {
     public static final String TYPE_IGNITION_ON = "ignitionOn";
     public static final String TYPE_IGNITION_OFF = "ignitionOff";
 
+    public static final String TYPE_MAINTENANCE_NEED = "maintenanceNeed";
+
     private Date serverTime;
 
     public Date getServerTime() {

--- a/src/org/traccar/notification/NotificationFormatter.java
+++ b/src/org/traccar/notification/NotificationFormatter.java
@@ -39,6 +39,10 @@ public final class NotificationFormatter {
     public static final String MESSAGE_TEMPLATE_TYPE_DEVICE_ONLINE = "Device: %1$s%n"
             + "Online%n"
             + "Time: %2$tc%n";
+    public static final String TITLE_TEMPLATE_TYPE_DEVICE_UNKNOWN = "%1$s: status is unknown";
+    public static final String MESSAGE_TEMPLATE_TYPE_DEVICE_UNKNOWN = "Device: %1$s%n"
+            + "Status is unknown%n"
+            + "Time: %2$tc%n";
     public static final String TITLE_TEMPLATE_TYPE_DEVICE_OFFLINE = "%1$s: offline";
     public static final String MESSAGE_TEMPLATE_TYPE_DEVICE_OFFLINE = "Device: %1$s%n"
             + "Offline%n"
@@ -88,6 +92,11 @@ public final class NotificationFormatter {
             + "Ignition OFF%n"
             + "Point: http://www.openstreetmap.org/?mlat=%3$f&mlon=%4$f#map=16/%3$f/%4$f%n"
             + "Time: %2$tc%n";
+    public static final String TITLE_TEMPLATE_TYPE_MAINTENANCE_NEED = "%1$s: maintenance is needed";
+    public static final String MESSAGE_TEMPLATE_TYPE_MAINTENANCE_NEED = "Device: %1$s%n"
+            + "Maintenance is needed%n"
+            + "Point: http://www.openstreetmap.org/?mlat=%3$f&mlon=%4$f#map=16/%3$f/%4$f%n"
+            + "Time: %2$tc%n";
 
     public static String formatTitle(long userId, Event event, Position position) {
         Device device = Context.getIdentityManager().getDeviceById(event.getDeviceId());
@@ -100,6 +109,9 @@ public final class NotificationFormatter {
                 break;
             case Event.TYPE_DEVICE_ONLINE:
                 formatter.format(TITLE_TEMPLATE_TYPE_DEVICE_ONLINE, device.getName());
+                break;
+            case Event.TYPE_DEVICE_UNKNOWN:
+                formatter.format(TITLE_TEMPLATE_TYPE_DEVICE_UNKNOWN, device.getName());
                 break;
             case Event.TYPE_DEVICE_OFFLINE:
                 formatter.format(TITLE_TEMPLATE_TYPE_DEVICE_OFFLINE, device.getName());
@@ -128,6 +140,9 @@ public final class NotificationFormatter {
             case Event.TYPE_IGNITION_OFF:
                 formatter.format(TITLE_TEMPLATE_TYPE_IGNITION_OFF, device.getName());
                 break;
+            case Event.TYPE_MAINTENANCE_NEED:
+                formatter.format(TITLE_TEMPLATE_TYPE_MAINTENANCE_NEED, device.getName());
+                break;
             default:
                 formatter.format("Unknown type");
                 break;
@@ -149,6 +164,9 @@ public final class NotificationFormatter {
                 break;
             case Event.TYPE_DEVICE_ONLINE:
                 formatter.format(MESSAGE_TEMPLATE_TYPE_DEVICE_ONLINE, device.getName(), event.getServerTime());
+                break;
+            case Event.TYPE_DEVICE_UNKNOWN:
+                formatter.format(MESSAGE_TEMPLATE_TYPE_DEVICE_UNKNOWN, device.getName(), event.getServerTime());
                 break;
             case Event.TYPE_DEVICE_OFFLINE:
                 formatter.format(MESSAGE_TEMPLATE_TYPE_DEVICE_OFFLINE, device.getName(), event.getServerTime());
@@ -186,6 +204,10 @@ public final class NotificationFormatter {
                 break;
             case Event.TYPE_IGNITION_OFF:
                 formatter.format(MESSAGE_TEMPLATE_TYPE_IGNITION_OFF, device.getName(), position.getFixTime(),
+                        position.getLatitude(), position.getLongitude());
+                break;
+            case Event.TYPE_MAINTENANCE_NEED:
+                formatter.format(MESSAGE_TEMPLATE_TYPE_MAINTENANCE_NEED, device.getName(), position.getFixTime(),
                         position.getLatitude(), position.getLongitude());
                 break;
             default:

--- a/src/org/traccar/notification/NotificationFormatter.java
+++ b/src/org/traccar/notification/NotificationFormatter.java
@@ -92,10 +92,10 @@ public final class NotificationFormatter {
             + "Ignition OFF%n"
             + "Point: http://www.openstreetmap.org/?mlat=%3$f&mlon=%4$f#map=16/%3$f/%4$f%n"
             + "Time: %2$tc%n";
-    public static final String TITLE_TEMPLATE_TYPE_MAINTENANCE_NEED = "%1$s: maintenance is needed";
-    public static final String MESSAGE_TEMPLATE_TYPE_MAINTENANCE_NEED = "Device: %1$s%n"
+    public static final String TITLE_TEMPLATE_TYPE_MAINTENANCE_NEEDED = "%1$s: maintenance is needed";
+    public static final String MESSAGE_TEMPLATE_TYPE_MAINTENANCE_NEEDED = "Device: %1$s%n"
             + "Maintenance is needed%n"
-            + "Point: http://www.openstreetmap.org/?mlat=%3$f&mlon=%4$f#map=16/%3$f/%4$f%n"
+            + "Point: https://www.openstreetmap.org/?mlat=%3$f&mlon=%4$f#map=16/%3$f/%4$f%n"
             + "Time: %2$tc%n";
 
     public static String formatTitle(long userId, Event event, Position position) {
@@ -140,8 +140,8 @@ public final class NotificationFormatter {
             case Event.TYPE_IGNITION_OFF:
                 formatter.format(TITLE_TEMPLATE_TYPE_IGNITION_OFF, device.getName());
                 break;
-            case Event.TYPE_MAINTENANCE_NEED:
-                formatter.format(TITLE_TEMPLATE_TYPE_MAINTENANCE_NEED, device.getName());
+            case Event.TYPE_MAINTENANCE_NEEDED:
+                formatter.format(TITLE_TEMPLATE_TYPE_MAINTENANCE_NEEDED, device.getName());
                 break;
             default:
                 formatter.format("Unknown type");
@@ -206,8 +206,8 @@ public final class NotificationFormatter {
                 formatter.format(MESSAGE_TEMPLATE_TYPE_IGNITION_OFF, device.getName(), position.getFixTime(),
                         position.getLatitude(), position.getLongitude());
                 break;
-            case Event.TYPE_MAINTENANCE_NEED:
-                formatter.format(MESSAGE_TEMPLATE_TYPE_MAINTENANCE_NEED, device.getName(), position.getFixTime(),
+            case Event.TYPE_MAINTENANCE_NEEDED:
+                formatter.format(MESSAGE_TEMPLATE_TYPE_MAINTENANCE_NEEDED, device.getName(), position.getFixTime(),
                         position.getLatitude(), position.getLongitude());
                 break;
             default:


### PR DESCRIPTION
Here is implementation of "maintenance is needed" events.

Two configuration attributes:
- `device.maintenanceStart` zero if ommited 
- `device.maintenanceInterval` can't be zero
Both in meters

Example:
`device.maintenanceStart = 2000000`
`device.maintenanceInterval = 7500000`

Events will be generated once at the point then `totalDistance` overcome 2000 km, 9500 km, 17000 km, 24500 km and so on.

Also:
- Enabled `statusHandler` by default (or it was disabled intentionally? )
- Added mail templates for new event types