### PR TITLE
Reset additional parameters of GPS position after geolocation

### DIFF
--- a/src/org/traccar/GeolocationHandler.java
+++ b/src/org/traccar/GeolocationHandler.java
@@ -57,6 +57,10 @@ public class GeolocationHandler implements ChannelUpstreamHandler {
                         position.setLatitude(latitude);
                         position.setLongitude(longitude);
                         position.setAccuracy(accuracy);
+                        position.setAltitude(0);
+                        position.setSpeed(0);
+                        position.setCourse(0);
+                        position.set(Position.KEY_RSSI, 0);
                         Channels.fireMessageReceived(ctx, position, event.getRemoteAddress());
                     }
 


### PR DESCRIPTION
When geolocation found a lat/lon from LBS/WIFI, only lat/lon and
accuracy are updated.
If protocol has copied "last" position to "Position" class before
issuing the geolocation, then all other parameters of GPS position
will be invalid (from "last" position).
So this fix reset to 0 the altitude, speed, course and rssi.