### PR TITLE
Use "id" parameter instead of "positionId"

### DIFF
--- a/src/org/traccar/api/resource/PositionResource.java
+++ b/src/org/traccar/api/resource/PositionResource.java
@@ -48,7 +48,7 @@ public class PositionResource extends BaseResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Collection<Position> getJson(
-            @QueryParam("deviceId") long deviceId, @QueryParam("positionId") List<Long> positionIds,
+            @QueryParam("deviceId") long deviceId, @QueryParam("id") List<Long> positionIds,
             @QueryParam("from") String from, @QueryParam("to") String to)
             throws SQLException {
         if (!positionIds.isEmpty()) {


### PR DESCRIPTION
It will short request
`http://localhost:8082/api/positions?id=15661&id=15661&id=15661&id=15662&id=15662&id=15663&id=15663&id=15663&id=15664&id=15664&id=15665&id=15667&id=15673&id=15677&id=15680&id=15680&page=1&start=0&limit=25`