### PR TITLE
Use model instead of attributes to store Notification options

### DIFF
--- a/schema/changelog-3.9.xml
+++ b/schema/changelog-3.9.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd"
+  logicalFilePath="changelog-3.9">
+
+  <changeSet author="author" id="changelog-3.9">
+
+    <addColumn tableName="notifications">
+      <column name="web" type="BOOLEAN" defaultValueBoolean="false" />
+      <column name="mail" type="BOOLEAN" defaultValueBoolean="false" />
+    </addColumn>
+
+    <update tableName="notifications">
+        <column name="web" valueBoolean="true" />
+        <where>attributes = '{"web":"true"}'</where>
+    </update>
+
+    <update tableName="notifications">
+        <column name="mail" valueBoolean="true" />
+        <where>attributes = '{"mail":"true"}'</where>
+    </update>
+
+    <update tableName="notifications">
+        <column name="web" valueBoolean="true" />
+        <column name="mail" valueBoolean="true" />
+        <where>attributes = '{"web":"true","mail":"true"}'</where>
+    </update>
+
+    <update tableName="notifications">
+        <column name="attributes" value="{}" />
+    </update>
+
+  </changeSet>
+</databaseChangeLog>

--- a/schema/changelog-master.xml
+++ b/schema/changelog-master.xml
@@ -10,4 +10,5 @@
   <include file="changelog-3.6.xml" relativeToChangelogFile="true" />
   <include file="changelog-3.7.xml" relativeToChangelogFile="true" />
   <include file="changelog-3.8.xml" relativeToChangelogFile="true" />
+  <include file="changelog-3.9.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/setup/default.xml
+++ b/setup/default.xml
@@ -264,14 +264,16 @@
     </entry>
 
     <entry key='database.insertNotification'>
-        INSERT INTO notifications (userId, type, attributes)
-        VALUES (:userId, :type, :attributes)
+        INSERT INTO notifications (userId, type, web, mail, attributes)
+        VALUES (:userId, :type, :web, :mail, :attributes)
     </entry>
 
     <entry key='database.updateNotification'>
         UPDATE notifications SET
         userId = :userId,
         type = :type,
+        web = :web,
+        mail = :mail,
         attributes = :attributes
         WHERE id = :id
     </entry>

--- a/src/org/traccar/api/resource/NotificationResource.java
+++ b/src/org/traccar/api/resource/NotificationResource.java
@@ -49,7 +49,7 @@ public class NotificationResource extends BaseResource {
             userId = getUserId();
         }
         Context.getPermissionsManager().checkUser(getUserId(), userId);
-        return Context.getNotificationManager().getUserNotifications(userId);
+        return Context.getNotificationManager().getAllUserNotifications(userId);
     }
 
     @POST

--- a/src/org/traccar/database/NotificationManager.java
+++ b/src/org/traccar/database/NotificationManager.java
@@ -131,10 +131,8 @@ public class NotificationManager {
         Notification cachedNotification = getUserNotificationByType(notification.getUserId(), notification.getType());
         if (cachedNotification != null) {
             if (cachedNotification.getWeb() != notification.getWeb()
-                    || cachedNotification.getMail() != notification.getMail()
-                    || !cachedNotification.getAttributes().equals(notification.getAttributes())) {
-                if (!notification.getWeb() && !notification.getMail()
-                        && notification.getAttributes().isEmpty()) {
+                    || cachedNotification.getMail() != notification.getMail()) {
+                if (!notification.getWeb() && !notification.getMail()) {
                     try {
                         dataManager.removeNotification(cachedNotification);
                     } catch (SQLException error) {
@@ -164,7 +162,7 @@ public class NotificationManager {
             } else {
                 notification.setId(cachedNotification.getId());
             }
-        } else if (notification.getWeb() || notification.getMail() || !notification.getAttributes().isEmpty()) {
+        } else if (notification.getWeb() || notification.getMail()) {
             try {
                 dataManager.addNotification(notification);
             } catch (SQLException error) {

--- a/src/org/traccar/model/Notification.java
+++ b/src/org/traccar/model/Notification.java
@@ -56,6 +56,4 @@ public class Notification extends Extensible {
     public void setMail(boolean mail) {
         this.mail = mail;
     }
-
-
 }

--- a/src/org/traccar/model/Notification.java
+++ b/src/org/traccar/model/Notification.java
@@ -37,4 +37,25 @@ public class Notification extends Extensible {
         this.type = type;
     }
 
+    private boolean web;
+
+    public boolean getWeb() {
+        return web;
+    }
+
+    public void setWeb(boolean web) {
+        this.web = web;
+    }
+
+    private boolean mail;
+
+    public boolean getMail() {
+        return mail;
+    }
+
+    public void setMail(boolean mail) {
+        this.mail = mail;
+    }
+
+
 }


### PR DESCRIPTION
- Extended model
- Copy values with help of DB changelog
- Remove notification only if everything is false and attributes is empty.
- Merge all types of notifications with actual user notifications on server side. 

Also tested on MSSQL, works fine.