### PR TITLE
Implemented polyline geofence

### DIFF
--- a/src/org/traccar/geofence/GeofenceGeometry.java
+++ b/src/org/traccar/geofence/GeofenceGeometry.java
@@ -25,4 +25,33 @@ public abstract class GeofenceGeometry {
 
     public abstract void fromWkt(String wkt) throws ParseException;
 
+    public static class Coordinate {
+
+        public static final double DEGREE360 = 360;
+
+        private double lat;
+        private double lon;
+
+        public double getLat() {
+            return lat;
+        }
+
+        public void setLat(double lat) {
+            this.lat = lat;
+        }
+
+        public double getLon() {
+            return lon;
+        }
+
+        // Need not to confuse algorithm by the abrupt reset of longitude
+        public double getLon360() {
+            return lon + DEGREE360;
+        }
+
+        public void setLon(double lon) {
+            this.lon = lon;
+        }
+    }
+
 }

--- a/src/org/traccar/geofence/GeofenceGeometry.java
+++ b/src/org/traccar/geofence/GeofenceGeometry.java
@@ -27,8 +27,6 @@ public abstract class GeofenceGeometry {
 
     public static class Coordinate {
 
-        public static final double DEGREE360 = 360;
-
         private double lat;
         private double lon;
 
@@ -42,11 +40,6 @@ public abstract class GeofenceGeometry {
 
         public double getLon() {
             return lon;
-        }
-
-        // Need not to confuse algorithm by the abrupt reset of longitude
-        public double getLon360() {
-            return lon + DEGREE360;
         }
 
         public void setLon(double lon) {

--- a/src/org/traccar/geofence/GeofencePolygon.java
+++ b/src/org/traccar/geofence/GeofencePolygon.java
@@ -27,35 +27,6 @@ public class GeofencePolygon extends GeofenceGeometry {
         fromWkt(wkt);
     }
 
-    private static class Coordinate {
-
-        public static final double DEGREE360 = 360;
-
-        private double lat;
-        private double lon;
-
-        public double getLat() {
-            return lat;
-        }
-
-        public void setLat(double lat) {
-            this.lat = lat;
-        }
-
-        public double getLon() {
-            return lon;
-        }
-
-        // Need not to confuse algorithm by the abrupt reset of longitude
-        public double getLon360() {
-            return lon + DEGREE360;
-        }
-
-        public void setLon(double lon) {
-            this.lon = lon;
-        }
-    }
-
     private ArrayList<Coordinate> coordinates;
 
     private double[] constant;

--- a/src/org/traccar/geofence/GeofencePolyline.java
+++ b/src/org/traccar/geofence/GeofencePolyline.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2016 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.traccar.geofence;
 
 import java.text.ParseException;

--- a/src/org/traccar/geofence/GeofencePolyline.java
+++ b/src/org/traccar/geofence/GeofencePolyline.java
@@ -36,11 +36,10 @@ public class GeofencePolyline extends GeofenceGeometry {
 
     @Override
     public boolean containsPoint(double latitude, double longitude) {
-        double longitude360 = longitude + Coordinate.DEGREE360;
         for (int i = 1; i < coordinates.size(); i++) {
             if (DistanceCalculator.distanceToLine(
-                    latitude, longitude360, coordinates.get(i - 1).getLat(), coordinates.get(i - 1).getLon360(),
-                    coordinates.get(i).getLat(), coordinates.get(i).getLon360()) <= distance) {
+                    latitude, longitude, coordinates.get(i - 1).getLat(), coordinates.get(i - 1).getLon(),
+                    coordinates.get(i).getLat(), coordinates.get(i).getLon()) <= distance) {
                 return true;
             }
         }

--- a/src/org/traccar/geofence/GeofencePolyline.java
+++ b/src/org/traccar/geofence/GeofencePolyline.java
@@ -1,0 +1,92 @@
+package org.traccar.geofence;
+
+import java.text.ParseException;
+import java.util.ArrayList;
+
+import org.traccar.helper.DistanceCalculator;
+
+public class GeofencePolyline extends GeofenceGeometry {
+
+    private ArrayList<Coordinate> coordinates;
+    private double distance;
+
+    public GeofencePolyline() {
+    }
+
+    public GeofencePolyline(String wkt, double distance) throws ParseException {
+        fromWkt(wkt);
+        this.distance = distance;
+    }
+
+    @Override
+    public boolean containsPoint(double latitude, double longitude) {
+        double longitude360 = longitude + Coordinate.DEGREE360;
+        for (int i = 1; i < coordinates.size(); i++) {
+            if (DistanceCalculator.distanceToInterval(
+                    latitude, longitude360, coordinates.get(i - 1).getLat(), coordinates.get(i - 1).getLon360(),
+                    coordinates.get(i).getLat(), coordinates.get(i).getLon360()) <= distance) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String toWkt() {
+        StringBuilder buf = new StringBuilder();
+        buf.append("LINESTRING (");
+        for (Coordinate coordinate : coordinates) {
+            buf.append(String.valueOf(coordinate.getLat()));
+            buf.append(" ");
+            buf.append(String.valueOf(coordinate.getLon()));
+            buf.append(", ");
+        }
+        return buf.substring(0, buf.length() - 2) + ")";
+    }
+
+    @Override
+    public void fromWkt(String wkt) throws ParseException {
+        if (coordinates == null) {
+            coordinates = new ArrayList<>();
+        } else {
+            coordinates.clear();
+        }
+
+        if (!wkt.startsWith("LINESTRING")) {
+            throw new ParseException("Mismatch geometry type", 0);
+        }
+        String content = wkt.substring(wkt.indexOf("(") + 1, wkt.indexOf(")"));
+        if (content.isEmpty()) {
+            throw new ParseException("No content", 0);
+        }
+        String[] commaTokens = content.split(",");
+        if (commaTokens.length < 2) {
+            throw new ParseException("Not valid content", 0);
+        }
+
+        for (String commaToken : commaTokens) {
+            String[] tokens = commaToken.trim().split("\\s");
+            if (tokens.length != 2) {
+                throw new ParseException("Here must be two coordinates: " + commaToken, 0);
+            }
+            Coordinate coordinate = new Coordinate();
+            try {
+                coordinate.setLat(Double.parseDouble(tokens[0]));
+            } catch (NumberFormatException e) {
+                throw new ParseException(tokens[0] + " is not a double", 0);
+            }
+            try {
+                coordinate.setLon(Double.parseDouble(tokens[1]));
+            } catch (NumberFormatException e) {
+                throw new ParseException(tokens[1] + " is not a double", 0);
+            }
+            coordinates.add(coordinate);
+        }
+
+    }
+
+    public void setDistance(double distance) {
+        this.distance = distance;
+    }
+
+}

--- a/src/org/traccar/geofence/GeofencePolyline.java
+++ b/src/org/traccar/geofence/GeofencePolyline.java
@@ -38,7 +38,7 @@ public class GeofencePolyline extends GeofenceGeometry {
     public boolean containsPoint(double latitude, double longitude) {
         double longitude360 = longitude + Coordinate.DEGREE360;
         for (int i = 1; i < coordinates.size(); i++) {
-            if (DistanceCalculator.distanceToInterval(
+            if (DistanceCalculator.distanceToLine(
                     latitude, longitude360, coordinates.get(i - 1).getLat(), coordinates.get(i - 1).getLon360(),
                     coordinates.get(i).getLat(), coordinates.get(i).getLon360()) <= distance) {
                 return true;

--- a/src/org/traccar/helper/DistanceCalculator.java
+++ b/src/org/traccar/helper/DistanceCalculator.java
@@ -34,7 +34,7 @@ public final class DistanceCalculator {
         return d * 1000;
     }
 
-    public static double distanceToInterval(
+    public static double distanceToLine(
             double pointLat, double pointLon, double lat1, double lon1, double lat2, double lon2) {
         double d0 = distance(pointLat, pointLon, lat1, lon1);
         double d1 = distance(lat1, lon1, lat2, lon2);

--- a/src/org/traccar/helper/DistanceCalculator.java
+++ b/src/org/traccar/helper/DistanceCalculator.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2014 Anton Tananaev (anton@traccar.org)
+ * Copyright 2014 - 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2016 Andrey Kunitsyn (andrey@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/org/traccar/helper/DistanceCalculator.java
+++ b/src/org/traccar/helper/DistanceCalculator.java
@@ -33,4 +33,20 @@ public final class DistanceCalculator {
         return d * 1000;
     }
 
+    public static double distanceToInterval(
+            double pointLat, double pointLon, double lat1, double lon1, double lat2, double lon2) {
+        double d0 = distance(pointLat, pointLon, lat1, lon1);
+        double d1 = distance(lat1, lon1, lat2, lon2);
+        double d2 = distance(lat2, lon2, pointLat, pointLon);
+        if (Math.pow(d0, 2) > Math.pow(d1, 2) + Math.pow(d2, 2)) {
+            return d2;
+        }
+        if (Math.pow(d2, 2) > Math.pow(d1, 2) + Math.pow(d0, 2)) {
+            return d0;
+        }
+        double halfP = (d0 + d1 + d2) * 0.5;
+        double area = Math.sqrt(halfP * (halfP - d0) * (halfP - d1) * (halfP - d2));
+        return 2 * area / d1;
+    }
+
 }

--- a/src/org/traccar/model/Geofence.java
+++ b/src/org/traccar/model/Geofence.java
@@ -17,9 +17,11 @@ package org.traccar.model;
 
 import java.text.ParseException;
 
+import org.traccar.Context;
 import org.traccar.geofence.GeofenceCircle;
 import org.traccar.geofence.GeofenceGeometry;
 import org.traccar.geofence.GeofencePolygon;
+import org.traccar.geofence.GeofencePolyline;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -27,6 +29,7 @@ public class Geofence extends Extensible {
 
     public static final String TYPE_GEOFENCE_CILCLE = "geofenceCircle";
     public static final String TYPE_GEOFENCE_POLYGON = "geofencePolygon";
+    public static final String TYPE_GEOFENCE_POLYLINE = "geofencePolyline";
 
     private String name;
 
@@ -60,6 +63,8 @@ public class Geofence extends Extensible {
             geometry = new GeofenceCircle(area);
         } else if (area.startsWith("POLYGON")) {
             geometry = new GeofencePolygon(area);
+        } else if (area.startsWith("LINESTRING")) {
+            geometry = new GeofencePolyline(area, Context.getConfig().getDouble("geofence.polylineDistance", 25));
         } else {
             throw new ParseException("Unknown geometry type", 0);
         }

--- a/test/org/traccar/geofence/GeofenceCircleTest.java
+++ b/test/org/traccar/geofence/GeofenceCircleTest.java
@@ -8,29 +8,19 @@ import org.junit.Test;
 public class GeofenceCircleTest {
 
     @Test
-    public void testCircleWKT() {
+    public void testCircleWkt() throws ParseException {
         String test = "CIRCLE (55.75414 37.6204, 100)";
         GeofenceGeometry geofenceGeometry = new GeofenceCircle();
-        try {
         geofenceGeometry.fromWkt(test);
-        } catch (ParseException e){
-            Assert.assertTrue("ParseExceprion: " + e.getMessage(), true);
-        }
         Assert.assertEquals(geofenceGeometry.toWkt(), test);
     }
 
     @Test
-    public void testContainsCircle() {
+    public void testContainsCircle() throws ParseException {
         String test = "CIRCLE (55.75414 37.6204, 100)";
         GeofenceGeometry geofenceGeometry = new GeofenceCircle();
-        try {
         geofenceGeometry.fromWkt(test);
-        } catch (ParseException e){
-            Assert.assertTrue("ParseExceprion: " + e.getMessage(), true);
-        }
-
         Assert.assertTrue(geofenceGeometry.containsPoint(55.75477, 37.62025));
-
         Assert.assertTrue(!geofenceGeometry.containsPoint(55.75545, 37.61921));
     }
 }

--- a/test/org/traccar/geofence/GeofencePolygonTest.java
+++ b/test/org/traccar/geofence/GeofencePolygonTest.java
@@ -8,30 +8,42 @@ import org.junit.Test;
 public class GeofencePolygonTest {
 
     @Test
-    public void testPolygonWKT() {
+    public void testPolygonWkt() throws ParseException {
         String test = "POLYGON ((55.75474 37.61823, 55.75513 37.61888, 55.7535 37.6222, 55.75315 37.62165))";
         GeofenceGeometry geofenceGeometry = new GeofencePolygon();
-        try {
         geofenceGeometry.fromWkt(test);
-        } catch (ParseException e){
-            Assert.assertTrue("ParseExceprion: " + e.getMessage(), true);
-        }
         Assert.assertEquals(geofenceGeometry.toWkt(), test);
     }
 
     @Test
-    public void testContainsPolygon() {
+    public void testContainsPolygon() throws ParseException {
         String test = "POLYGON ((55.75474 37.61823, 55.75513 37.61888, 55.7535 37.6222, 55.75315 37.62165))";
         GeofenceGeometry geofenceGeometry = new GeofencePolygon();
-        try {
         geofenceGeometry.fromWkt(test);
-        } catch (ParseException e){
-            Assert.assertTrue("ParseExceprion: " + e.getMessage(), true);
-        }
-
         Assert.assertTrue(geofenceGeometry.containsPoint(55.75476, 37.61915));
-
         Assert.assertTrue(!geofenceGeometry.containsPoint(55.75545, 37.61921));
+
+    }
+    
+    @Test
+    public void testContainsPolygon180() throws ParseException {
+        String test = "POLYGON ((66.9494 179.838, 66.9508 -179.8496, 66.8406 -180.0014))";
+        GeofenceGeometry geofenceGeometry = new GeofencePolygon();
+        geofenceGeometry.fromWkt(test);
+        Assert.assertTrue(geofenceGeometry.containsPoint(66.9015, -180.0096));
+        Assert.assertTrue(geofenceGeometry.containsPoint(66.9015, 179.991));
+        Assert.assertTrue(!geofenceGeometry.containsPoint(66.8368, -179.8792));
+
+    }
+    
+    @Test
+    public void testContainsPolygon0() throws ParseException {
+        String test = "POLYGON ((51.1966 -0.6207, 51.1897 0.4147, 50.9377 0.5136, 50.8675 -0.6082))";
+        GeofenceGeometry geofenceGeometry = new GeofencePolygon();
+        geofenceGeometry.fromWkt(test);
+        Assert.assertTrue(geofenceGeometry.containsPoint(51.0466, -0.0165));
+        Assert.assertTrue(geofenceGeometry.containsPoint(51.0466, 0.018));
+        Assert.assertTrue(!geofenceGeometry.containsPoint(50.9477, 0.5836));
 
     }
 

--- a/test/org/traccar/geofence/GeofencePolylineTest.java
+++ b/test/org/traccar/geofence/GeofencePolylineTest.java
@@ -1,0 +1,54 @@
+package org.traccar.geofence;
+
+import java.text.ParseException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class GeofencePolylineTest {
+
+    @Test
+    public void testPolylineWKT() {
+        String test = "LINESTRING (55.75474 37.61823, 55.75513 37.61888, 55.7535 37.6222, 55.75315 37.62165)";
+        GeofenceGeometry geofenceGeometry = new GeofencePolyline();
+        try {
+        geofenceGeometry.fromWkt(test);
+        } catch (ParseException e){
+            Assert.assertTrue("ParseExceprion: " + e.getMessage(), true);
+        }
+        Assert.assertEquals(geofenceGeometry.toWkt(), test);
+    }
+    
+    @Test
+    public void testContainsPolyline1Interval() {
+        String test = "LINESTRING (56.83777 60.59833, 56.83766 60.5968)";
+
+        try {
+        GeofenceGeometry geofenceGeometry = new GeofencePolyline(test, 35);
+        Assert.assertTrue(geofenceGeometry.containsPoint(56.83801, 60.59748));
+
+        ((GeofencePolyline) geofenceGeometry).setDistance(15);
+        Assert.assertTrue(!geofenceGeometry.containsPoint(56.83801, 60.59748));
+
+        } catch (ParseException e){
+            Assert.assertTrue("ParseExceprion: " + e.getMessage(), true);
+        }
+    }
+
+
+    @Test
+    public void testContainsPolyline3Intervals() {
+        String test = "LINESTRING (56.836 60.6126, 56.8393 60.6114, 56.83887 60.60811, 56.83782 60.5988)";
+
+        try {
+        GeofenceGeometry geofenceGeometry = new GeofencePolyline(test, 15);
+        Assert.assertTrue(geofenceGeometry.containsPoint(56.83847, 60.60458));
+        Assert.assertTrue(!geofenceGeometry.containsPoint(56.83764, 60.59725));
+        Assert.assertTrue(!geofenceGeometry.containsPoint(56.83861, 60.60822));
+
+        } catch (ParseException e){
+            Assert.assertTrue("ParseExceprion: " + e.getMessage(), true);
+        }
+    }
+
+}

--- a/test/org/traccar/geofence/GeofencePolylineTest.java
+++ b/test/org/traccar/geofence/GeofencePolylineTest.java
@@ -8,40 +8,38 @@ import org.junit.Test;
 public class GeofencePolylineTest {
 
     @Test
-    public void testPolylineWKT() {
+    public void testPolylineWkt() throws ParseException {
         String test = "LINESTRING (55.75474 37.61823, 55.75513 37.61888, 55.7535 37.6222, 55.75315 37.62165)";
         GeofenceGeometry geofenceGeometry = new GeofencePolyline();
-        try {
-            geofenceGeometry.fromWkt(test);
-        } catch (ParseException e){
-            Assert.assertTrue("ParseExceprion: " + e.getMessage(), true);
-        }
+        geofenceGeometry.fromWkt(test);
         Assert.assertEquals(geofenceGeometry.toWkt(), test);
     }
     
     @Test
-    public void testContainsPolyline1Interval() {
+    public void testContainsPolyline1Interval() throws ParseException {
         String test = "LINESTRING (56.83777 60.59833, 56.83766 60.5968)";
-        try {
-            GeofenceGeometry geofenceGeometry = new GeofencePolyline(test, 35);
-            Assert.assertTrue(geofenceGeometry.containsPoint(56.83801, 60.59748));
-            ((GeofencePolyline) geofenceGeometry).setDistance(15);
-            Assert.assertTrue(!geofenceGeometry.containsPoint(56.83801, 60.59748));
-        } catch (ParseException e){
-            Assert.assertTrue("ParseExceprion: " + e.getMessage(), true);
-        }
+        GeofenceGeometry geofenceGeometry = new GeofencePolyline(test, 35);
+        Assert.assertTrue(geofenceGeometry.containsPoint(56.83801, 60.59748));
+        ((GeofencePolyline) geofenceGeometry).setDistance(15);
+        Assert.assertTrue(!geofenceGeometry.containsPoint(56.83801, 60.59748));
     }
 
     @Test
-    public void testContainsPolyline3Intervals() {
+    public void testContainsPolyline3Intervals() throws ParseException {
         String test = "LINESTRING (56.836 60.6126, 56.8393 60.6114, 56.83887 60.60811, 56.83782 60.5988)";
-        try {
-            GeofenceGeometry geofenceGeometry = new GeofencePolyline(test, 15);
-            Assert.assertTrue(geofenceGeometry.containsPoint(56.83847, 60.60458));
-            Assert.assertTrue(!geofenceGeometry.containsPoint(56.83764, 60.59725));
-            Assert.assertTrue(!geofenceGeometry.containsPoint(56.83861, 60.60822));
-        } catch (ParseException e){
-            Assert.assertTrue("ParseExceprion: " + e.getMessage(), true);
-        }
+        GeofenceGeometry geofenceGeometry = new GeofencePolyline(test, 15);
+        Assert.assertTrue(geofenceGeometry.containsPoint(56.83847, 60.60458));
+        Assert.assertTrue(!geofenceGeometry.containsPoint(56.83764, 60.59725));
+        Assert.assertTrue(!geofenceGeometry.containsPoint(56.83861, 60.60822));
+
+    }
+    
+    @Test
+    public void testContainsPolylineNear180() throws ParseException {
+        String test = "LINESTRING (66.9494 179.838, 66.9508 -179.8496)";
+        GeofenceGeometry geofenceGeometry = new GeofencePolyline(test, 25);
+        Assert.assertTrue(geofenceGeometry.containsPoint(66.95, 180.0));
+        Assert.assertTrue(!geofenceGeometry.containsPoint(66.96, 180.0));
+        Assert.assertTrue(!geofenceGeometry.containsPoint(66.9509, -179.83));
     }
 }

--- a/test/org/traccar/geofence/GeofencePolylineTest.java
+++ b/test/org/traccar/geofence/GeofencePolylineTest.java
@@ -12,7 +12,7 @@ public class GeofencePolylineTest {
         String test = "LINESTRING (55.75474 37.61823, 55.75513 37.61888, 55.7535 37.6222, 55.75315 37.62165)";
         GeofenceGeometry geofenceGeometry = new GeofencePolyline();
         try {
-        geofenceGeometry.fromWkt(test);
+            geofenceGeometry.fromWkt(test);
         } catch (ParseException e){
             Assert.assertTrue("ParseExceprion: " + e.getMessage(), true);
         }
@@ -22,33 +22,26 @@ public class GeofencePolylineTest {
     @Test
     public void testContainsPolyline1Interval() {
         String test = "LINESTRING (56.83777 60.59833, 56.83766 60.5968)";
-
         try {
-        GeofenceGeometry geofenceGeometry = new GeofencePolyline(test, 35);
-        Assert.assertTrue(geofenceGeometry.containsPoint(56.83801, 60.59748));
-
-        ((GeofencePolyline) geofenceGeometry).setDistance(15);
-        Assert.assertTrue(!geofenceGeometry.containsPoint(56.83801, 60.59748));
-
+            GeofenceGeometry geofenceGeometry = new GeofencePolyline(test, 35);
+            Assert.assertTrue(geofenceGeometry.containsPoint(56.83801, 60.59748));
+            ((GeofencePolyline) geofenceGeometry).setDistance(15);
+            Assert.assertTrue(!geofenceGeometry.containsPoint(56.83801, 60.59748));
         } catch (ParseException e){
             Assert.assertTrue("ParseExceprion: " + e.getMessage(), true);
         }
     }
-
 
     @Test
     public void testContainsPolyline3Intervals() {
         String test = "LINESTRING (56.836 60.6126, 56.8393 60.6114, 56.83887 60.60811, 56.83782 60.5988)";
-
         try {
-        GeofenceGeometry geofenceGeometry = new GeofencePolyline(test, 15);
-        Assert.assertTrue(geofenceGeometry.containsPoint(56.83847, 60.60458));
-        Assert.assertTrue(!geofenceGeometry.containsPoint(56.83764, 60.59725));
-        Assert.assertTrue(!geofenceGeometry.containsPoint(56.83861, 60.60822));
-
+            GeofenceGeometry geofenceGeometry = new GeofencePolyline(test, 15);
+            Assert.assertTrue(geofenceGeometry.containsPoint(56.83847, 60.60458));
+            Assert.assertTrue(!geofenceGeometry.containsPoint(56.83764, 60.59725));
+            Assert.assertTrue(!geofenceGeometry.containsPoint(56.83861, 60.60822));
         } catch (ParseException e){
             Assert.assertTrue("ParseExceprion: " + e.getMessage(), true);
         }
     }
-
 }

--- a/test/org/traccar/helper/DistanceCalculatorTest.java
+++ b/test/org/traccar/helper/DistanceCalculatorTest.java
@@ -10,5 +10,14 @@ public class DistanceCalculatorTest {
         Assert.assertEquals(
                 DistanceCalculator.distance(0.0, 0.0, 0.05, 0.05), 7863.0, 10.0);
     }
+    
+    @Test
+    public void testDistanceToInterval() {
+        Assert.assertEquals(DistanceCalculator.distanceToInterval(
+                56.83801, 60.59748, 56.83777, 60.59833, 56.83766, 60.5968), 33.0, 5.0);
+        
+        Assert.assertEquals(DistanceCalculator.distanceToInterval(
+                56.83753, 60.59508, 56.83777, 60.59833, 56.83766, 60.5968), 105.0, 5.0);
+    }
 
 }

--- a/test/org/traccar/helper/DistanceCalculatorTest.java
+++ b/test/org/traccar/helper/DistanceCalculatorTest.java
@@ -12,11 +12,11 @@ public class DistanceCalculatorTest {
     }
     
     @Test
-    public void testDistanceToInterval() {
-        Assert.assertEquals(DistanceCalculator.distanceToInterval(
+    public void testDistanceToLine() {
+        Assert.assertEquals(DistanceCalculator.distanceToLine(
                 56.83801, 60.59748, 56.83777, 60.59833, 56.83766, 60.5968), 33.0, 5.0);
         
-        Assert.assertEquals(DistanceCalculator.distanceToInterval(
+        Assert.assertEquals(DistanceCalculator.distanceToLine(
                 56.83753, 60.59508, 56.83777, 60.59833, 56.83766, 60.5968), 105.0, 5.0);
     }
 


### PR DESCRIPTION
fix  #2600 

Polyline Geofence consider to contains point if distance between point and at least one interval less than predefined

Default value for `geofence.polylineDistance` is 25 meters. It is with wide margins.

Also moved `Coordinate` class to parent for use it in both polyline and polygon.