### PR TITLE
Remove check for valid in IgnitionEventHandler

### DIFF
--- a/src/org/traccar/events/IgnitionEventHandler.java
+++ b/src/org/traccar/events/IgnitionEventHandler.java
@@ -30,10 +30,7 @@ public class IgnitionEventHandler extends BaseEventHandler {
     @Override
     protected Collection<Event> analyzePosition(Position position) {
         Device device = Context.getIdentityManager().getDeviceById(position.getDeviceId());
-        if (device == null) {
-            return null;
-        }
-        if (!Context.getIdentityManager().isLatestPosition(position) || !position.getValid()) {
+        if (device == null || !Context.getIdentityManager().isLatestPosition(position)) {
             return null;
         }
 


### PR DESCRIPTION
In some cases we need to get ignition event even if position is not valid. For example if car starts in underground parking.

fix #2911 