### PR TITLE
Permissions improvements

### DIFF
--- a/schema/changelog-3.10.xml
+++ b/schema/changelog-3.10.xml
@@ -64,5 +64,15 @@
     <addForeignKeyConstraint baseTableName="user_user" baseColumnNames="userid" constraintName="fk_user_user_userid" referencedTableName="users" referencedColumnNames="id" onDelete="CASCADE" />
     <addForeignKeyConstraint baseTableName="user_user" baseColumnNames="manageduserid" constraintName="fk_user_user_manageduserid" referencedTableName="users" referencedColumnNames="id" onDelete="CASCADE" />
 
+    <update tableName="users">
+        <column name="devicelimit" valueNumeric="-1" />
+        <where>devicelimit = 0</where>
+    </update>
+    <addDefaultValue tableName="users" columnName="devicelimit" defaultValueNumeric="-1" />
+
+    <addColumn tableName="users">
+      <column name="devicereadonly" type="BOOLEAN" defaultValueBoolean="false" />
+    </addColumn>
+
   </changeSet>
 </databaseChangeLog>

--- a/setup/default.xml
+++ b/setup/default.xml
@@ -64,8 +64,8 @@
     </entry>
 
     <entry key='database.insertUser'>
-        INSERT INTO users (name, email, hashedPassword, salt, readonly, admin, map, distanceUnit, speedUnit, latitude, longitude, zoom, twelveHourFormat, coordinateFormat, disabled, expirationTime, deviceLimit, userLimit, token, attributes)
-        VALUES (:name, :email, :hashedPassword, :salt, :readonly, :admin, :map, :distanceUnit, :speedUnit, :latitude, :longitude, :zoom, :twelveHourFormat, :coordinateFormat, :disabled, :expirationTime, :deviceLimit, :userLimit, :token, :attributes)
+        INSERT INTO users (name, email, hashedPassword, salt, readonly, admin, map, distanceUnit, speedUnit, latitude, longitude, zoom, twelveHourFormat, coordinateFormat, disabled, expirationTime, deviceLimit, userLimit, deviceReadonly, token, attributes)
+        VALUES (:name, :email, :hashedPassword, :salt, :readonly, :admin, :map, :distanceUnit, :speedUnit, :latitude, :longitude, :zoom, :twelveHourFormat, :coordinateFormat, :disabled, :expirationTime, :deviceLimit, :userLimit, :deviceReadonly, :token, :attributes)
     </entry>
 
     <entry key='database.updateUser'>
@@ -86,6 +86,7 @@
         expirationTime = :expirationTime,
         deviceLimit = :deviceLimit,
         userLimit = :userLimit,
+        deviceReadonly = :deviceReadonly,
         token = :token,
         attributes = :attributes
         WHERE id = :id

--- a/src/org/traccar/api/resource/DevicePermissionResource.java
+++ b/src/org/traccar/api/resource/DevicePermissionResource.java
@@ -38,9 +38,6 @@ public class DevicePermissionResource extends BaseResource {
         Context.getPermissionsManager().checkReadonly(getUserId());
         Context.getPermissionsManager().checkUser(getUserId(), entity.getUserId());
         Context.getPermissionsManager().checkDevice(getUserId(), entity.getDeviceId());
-        if (!Context.getPermissionsManager().isAdmin(getUserId())) {
-            Context.getPermissionsManager().checkDeviceLimit(entity.getUserId());
-        }
         Context.getDataManager().linkDevice(entity.getUserId(), entity.getDeviceId());
         Context.getPermissionsManager().refreshPermissions();
         if (Context.getGeofenceManager() != null) {
@@ -52,7 +49,11 @@ public class DevicePermissionResource extends BaseResource {
     @DELETE
     public Response remove(DevicePermission entity) throws SQLException {
         Context.getPermissionsManager().checkReadonly(getUserId());
-        Context.getPermissionsManager().checkUser(getUserId(), entity.getUserId());
+        if (getUserId() != entity.getUserId()) {
+            Context.getPermissionsManager().checkUser(getUserId(), entity.getUserId());
+        } else {
+            Context.getPermissionsManager().checkAdmin(getUserId());
+        }
         Context.getPermissionsManager().checkDevice(getUserId(), entity.getDeviceId());
         Context.getDataManager().unlinkDevice(entity.getUserId(), entity.getDeviceId());
         Context.getPermissionsManager().refreshPermissions();

--- a/src/org/traccar/api/resource/DeviceResource.java
+++ b/src/org/traccar/api/resource/DeviceResource.java
@@ -62,6 +62,7 @@ public class DeviceResource extends BaseResource {
     @POST
     public Response add(Device entity) throws SQLException {
         Context.getPermissionsManager().checkReadonly(getUserId());
+        Context.getPermissionsManager().checkDeviceReadonly(getUserId());
         Context.getPermissionsManager().checkDeviceLimit(getUserId());
         Context.getDeviceManager().addDevice(entity);
         Context.getDataManager().linkDevice(getUserId(), entity.getId());
@@ -76,6 +77,7 @@ public class DeviceResource extends BaseResource {
     @PUT
     public Response update(Device entity) throws SQLException {
         Context.getPermissionsManager().checkReadonly(getUserId());
+        Context.getPermissionsManager().checkDeviceReadonly(getUserId());
         Context.getPermissionsManager().checkDevice(getUserId(), entity.getId());
         Context.getDeviceManager().updateDevice(entity);
         if (Context.getGeofenceManager() != null) {
@@ -88,6 +90,7 @@ public class DeviceResource extends BaseResource {
     @DELETE
     public Response remove(@PathParam("id") long id) throws SQLException {
         Context.getPermissionsManager().checkReadonly(getUserId());
+        Context.getPermissionsManager().checkDeviceReadonly(getUserId());
         Context.getPermissionsManager().checkDevice(getUserId(), id);
         Context.getDeviceManager().removeDevice(id);
         Context.getPermissionsManager().refreshPermissions();

--- a/src/org/traccar/api/resource/UserResource.java
+++ b/src/org/traccar/api/resource/UserResource.java
@@ -64,7 +64,7 @@ public class UserResource extends BaseResource {
                 Context.getPermissionsManager().checkUserLimit(getUserId());
             } else {
                 Context.getPermissionsManager().checkRegistration(getUserId());
-                entity.setDeviceLimit(Context.getConfig().getInteger("users.defaultDeviceLimit"));
+                entity.setDeviceLimit(Context.getConfig().getInteger("users.defaultDeviceLimit", -1));
                 int expirationDays = Context.getConfig().getInteger("users.defaultExpirationDays");
                 if (expirationDays > 0) {
                     entity.setExpirationTime(
@@ -86,6 +86,7 @@ public class UserResource extends BaseResource {
     @Path("{id}")
     @PUT
     public Response update(User entity) throws SQLException {
+        Context.getPermissionsManager().checkReadonly(getUserId());
         User before = Context.getPermissionsManager().getUser(entity.getId());
         Context.getPermissionsManager().checkUser(getUserId(), entity.getId());
         Context.getPermissionsManager().checkUserUpdate(getUserId(), before, entity);
@@ -99,6 +100,7 @@ public class UserResource extends BaseResource {
     @Path("{id}")
     @DELETE
     public Response remove(@PathParam("id") long id) throws SQLException {
+        Context.getPermissionsManager().checkReadonly(getUserId());
         Context.getPermissionsManager().checkUser(getUserId(), id);
         Context.getPermissionsManager().removeUser(id);
         if (Context.getGeofenceManager() != null) {

--- a/src/org/traccar/model/User.java
+++ b/src/org/traccar/model/User.java
@@ -190,6 +190,16 @@ public class User extends Extensible {
         this.userLimit = userLimit;
     }
 
+    private boolean deviceReadonly;
+
+    public boolean getDeviceReadonly() {
+        return deviceReadonly;
+    }
+
+    public void setDeviceReadonly(boolean deviceReadonly) {
+        this.deviceReadonly = deviceReadonly;
+    }
+
     private String token;
 
     public String getToken() {


### PR DESCRIPTION
Here is changes discussed #2810 

- Add "deviceReadonly" user field. Such user can not add/edit/delete devices.
- Allow users edit `token`s
- `deviceLimit = 0` means zero, not infinite 
- Managers can create users with `deviceLimit = 0` only
- `userLimit = 0` means ordinary user
- `userLimit = -1` means manager without user limit
- Manager can't create users with `expirationTime` later then their
- Only admin can unlink devices from himself
- Readonly user becomes totally readonly
- Other discussed permissions improvements