### PR TITLE
Do not allow readonly users send commands

### DIFF
--- a/src/org/traccar/api/resource/CommandResource.java
+++ b/src/org/traccar/api/resource/CommandResource.java
@@ -33,6 +33,8 @@ public class CommandResource extends BaseResource {
 
     @POST
     public Response add(Command entity) {
+        Context.getPermissionsManager().checkReadonly(getUserId());
+        Context.getPermissionsManager().checkDeviceReadonly(getUserId());
         Context.getPermissionsManager().checkDevice(getUserId(), entity.getDeviceId());
         Context.getConnectionManager().getActiveDevice(entity.getDeviceId()).sendCommand(entity);
         return Response.ok(entity).build();


### PR DESCRIPTION
It is can be controversial, but I think readonly and device readonly users should not be able send commands.