### PR TITLE
Add support for "mail.smtp.ssl.protocols" parameter

### DIFF
--- a/src/org/traccar/notification/NotificationMail.java
+++ b/src/org/traccar/notification/NotificationMail.java
@@ -61,6 +61,11 @@ public final class NotificationMail {
                 properties.put("mail.smtp.ssl.trust", sslTrust);
             }
 
+            String sslProtocols = provider.getString("mail.smtp.ssl.protocols");
+            if (sslProtocols != null) {
+                properties.put("mail.smtp.ssl.protocols", sslProtocols);
+            }
+
             properties.put("mail.smtp.auth", provider.getString("mail.smtp.auth"));
 
             String username = provider.getString("mail.smtp.username");


### PR DESCRIPTION
fix #2651 
I don't think we should investigate why it does not work by default, may this parameter will help somebody else.