### PR TITLE
Implement SMS notifications with help of smpp protocol

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,11 @@
             <artifactId>ical4j</artifactId>
             <version>2.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.fizzed</groupId>
+            <artifactId>ch-smpp</artifactId>
+            <version>5.0.9</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/schema/changelog-3.11.xml
+++ b/schema/changelog-3.11.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd"
+  logicalFilePath="changelog-3.11">
+
+  <changeSet author="author" id="changelog-3.11">
+
+    <addColumn tableName="users">
+      <column name="phone" type="VARCHAR(128)" />
+    </addColumn>
+    
+    <addColumn tableName="notifications">
+      <column name="sms" type="BOOLEAN" defaultValueBoolean="false" />
+    </addColumn>
+
+  </changeSet>
+
+</databaseChangeLog>

--- a/schema/changelog-master.xml
+++ b/schema/changelog-master.xml
@@ -12,4 +12,5 @@
   <include file="changelog-3.8.xml" relativeToChangelogFile="true" />
   <include file="changelog-3.9.xml" relativeToChangelogFile="true" />
   <include file="changelog-3.10.xml" relativeToChangelogFile="true" />
+  <include file="changelog-3.11.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/setup/default.xml
+++ b/setup/default.xml
@@ -64,14 +64,15 @@
     </entry>
 
     <entry key='database.insertUser'>
-        INSERT INTO users (name, email, hashedPassword, salt, readonly, admin, map, distanceUnit, speedUnit, latitude, longitude, zoom, twelveHourFormat, coordinateFormat, disabled, expirationTime, deviceLimit, userLimit, deviceReadonly, token, attributes)
-        VALUES (:name, :email, :hashedPassword, :salt, :readonly, :admin, :map, :distanceUnit, :speedUnit, :latitude, :longitude, :zoom, :twelveHourFormat, :coordinateFormat, :disabled, :expirationTime, :deviceLimit, :userLimit, :deviceReadonly, :token, :attributes)
+        INSERT INTO users (name, email, phone, hashedPassword, salt, readonly, admin, map, distanceUnit, speedUnit, latitude, longitude, zoom, twelveHourFormat, coordinateFormat, disabled, expirationTime, deviceLimit, userLimit, deviceReadonly, token, attributes)
+        VALUES (:name, :email, :phone, :hashedPassword, :salt, :readonly, :admin, :map, :distanceUnit, :speedUnit, :latitude, :longitude, :zoom, :twelveHourFormat, :coordinateFormat, :disabled, :expirationTime, :deviceLimit, :userLimit, :deviceReadonly, :token, :attributes)
     </entry>
 
     <entry key='database.updateUser'>
         UPDATE users SET
         name = :name,
         email = :email,
+        phone = :phone,
         readonly = :readonly,
         admin = :admin,
         map = :map,
@@ -268,8 +269,8 @@
     </entry>
 
     <entry key='database.insertNotification'>
-        INSERT INTO notifications (userId, type, web, mail, attributes)
-        VALUES (:userId, :type, :web, :mail, :attributes)
+        INSERT INTO notifications (userId, type, web, mail, sms, attributes)
+        VALUES (:userId, :type, :web, :mail, :sms, :attributes)
     </entry>
 
     <entry key='database.updateNotification'>
@@ -278,6 +279,7 @@
         type = :type,
         web = :web,
         mail = :mail,
+        sms = :sms,
         attributes = :attributes
         WHERE id = :id
     </entry>

--- a/src/org/traccar/Context.java
+++ b/src/org/traccar/Context.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 - 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2015 - 2017 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,7 @@ import org.traccar.geolocation.GeolocationProvider;
 import org.traccar.geolocation.MozillaGeolocationProvider;
 import org.traccar.geolocation.OpenCellIdGeolocationProvider;
 import org.traccar.notification.EventForwarder;
+import org.traccar.smpp.SmppClient;
 import org.traccar.web.WebServer;
 
 public final class Context {
@@ -176,6 +177,12 @@ public final class Context {
         return statisticsManager;
     }
 
+    private static SmppClient smppClient;
+
+    public static SmppClient getSmppManager() {
+        return smppClient;
+    }
+
     public static void init(String[] arguments) throws Exception {
 
         config = new Config();
@@ -277,7 +284,7 @@ public final class Context {
             notificationManager = new NotificationManager(dataManager);
             Properties velocityProperties = new Properties();
             velocityProperties.setProperty("file.resource.loader.path",
-                    Context.getConfig().getString("mail.templatesPath", "templates/mail") + "/");
+                    Context.getConfig().getString("templates.rootPath", "templates") + "/");
             velocityProperties.setProperty("runtime.log.logsystem.class",
                     "org.apache.velocity.runtime.log.NullLogChute");
 
@@ -300,6 +307,10 @@ public final class Context {
         aliasesManager = new AliasesManager(dataManager);
 
         statisticsManager = new StatisticsManager();
+
+        if (config.getBoolean("sms.smpp.enable")) {
+            smppClient = new SmppClient();
+        }
 
     }
 

--- a/src/org/traccar/api/resource/NotificationResource.java
+++ b/src/org/traccar/api/resource/NotificationResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2016 - 2017 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,12 @@ import org.traccar.api.BaseResource;
 import org.traccar.model.Event;
 import org.traccar.model.Notification;
 import org.traccar.notification.NotificationMail;
+import org.traccar.notification.NotificationSms;
+
+import com.cloudhopper.smpp.type.RecoverablePduException;
+import com.cloudhopper.smpp.type.SmppChannelException;
+import com.cloudhopper.smpp.type.SmppTimeoutException;
+import com.cloudhopper.smpp.type.UnrecoverablePduException;
 
 @Path("users/notifications")
 @Produces(MediaType.APPLICATION_JSON)
@@ -62,8 +68,10 @@ public class NotificationResource extends BaseResource {
 
     @Path("test")
     @POST
-    public Response testMail() throws MessagingException {
+    public Response testMessage() throws MessagingException, RecoverablePduException,
+            UnrecoverablePduException, SmppTimeoutException, SmppChannelException, InterruptedException {
         NotificationMail.sendMailSync(getUserId(), new Event("test", 0), null);
+        NotificationSms.sendSmsSync(getUserId(), new Event("test", 0), null);
         return Response.noContent().build();
     }
 

--- a/src/org/traccar/database/NotificationManager.java
+++ b/src/org/traccar/database/NotificationManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2016 - 2017 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.traccar.model.Event;
 import org.traccar.model.Notification;
 import org.traccar.model.Position;
 import org.traccar.notification.NotificationMail;
+import org.traccar.notification.NotificationSms;
 
 public class NotificationManager {
 
@@ -64,6 +65,9 @@ public class NotificationManager {
                     }
                     if (notification.getMail()) {
                         NotificationMail.sendMailAsync(userId, event, position);
+                    }
+                    if (notification.getSms()) {
+                        NotificationSms.sendSmsAsync(userId, event, position);
                     }
                 }
             }
@@ -131,8 +135,9 @@ public class NotificationManager {
         Notification cachedNotification = getUserNotificationByType(notification.getUserId(), notification.getType());
         if (cachedNotification != null) {
             if (cachedNotification.getWeb() != notification.getWeb()
-                    || cachedNotification.getMail() != notification.getMail()) {
-                if (!notification.getWeb() && !notification.getMail()) {
+                    || cachedNotification.getMail() != notification.getMail()
+                    || cachedNotification.getSms() != notification.getSms()) {
+                if (!notification.getWeb() && !notification.getMail() && !notification.getSms()) {
                     try {
                         dataManager.removeNotification(cachedNotification);
                     } catch (SQLException error) {
@@ -149,6 +154,7 @@ public class NotificationManager {
                     try {
                         cachedNotification.setWeb(notification.getWeb());
                         cachedNotification.setMail(notification.getMail());
+                        cachedNotification.setSms(notification.getSms());
                         cachedNotification.setAttributes(notification.getAttributes());
                     } finally {
                         notificationsLock.writeLock().unlock();
@@ -162,7 +168,7 @@ public class NotificationManager {
             } else {
                 notification.setId(cachedNotification.getId());
             }
-        } else if (notification.getWeb() || notification.getMail()) {
+        } else if (notification.getWeb() || notification.getMail() || notification.getSms()) {
             try {
                 dataManager.addNotification(notification);
             } catch (SQLException error) {

--- a/src/org/traccar/model/Notification.java
+++ b/src/org/traccar/model/Notification.java
@@ -56,4 +56,14 @@ public class Notification extends Extensible {
     public void setMail(boolean mail) {
         this.mail = mail;
     }
+
+    private boolean sms;
+
+    public boolean getSms() {
+        return sms;
+    }
+
+    public void setSms(boolean sms) {
+        this.sms = sms;
+    }
 }

--- a/src/org/traccar/model/User.java
+++ b/src/org/traccar/model/User.java
@@ -42,6 +42,16 @@ public class User extends Extensible {
         this.email = email;
     }
 
+    private String phone;
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
     private boolean readonly;
 
     public boolean getReadonly() {

--- a/src/org/traccar/notification/NotificationFormatter.java
+++ b/src/org/traccar/notification/NotificationFormatter.java
@@ -51,20 +51,14 @@ public final class NotificationFormatter {
         return velocityContext;
     }
 
-    private static Template getTemplate(Event event, boolean mail) {
+    private static Template getTemplate(Event event, String path) {
         Template template;
-        String subPath = "";
-        if (mail) {
-            subPath = Context.getConfig().getString("mail.templatesPath", "mail") + "/";
-        } else {
-            subPath  = Context.getConfig().getString("sms.templatesPath", "sms") + "/";
-        }
         try {
-            template = Context.getVelocityEngine().getTemplate(subPath + event.getType() + ".vm",
+            template = Context.getVelocityEngine().getTemplate(path + event.getType() + ".vm",
                     StandardCharsets.UTF_8.name());
         } catch (ResourceNotFoundException error) {
             Log.warning(error);
-            template = Context.getVelocityEngine().getTemplate(subPath + "unknown.vm",
+            template = Context.getVelocityEngine().getTemplate(path + "unknown.vm",
                     StandardCharsets.UTF_8.name());
         }
         return template;
@@ -73,14 +67,16 @@ public final class NotificationFormatter {
     public static MailMessage formatMailMessage(long userId, Event event, Position position) {
         VelocityContext velocityContext = prepareContext(userId, event, position);
         StringWriter writer = new StringWriter();
-        getTemplate(event, true).merge(velocityContext, writer);
+        getTemplate(event, Context.getConfig().getString("mail.templatesPath", "mail") + "/")
+                .merge(velocityContext, writer);
         return new MailMessage((String) velocityContext.get("subject"), writer.toString());
     }
 
     public static String formatSmsMessage(long userId, Event event, Position position) {
         VelocityContext velocityContext = prepareContext(userId, event, position);
         StringWriter writer = new StringWriter();
-        getTemplate(event, false).merge(velocityContext, writer);
+        getTemplate(event, Context.getConfig().getString("sms.templatesPath", "sms") + "/")
+                .merge(velocityContext, writer);
         return writer.toString();
     }
 }

--- a/src/org/traccar/notification/NotificationMail.java
+++ b/src/org/traccar/notification/NotificationMail.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2016 - 2017 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 Andrey Kunitsyn (andrey@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,7 +107,7 @@ public final class NotificationMail {
         }
 
         message.addRecipient(Message.RecipientType.TO, new InternetAddress(user.getEmail()));
-        MailMessage mailMessage = NotificationFormatter.formatMessage(userId, event, position);
+        MailMessage mailMessage = NotificationFormatter.formatMailMessage(userId, event, position);
         message.setSubject(mailMessage.getSubject());
         message.setContent(mailMessage.getBody(), "text/html; charset=utf-8");
 

--- a/src/org/traccar/notification/NotificationSms.java
+++ b/src/org/traccar/notification/NotificationSms.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.notification;
+
+import org.traccar.Context;
+import org.traccar.model.Event;
+import org.traccar.model.Position;
+import org.traccar.model.User;
+
+import com.cloudhopper.smpp.type.RecoverablePduException;
+import com.cloudhopper.smpp.type.SmppChannelException;
+import com.cloudhopper.smpp.type.SmppTimeoutException;
+import com.cloudhopper.smpp.type.UnrecoverablePduException;
+
+public final class NotificationSms {
+
+    private NotificationSms() {
+    }
+
+    public static void sendSmsAsync(long userId, Event event, Position position) {
+        User user = Context.getPermissionsManager().getUser(userId);
+        if (Context.getSmppManager() != null && user.getPhone() != null) {
+            Context.getSmppManager().sendMessageAsync(user.getPhone(),
+                    NotificationFormatter.formatSmsMessage(userId, event, position));
+        }
+    }
+
+    public static void sendSmsSync(long userId, Event event, Position position) throws RecoverablePduException,
+            UnrecoverablePduException, SmppTimeoutException, SmppChannelException, InterruptedException {
+        User user = Context.getPermissionsManager().getUser(userId);
+        if (Context.getSmppManager() != null && user.getPhone() != null) {
+            Context.getSmppManager().sendMessageSync(user.getPhone(),
+                    NotificationFormatter.formatSmsMessage(userId, event, position));
+        }
+    }
+}

--- a/src/org/traccar/smpp/ClientSmppSessionHandler.java
+++ b/src/org/traccar/smpp/ClientSmppSessionHandler.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.smpp;
+
+import org.traccar.helper.Log;
+
+import com.cloudhopper.commons.charset.CharsetUtil;
+import com.cloudhopper.smpp.SmppConstants;
+import com.cloudhopper.smpp.impl.DefaultSmppSessionHandler;
+import com.cloudhopper.smpp.pdu.DeliverSm;
+import com.cloudhopper.smpp.pdu.PduRequest;
+import com.cloudhopper.smpp.pdu.PduResponse;
+
+public class ClientSmppSessionHandler extends DefaultSmppSessionHandler {
+
+    private SmppClient smppClient;
+
+    public ClientSmppSessionHandler(SmppClient smppClient) {
+        this.smppClient = smppClient;
+    }
+
+    @Override
+    public void firePduRequestExpired(PduRequest pduRequest) {
+        Log.warning("PDU request expired: " + pduRequest);
+    }
+
+    @Override
+    public PduResponse firePduRequestReceived(PduRequest request) {
+        PduResponse response = null;
+        try {
+            if (request instanceof DeliverSm) {
+                Log.debug("Message Received: "
+                        + CharsetUtil.decode(((DeliverSm) request).getShortMessage(),
+                        smppClient.mapDataCodingToCharset(((DeliverSm) request).getDataCoding()))
+                        + ", Source Address: "
+                        + ((DeliverSm) request).getSourceAddress().getAddress());
+            }
+            response = request.createResponse();
+        } catch (Throwable error) {
+            Log.warning(error);
+            response = request.createResponse();
+            response.setResultMessage(error.getMessage());
+            response.setCommandStatus(SmppConstants.STATUS_UNKNOWNERR);
+        }
+        return response;
+    }
+
+    @Override
+    public void fireChannelUnexpectedlyClosed() {
+        Log.warning("Smpp session channel unexpectedly closed");
+        smppClient.scheduleReconnect();
+    }
+}

--- a/src/org/traccar/smpp/ClientSmppSessionHandler.java
+++ b/src/org/traccar/smpp/ClientSmppSessionHandler.java
@@ -43,11 +43,18 @@ public class ClientSmppSessionHandler extends DefaultSmppSessionHandler {
         PduResponse response = null;
         try {
             if (request instanceof DeliverSm) {
-                Log.debug("Message Received: "
-                        + CharsetUtil.decode(((DeliverSm) request).getShortMessage(),
-                        smppClient.mapDataCodingToCharset(((DeliverSm) request).getDataCoding()))
-                        + ", Source Address: "
-                        + ((DeliverSm) request).getSourceAddress().getAddress());
+                if (request.getOptionalParameters() != null) {
+                    Log.debug("Message Delivered: "
+                            + request.getOptionalParameter(SmppConstants.TAG_RECEIPTED_MSG_ID).getValueAsString()
+                            + ", State: "
+                            + request.getOptionalParameter(SmppConstants.TAG_MSG_STATE).getValueAsByte());
+                } else {
+                    Log.debug("Message Received: "
+                            + CharsetUtil.decode(((DeliverSm) request).getShortMessage(),
+                            smppClient.mapDataCodingToCharset(((DeliverSm) request).getDataCoding()))
+                            + ", Source Address: "
+                            + ((DeliverSm) request).getSourceAddress().getAddress());
+                }
             }
             response = request.createResponse();
         } catch (Throwable error) {

--- a/src/org/traccar/smpp/EnquireLinkTask.java
+++ b/src/org/traccar/smpp/EnquireLinkTask.java
@@ -43,13 +43,13 @@ public class EnquireLinkTask implements Runnable {
                 smppSession.enquireLink(new EnquireLink(), enquireLinkTimeout);
             } catch (SmppTimeoutException | SmppChannelException
                     | RecoverablePduException | UnrecoverablePduException error) {
-                Log.warning("Enquire link failed, executing reconnect: " + error);
+                Log.warning("Enquire link failed, executing reconnect: ", error);
                 smppClient.reconnect();
             } catch (InterruptedException error) {
                 Log.info("Enquire link interrupted, probably killed by reconnecting");
             }
         } else {
-            Log.error("Enquire link running while session is not connected");
+            Log.warning("Enquire link running while session is not connected");
         }
     }
 

--- a/src/org/traccar/smpp/EnquireLinkTask.java
+++ b/src/org/traccar/smpp/EnquireLinkTask.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.smpp;
+
+import org.traccar.helper.Log;
+
+import com.cloudhopper.smpp.SmppSession;
+import com.cloudhopper.smpp.pdu.EnquireLink;
+import com.cloudhopper.smpp.type.RecoverablePduException;
+import com.cloudhopper.smpp.type.SmppChannelException;
+import com.cloudhopper.smpp.type.SmppTimeoutException;
+import com.cloudhopper.smpp.type.UnrecoverablePduException;
+
+public class EnquireLinkTask implements Runnable {
+
+    private SmppClient smppClient;
+    private Integer enquireLinkTimeout;
+
+    public EnquireLinkTask(SmppClient smppClient, Integer enquireLinkTimeout) {
+        this.smppClient = smppClient;
+        this.enquireLinkTimeout = enquireLinkTimeout;
+    }
+
+    @Override
+    public void run() {
+        SmppSession smppSession = smppClient.getSession();
+        if (smppSession != null && smppSession.isBound()) {
+            try {
+                smppSession.enquireLink(new EnquireLink(), enquireLinkTimeout);
+            } catch (SmppTimeoutException | SmppChannelException
+                    | RecoverablePduException | UnrecoverablePduException error) {
+                Log.warning("Enquire link failed, executing reconnect: " + error);
+                smppClient.reconnect();
+            } catch (InterruptedException error) {
+                Log.info("Enquire link interrupted, probably killed by reconnecting");
+            }
+        } else {
+            Log.error("Enquire link running while session is not connected");
+        }
+    }
+
+}

--- a/src/org/traccar/smpp/ReconnectionTask.java
+++ b/src/org/traccar/smpp/ReconnectionTask.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.smpp;
+
+public class ReconnectionTask implements Runnable {
+
+    private final SmppClient smppClient;
+
+    protected ReconnectionTask(SmppClient smppClient) {
+        this.smppClient = smppClient;
+    }
+
+    @Override
+    public void run() {
+        smppClient.reconnect();
+    }
+}

--- a/src/org/traccar/smpp/SmppClient.java
+++ b/src/org/traccar/smpp/SmppClient.java
@@ -193,7 +193,7 @@ public class SmppClient {
             submit.setSourceAddress(new Address(sourceTon, sourceNpi, sourceAddress));
             submit.setDestAddress(new Address(destTon, destNpi, destAddress));
             submit.setRegisteredDelivery(SmppConstants.REGISTERED_DELIVERY_SMSC_RECEIPT_REQUESTED);
-            submit.setDataCoding((byte) dataCoding);
+            submit.setDataCoding(dataCoding);
             submit.setShortMessage(textBytes);
             SubmitSmResp submitResponce = getSession().submit(submit, submitTimeout);
             Log.debug("SMS submited, msg_id: " + submitResponce.getMessageId());

--- a/src/org/traccar/smpp/SmppClient.java
+++ b/src/org/traccar/smpp/SmppClient.java
@@ -192,7 +192,6 @@ public class SmppClient {
             SubmitSm submit = new SubmitSm();
             submit.setSourceAddress(new Address(sourceTon, sourceNpi, sourceAddress));
             submit.setDestAddress(new Address(destTon, destNpi, destAddress));
-            submit.setRegisteredDelivery(SmppConstants.REGISTERED_DELIVERY_SMSC_RECEIPT_REQUESTED);
             submit.setDataCoding(dataCoding);
             submit.setShortMessage(textBytes);
             SubmitSmResp submitResponce = getSession().submit(submit, submitTimeout);

--- a/src/org/traccar/smpp/SmppClient.java
+++ b/src/org/traccar/smpp/SmppClient.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.smpp;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+import org.traccar.Context;
+import org.traccar.helper.Log;
+
+import com.cloudhopper.commons.charset.CharsetUtil;
+import com.cloudhopper.smpp.SmppBindType;
+import com.cloudhopper.smpp.SmppConstants;
+import com.cloudhopper.smpp.SmppSession;
+import com.cloudhopper.smpp.SmppSessionConfiguration;
+import com.cloudhopper.smpp.impl.DefaultSmppClient;
+import com.cloudhopper.smpp.impl.DefaultSmppSessionHandler;
+import com.cloudhopper.smpp.pdu.SubmitSm;
+import com.cloudhopper.smpp.pdu.SubmitSmResp;
+import com.cloudhopper.smpp.type.Address;
+import com.cloudhopper.smpp.type.RecoverablePduException;
+import com.cloudhopper.smpp.type.SmppChannelException;
+import com.cloudhopper.smpp.type.SmppTimeoutException;
+import com.cloudhopper.smpp.type.UnrecoverablePduException;
+
+public class SmppClient {
+
+    private SmppSessionConfiguration sessionConfig = new SmppSessionConfiguration();
+    private SmppSession smppSession;
+    private DefaultSmppSessionHandler sessionHandler = new ClientSmppSessionHandler(this);
+    private ExecutorService executorService = Executors.newCachedThreadPool();
+    private DefaultSmppClient clientBootstrap = new DefaultSmppClient(executorService, 1);
+
+    private ScheduledExecutorService enquireLinkExecutor;
+    private ScheduledFuture<?> enquireLinkTask;
+    private Integer enquireLinkPeriod;
+    private Integer enquireLinkTimeout;
+
+    private ScheduledExecutorService reconnectionExecutor;
+    private ScheduledFuture<?> reconnectionTask;
+    private Integer reconnectionDelay;
+
+    private String sourceAddress;
+    private int submitTimeout;
+    private String charsetName;
+    private byte dataCoding;
+
+    private byte sourceTon;
+    private byte sourceNpi;
+
+    private byte destTon;
+    private byte destNpi;
+
+    public SmppClient() {
+        sessionConfig.setName("Traccar.smppSession");
+        sessionConfig.setInterfaceVersion(
+                (byte) Context.getConfig().getInteger("sms.smpp.version", SmppConstants.VERSION_3_4));
+        sessionConfig.setType(SmppBindType.TRANSCEIVER);
+        sessionConfig.setHost(Context.getConfig().getString("sms.smpp.host", "localhost"));
+        sessionConfig.setPort(Context.getConfig().getInteger("sms.smpp.port", 2775));
+        sessionConfig.setSystemId(Context.getConfig().getString("sms.smpp.username", "user"));
+        sessionConfig.setPassword(Context.getConfig().getString("sms.smpp.password", "password"));
+        sessionConfig.getLoggingOptions().setLogBytes(false);
+        sessionConfig.getLoggingOptions().setLogPdu(Context.getConfig().getBoolean("sms.smpp.logPdu"));
+
+        sourceAddress = Context.getConfig().getString("sms.smpp.sourceAddress", "");
+        submitTimeout = Context.getConfig().getInteger("sms.smpp.submitTimeout", 10000);
+
+        charsetName = Context.getConfig().getString("sms.smpp.charsetName", CharsetUtil.NAME_UCS_2);
+        dataCoding = (byte) Context.getConfig().getInteger("sms.smpp.dataCoding", SmppConstants.DATA_CODING_UCS2);
+
+        sourceTon = (byte) Context.getConfig().getInteger("sms.smpp.sourceTon", SmppConstants.TON_ALPHANUMERIC);
+        sourceNpi = (byte) Context.getConfig().getInteger("sms.smpp.sourceNpi", SmppConstants.NPI_UNKNOWN);
+
+        destTon = (byte) Context.getConfig().getInteger("sms.smpp.destTon", SmppConstants.TON_INTERNATIONAL);
+        destNpi = (byte) Context.getConfig().getInteger("sms.smpp.destNpi", SmppConstants.NPI_E164);
+
+        enquireLinkPeriod = Context.getConfig().getInteger("sms.smpp.enquireLinkPeriod", 60000);
+        enquireLinkTimeout = Context.getConfig().getInteger("sms.smpp.enquireLinkTimeout", 10000);
+        enquireLinkExecutor = Executors.newScheduledThreadPool(1, new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable runnable) {
+                Thread thread = new Thread(runnable);
+                String name = sessionConfig.getName();
+                thread.setName("EnquireLink-" + name);
+                return thread;
+            }
+        });
+
+        reconnectionDelay = Context.getConfig().getInteger("sms.smpp.reconnectionDelay", 10000);
+        reconnectionExecutor = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable runnable) {
+                Thread thread = new Thread(runnable);
+                String name = sessionConfig.getName();
+                thread.setName("Reconnection-" + name);
+                return thread;
+            }
+        });
+
+        scheduleReconnect();
+    }
+
+    public synchronized SmppSession getSession() {
+        return smppSession;
+    }
+
+    public String mapDataCodingToCharset(byte dataCoding) {
+        switch (dataCoding) {
+            case SmppConstants.DATA_CODING_LATIN1:
+                return CharsetUtil.NAME_ISO_8859_1;
+            case SmppConstants.DATA_CODING_UCS2:
+                return CharsetUtil.NAME_UCS_2;
+            default:
+                return CharsetUtil.NAME_GSM;
+        }
+    }
+
+    protected synchronized void reconnect() {
+        try {
+            disconnect();
+            smppSession = clientBootstrap.bind(sessionConfig, sessionHandler);
+            stopReconnectionkTask();
+            runEnquireLinkTask();
+            Log.info("Smpp session connected");
+        } catch (SmppTimeoutException | SmppChannelException
+                | UnrecoverablePduException | InterruptedException error) {
+            Log.warning("Unable to connect to smpp server: ", error);
+        }
+    }
+
+    public void scheduleReconnect() {
+        reconnectionTask = reconnectionExecutor.scheduleWithFixedDelay(
+                new ReconnectionTask(this),
+                reconnectionDelay, reconnectionDelay, TimeUnit.MILLISECONDS);
+    }
+
+    private void stopReconnectionkTask() {
+        if (reconnectionTask != null) {
+            reconnectionTask.cancel(false);
+        }
+    }
+
+    private void disconnect() {
+        stopEnquireLinkTask();
+        destroySession();
+    }
+
+    private void runEnquireLinkTask() {
+        enquireLinkTask = enquireLinkExecutor.scheduleWithFixedDelay(
+                new EnquireLinkTask(this, enquireLinkTimeout),
+                enquireLinkPeriod, enquireLinkPeriod, TimeUnit.MILLISECONDS);
+    }
+
+    private void stopEnquireLinkTask() {
+        if (enquireLinkTask != null) {
+            enquireLinkTask.cancel(true);
+        }
+    }
+
+    private void destroySession() {
+        if (smppSession != null) {
+            Log.debug("Cleaning up smpp session... ");
+            smppSession.destroy();
+            smppSession = null;
+        }
+    }
+
+    public synchronized void sendMessageSync(String destAddress, String message) throws RecoverablePduException,
+            UnrecoverablePduException, SmppTimeoutException, SmppChannelException, InterruptedException {
+        if (getSession() != null && getSession().isBound()) {
+            byte[] textBytes = CharsetUtil.encode(message, charsetName);
+
+            SubmitSm submit = new SubmitSm();
+            submit.setSourceAddress(new Address(sourceTon, sourceNpi, sourceAddress));
+            submit.setDestAddress(new Address(destTon, destNpi, destAddress));
+            submit.setRegisteredDelivery(SmppConstants.REGISTERED_DELIVERY_SMSC_RECEIPT_REQUESTED);
+            submit.setDataCoding((byte) dataCoding);
+            submit.setShortMessage(textBytes);
+            SubmitSmResp submitResponce = getSession().submit(submit, submitTimeout);
+            Log.debug("SMS submited, msg_id: " + submitResponce.getMessageId());
+        } else {
+            throw new SmppChannelException("Smpp session is not connected");
+        }
+    }
+
+    public void sendMessageAsync(final String destAddress, final String message) {
+        executorService.execute(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    sendMessageSync(destAddress, message);
+                } catch (InterruptedException | RecoverablePduException | UnrecoverablePduException
+                        | SmppTimeoutException | SmppChannelException error) {
+                    Log.warning(error);
+                }
+            }
+        });
+    }
+}

--- a/templates/sms/alarm.vm
+++ b/templates/sms/alarm.vm
@@ -1,0 +1,1 @@
+$device.name alarm: $position.getString("alarm") at $event.serverTime

--- a/templates/sms/commandResult.vm
+++ b/templates/sms/commandResult.vm
@@ -1,0 +1,1 @@
+$device.name command result received: $position.getString("result") at $event.serverTime

--- a/templates/sms/deviceMoving.vm
+++ b/templates/sms/deviceMoving.vm
@@ -1,0 +1,1 @@
+$device.name moving at $event.serverTime

--- a/templates/sms/deviceOffline.vm
+++ b/templates/sms/deviceOffline.vm
@@ -1,0 +1,1 @@
+$device.name offline at $event.serverTime

--- a/templates/sms/deviceOnline.vm
+++ b/templates/sms/deviceOnline.vm
@@ -1,0 +1,1 @@
+$device.name online at $event.serverTime

--- a/templates/sms/deviceOverspeed.vm
+++ b/templates/sms/deviceOverspeed.vm
@@ -1,0 +1,8 @@
+#if($speedUnits == 'kmh')
+#set($speedString = $position.speed * 1.852 + ' km/h')
+#elseif($speedUnits == 'mph')
+#set($speedString = $position.speed * 1.15078 + ' mph')
+#else
+#set($speedString = "$position.speed kn")
+#end
+$device.name exceeds the speed $speedString at $event.serverTime

--- a/templates/sms/deviceStopped.vm
+++ b/templates/sms/deviceStopped.vm
@@ -1,0 +1,1 @@
+$device.name stopped at $event.serverTime

--- a/templates/sms/deviceUnknown.vm
+++ b/templates/sms/deviceUnknown.vm
@@ -1,0 +1,1 @@
+$device.name status is unknown at $event.serverTime

--- a/templates/sms/geofenceEnter.vm
+++ b/templates/sms/geofenceEnter.vm
@@ -1,0 +1,1 @@
+$device.name has entered geofence $geofence.name at $event.serverTime

--- a/templates/sms/geofenceExit.vm
+++ b/templates/sms/geofenceExit.vm
@@ -1,0 +1,1 @@
+$device.name has exited geofence $geofence.name at $event.serverTime

--- a/templates/sms/ignitionOff.vm
+++ b/templates/sms/ignitionOff.vm
@@ -1,0 +1,1 @@
+$device.name ignition OFF at $event.serverTime

--- a/templates/sms/ignitionOn.vm
+++ b/templates/sms/ignitionOn.vm
@@ -1,0 +1,1 @@
+$device.name ignition ON at $event.serverTime

--- a/templates/sms/maintenance.vm
+++ b/templates/sms/maintenance.vm
@@ -1,0 +1,1 @@
+$device.name maintenance is required at $event.serverTime

--- a/templates/sms/test.vm
+++ b/templates/sms/test.vm
@@ -1,0 +1,1 @@
+Traccar test message

--- a/templates/sms/unknown.vm
+++ b/templates/sms/unknown.vm
@@ -1,0 +1,1 @@
+Unknown type


### PR DESCRIPTION
- Added `phone` field to `User` model
- Added `sms` field to `Notification` model
- Used velocity engine for SMS templates, because of that have to split templates path on `templates.rootPath`, `mail.templatesPath` and `sms.templatesPath`

`SmppClient` mostly inspired by demo https://github.com/fizzed/cloudhopper-smpp/tree/master/src/test/java/com/cloudhopper/smpp/demo/persist
but very simplified, especially `ReconnectionTask`

Tested on simulator, kannel with opensmppbox and commercial service kindly provided by @jaimzj  

The library uses another log system, because of that some logs go to `wrapper.log`

Will add more comments in code ...
