### PR TITLE
CellTowers and capturing additional protocol information

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -67,10 +67,7 @@
         <module name="LineLength">
             <property name="max" value="120"/>
         </module>
-	<module name="MethodLength">
-	    <property name="tokens" value="METHOD_DEF"/>
-	    <property name="max" value="160"/>
-	</module>
+	<module name="MethodLength"/>
         <module name="ParameterNumber"/>
 
         <!-- Checks for whitespace                               -->

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -67,7 +67,10 @@
         <module name="LineLength">
             <property name="max" value="120"/>
         </module>
-        <module name="MethodLength"/>
+	<module name="MethodLength">
+	    <property name="tokens" value="METHOD_DEF"/>
+	    <property name="max" value="160"/>
+	</module>
         <module name="ParameterNumber"/>
 
         <!-- Checks for whitespace                               -->

--- a/src/org/traccar/protocol/AplicomProtocolDecoder.java
+++ b/src/org/traccar/protocol/AplicomProtocolDecoder.java
@@ -490,7 +490,7 @@ public class AplicomProtocolDecoder extends BaseProtocolDecoder {
                         break;
                 }
                 buf.readUnsignedByte();
-                position.set(Position.KEY_VIN, buf.readBytes(17).toString());
+                position.set(Position.KEY_VIN, buf.readBytes(17).toString(StandardCharsets.US_ASCII));
                 position.set("towedDetectionStatus", buf.readUnsignedByte());
             } else if (type == 0x0E) {
                 buf.skipBytes(length);

--- a/src/org/traccar/protocol/AplicomProtocolDecoder.java
+++ b/src/org/traccar/protocol/AplicomProtocolDecoder.java
@@ -490,7 +490,7 @@ public class AplicomProtocolDecoder extends BaseProtocolDecoder {
                         break;
                 }
                 buf.readUnsignedByte();
-                buf.readBytes(17); // vin
+                position.set(Position.KEY_VIN, buf.readBytes(17).toString());
                 position.set("towedDetectionStatus", buf.readUnsignedByte());
             } else if (type == 0x0E) {
                 buf.skipBytes(length);

--- a/src/org/traccar/protocol/AutoFonProtocolDecoder.java
+++ b/src/org/traccar/protocol/AutoFonProtocolDecoder.java
@@ -23,6 +23,8 @@ import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
 import org.traccar.helper.BitUtil;
 import org.traccar.helper.DateBuilder;
+import org.traccar.model.CellTower;
+import org.traccar.model.Network;
 import org.traccar.model.Position;
 
 import java.net.SocketAddress;
@@ -84,11 +86,14 @@ public class AutoFonProtocolDecoder extends BaseProtocolDecoder {
         }
 
         position.set(Position.PREFIX_TEMP + 1, buf.readByte());
-        position.set(Position.KEY_RSSI, buf.readUnsignedByte());
-        buf.readUnsignedShort(); // mcc
-        buf.readUnsignedShort(); // mnc
-        buf.readUnsignedShort(); // lac
-        buf.readUnsignedShort(); // cid
+
+        int rssi = buf.readUnsignedByte();
+        CellTower cellTower = CellTower.from(buf.readUnsignedShort(),
+                                             buf.readUnsignedShort(),
+                                             buf.readUnsignedShort(),
+                                             buf.readUnsignedShort(),
+                                             rssi);
+        position.setNetwork(new Network(cellTower));
 
         int valid = buf.readUnsignedByte();
         position.setValid((valid & 0xc0) != 0);
@@ -182,6 +187,7 @@ public class AutoFonProtocolDecoder extends BaseProtocolDecoder {
             buf.readByte(); // mode
             buf.readByte(); // gprs sending interval
 
+            // Should call position.setNetwork() here
             buf.skipBytes(6); // mcc, mnc, lac, cid
 
             int valid = buf.readUnsignedByte();

--- a/src/org/traccar/protocol/BceProtocolDecoder.java
+++ b/src/org/traccar/protocol/BceProtocolDecoder.java
@@ -132,8 +132,8 @@ public class BceProtocolDecoder extends BaseProtocolDecoder {
                     if (BitUtil.check(mask, 14)) {
                         position.setNetwork(new Network(CellTower.from(
                                 buf.readUnsignedShort(), buf.readUnsignedByte(),
-                                buf.readUnsignedShort(), buf.readUnsignedShort())));
-                        position.set(Position.KEY_RSSI, buf.readUnsignedByte());
+                                buf.readUnsignedShort(), buf.readUnsignedShort(),
+                                buf.readUnsignedByte())));
                         buf.readUnsignedByte();
                     }
 

--- a/src/org/traccar/protocol/CellocatorProtocolDecoder.java
+++ b/src/org/traccar/protocol/CellocatorProtocolDecoder.java
@@ -137,7 +137,9 @@ public class CellocatorProtocolDecoder extends BaseProtocolDecoder {
             buf.readUnsignedByte(); // mode 1
             buf.readUnsignedByte(); // mode 2
 
-            position.setValid(buf.readUnsignedByte() >= 3); // satellites
+            int satellites = buf.readUnsignedByte();
+            position.setValid(satellites >= 3);
+            position.set(Position.KEY_SATELLITES, satellites);
 
             position.setLongitude(buf.readInt() / Math.PI * 180 / 100000000);
             position.setLatitude(buf.readInt() / Math.PI * 180 / 100000000.0);

--- a/src/org/traccar/protocol/CguardProtocolDecoder.java
+++ b/src/org/traccar/protocol/CguardProtocolDecoder.java
@@ -73,7 +73,7 @@ public class CguardProtocolDecoder extends BaseProtocolDecoder {
         position.setLongitude(parser.nextDouble());
         position.setSpeed(UnitsConverter.knotsFromKph(parser.nextDouble()));
 
-        position.set(Position.KEY_ACCURACY, parser.nextDouble());
+        position.setAccuracy(parser.nextDouble());
 
         position.setCourse(parser.nextDouble());
         position.setAltitude(parser.nextDouble());

--- a/src/org/traccar/protocol/FlextrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/FlextrackProtocolDecoder.java
@@ -123,7 +123,7 @@ public class FlextrackProtocolDecoder extends BaseProtocolDecoder {
 
             position.set(Position.KEY_SATELLITES, parser.nextInt());
             position.set(Position.KEY_BATTERY, parser.nextInt());
-            position.set(Position.KEY_RSSI, parser.nextInt());
+            int rssi = parser.nextInt();
             position.set(Position.KEY_STATUS, parser.nextInt(16));
 
             int mcc = parser.nextInt();
@@ -133,7 +133,7 @@ public class FlextrackProtocolDecoder extends BaseProtocolDecoder {
 
             position.set(Position.KEY_HDOP, parser.nextInt() * 0.1);
 
-            position.setNetwork(new Network(CellTower.from(mcc, mnc, parser.nextInt(16), parser.nextInt(16))));
+            position.setNetwork(new Network(CellTower.from(mcc, mnc, parser.nextInt(16), parser.nextInt(16), rssi)));
 
             position.set(Position.KEY_ODOMETER, parser.nextInt());
 

--- a/src/org/traccar/protocol/GpsmtaProtocolDecoder.java
+++ b/src/org/traccar/protocol/GpsmtaProtocolDecoder.java
@@ -73,7 +73,7 @@ public class GpsmtaProtocolDecoder extends BaseProtocolDecoder {
         position.setLongitude(parser.nextDouble());
         position.setSpeed(parser.nextInt());
         position.setCourse(parser.nextInt());
-        parser.next();
+        position.setAccuracy(parser.nextInt());
         position.setAltitude(parser.nextInt());
 
         position.set(Position.KEY_STATUS, parser.nextInt());

--- a/src/org/traccar/protocol/Jt600ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Jt600ProtocolDecoder.java
@@ -110,10 +110,14 @@ public class Jt600ProtocolDecoder extends BaseProtocolDecoder {
                 position.set(Position.KEY_BATTERY, battery + "%");
             }
 
-            position.setNetwork(new Network(
-                    CellTower.fromCidLac(buf.readUnsignedShort(), buf.readUnsignedShort())));
+            int cid  = buf.readUnsignedShort();
+            int lac  = buf.readUnsignedShort();
+            int rssi = buf.readUnsignedByte();
 
-            position.set(Position.KEY_RSSI, buf.readUnsignedByte());
+            CellTower cellTower = CellTower.fromCidLac(cid, lac);
+            cellTower.setSignalStrength(rssi);
+            position.setNetwork(new Network(cellTower));
+
             position.set(Position.KEY_INDEX, buf.readUnsignedByte());
 
         } else if (version == 1) {
@@ -125,13 +129,17 @@ public class Jt600ProtocolDecoder extends BaseProtocolDecoder {
 
             position.setAltitude(buf.readUnsignedShort());
 
-            int cid = buf.readUnsignedShort();
-            int lac = buf.readUnsignedShort();
-            if (cid != 0 && lac != 0) {
-                position.setNetwork(new Network(CellTower.fromCidLac(cid, lac)));
-            }
+            int cid  = buf.readUnsignedShort();
+            int lac  = buf.readUnsignedShort();
+            int rssi = buf.readUnsignedByte();
 
-            position.set(Position.KEY_RSSI, buf.readUnsignedByte());
+            if (cid != 0 && lac != 0) {
+                CellTower cellTower = CellTower.fromCidLac(cid, lac);
+                cellTower.setSignalStrength(rssi);
+                position.setNetwork(new Network(cellTower));
+            } else {
+                position.set(Position.KEY_RSSI, rssi);
+            }
 
         } else if (version == 2) {
 
@@ -259,9 +267,10 @@ public class Jt600ProtocolDecoder extends BaseProtocolDecoder {
         position.set(Position.KEY_BATTERY, parser.next());
         position.set(Position.KEY_STATUS, parser.nextInt(2));
 
-        position.setNetwork(new Network(CellTower.fromCidLac(parser.nextInt(), parser.nextInt())));
+        CellTower cellTower = CellTower.fromCidLac(parser.nextInt(), parser.nextInt());
+        cellTower.setSignalStrength(parser.nextInt());
+        position.setNetwork(new Network(cellTower));
 
-        position.set(Position.KEY_RSSI, parser.nextInt());
         position.set(Position.KEY_ODOMETER, parser.nextLong() * 1000);
         position.set(Position.KEY_INDEX, parser.nextInt());
 

--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -54,7 +54,7 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
             .number("(dd)(dd)(dd),")             // time
             .number("([AV]),")                   // validity
             .number("(d+),")                     // satellites
-            .number("(d+),")                     // gsm signal
+            .number("(d+),")                     // gsm signal (rssi)
             .number("(d+.?d*),")                 // speed
             .number("(d+),")                     // course
             .number("(d+.?d*),")                 // hdop
@@ -64,7 +64,7 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+)|")                     // mcc
             .number("(d+)|")                     // mnc
             .number("(x+)|")                     // lac
-            .number("(x+),")                     // cell
+            .number("(x+),")                     // cell id (cid)
             .number("(x+),")                     // state
             .number("(x+)?|")                    // adc1
             .number("(x+)?|")                    // adc2
@@ -115,7 +115,7 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
         position.setValid(parser.next().equals("A"));
 
         position.set(Position.KEY_SATELLITES, parser.next());
-        position.set(Position.KEY_RSSI, parser.next());
+        int rssi = parser.nextInt();
 
         position.setSpeed(UnitsConverter.knotsFromKph(parser.nextDouble()));
         position.setCourse(parser.nextDouble());
@@ -128,7 +128,7 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
         position.set("runtime", parser.next());
 
         position.setNetwork(new Network(
-                CellTower.from(parser.nextInt(), parser.nextInt(), parser.nextInt(16), parser.nextInt(16))));
+                CellTower.from(parser.nextInt(), parser.nextInt(), parser.nextInt(16), parser.nextInt(16), rssi)));
 
         position.set(Position.KEY_STATUS, parser.next());
 
@@ -200,7 +200,7 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
             position.setValid(buf.readUnsignedByte() == 1);
 
             position.set(Position.KEY_SATELLITES, buf.readUnsignedByte());
-            position.set(Position.KEY_RSSI, buf.readUnsignedByte());
+            int rssi = buf.readUnsignedByte();
 
             position.setSpeed(UnitsConverter.knotsFromKph(buf.readUnsignedShort()));
             position.setCourse(buf.readUnsignedShort());
@@ -214,7 +214,8 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
 
             position.setNetwork(new Network(CellTower.from(
                     buf.readUnsignedShort(), buf.readUnsignedShort(),
-                    buf.readUnsignedShort(), buf.readUnsignedShort())));
+                    buf.readUnsignedShort(), buf.readUnsignedShort(),
+                    rssi)));
 
             position.set(Position.KEY_STATUS, buf.readUnsignedShort());
 

--- a/src/org/traccar/protocol/MxtProtocolDecoder.java
+++ b/src/org/traccar/protocol/MxtProtocolDecoder.java
@@ -134,7 +134,7 @@ public class MxtProtocolDecoder extends BaseProtocolDecoder {
             if (BitUtil.check(infoGroups, 2)) {
                 position.set(Position.KEY_SATELLITES, buf.readUnsignedByte());
                 position.set(Position.KEY_HDOP, buf.readUnsignedByte());
-                buf.readUnsignedByte(); // GPS accuracy
+                position.setAccuracy(buf.readUnsignedByte());
                 position.set(Position.KEY_RSSI, buf.readUnsignedByte());
                 buf.readUnsignedShort(); // time since boot
                 buf.readUnsignedByte(); // input voltage

--- a/src/org/traccar/protocol/TeltonikaProtocolDecoder.java
+++ b/src/org/traccar/protocol/TeltonikaProtocolDecoder.java
@@ -166,11 +166,15 @@ public class TeltonikaProtocolDecoder extends BaseProtocolDecoder {
                 }
 
                 if (BitUtil.check(locationMask, 5)) {
-                    position.setNetwork(new Network(
-                            CellTower.fromLacCid(buf.readUnsignedShort(), buf.readUnsignedShort())));
-                }
+                    CellTower cellTower = CellTower.fromLacCid(buf.readUnsignedShort(), buf.readUnsignedShort());
 
-                if (BitUtil.check(locationMask, 6)) {
+                    if (BitUtil.check(locationMask, 6)) {
+                        cellTower.setSignalStrength((int) buf.readUnsignedByte());
+                    }
+
+                    position.setNetwork(new Network(cellTower));
+
+                } else if (BitUtil.check(locationMask, 6)) {
                     position.set(Position.KEY_RSSI, buf.readUnsignedByte());
                 }
 

--- a/src/org/traccar/protocol/TotemProtocolDecoder.java
+++ b/src/org/traccar/protocol/TotemProtocolDecoder.java
@@ -218,11 +218,11 @@ public class TotemProtocolDecoder extends BaseProtocolDecoder {
                 position.set(Position.KEY_ALARM, decodeAlarm(Short.parseShort(parser.next(), 16)));
             }
             DateBuilder dateBuilder = new DateBuilder();
-            int year = 0;
+            int year = 0, month = 0, day = 0;
             if (pattern == PATTERN2) {
-                dateBuilder.setDay(parser.nextInt()).setMonth(parser.nextInt());
-                year = parser.nextInt();
-                dateBuilder.setYear(year);
+                day   = parser.nextInt();
+                month = parser.nextInt();
+                year  = parser.nextInt();
             }
             dateBuilder.setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
 
@@ -233,13 +233,14 @@ public class TotemProtocolDecoder extends BaseProtocolDecoder {
             position.setCourse(parser.nextDouble());
 
             if (pattern == PATTERN1) {
-                dateBuilder.setDay(parser.nextInt()).setMonth(parser.nextInt());
-                year = parser.nextInt();
-                dateBuilder.setYear(year);
+                day   = parser.nextInt();
+                month = parser.nextInt();
+                year  = parser.nextInt();
             }
             if (year == 0) {
                 return null; // ignore invalid data
             }
+            dateBuilder.setDate(year, month, day);
             position.setTime(dateBuilder.getDate());
 
             if (pattern == PATTERN1) {
@@ -286,19 +287,15 @@ public class TotemProtocolDecoder extends BaseProtocolDecoder {
 
             position.setValid(parser.next().equals("A"));
             position.set(Position.KEY_SATELLITES, parser.next());
-
             position.setCourse(parser.nextDouble());
             position.setSpeed(parser.nextDouble());
-
             position.set("pdop", parser.next());
-
             position.set(Position.KEY_ODOMETER, parser.next());
 
             position.setLatitude(parser.nextCoordinate());
             position.setLongitude(parser.nextCoordinate());
 
         } else if (pattern == PATTERN4) {
-
             position.set(Position.KEY_STATUS, parser.next());
 
             DateBuilder dateBuilder = new DateBuilder()
@@ -323,14 +320,12 @@ public class TotemProtocolDecoder extends BaseProtocolDecoder {
 
             position.setCourse(parser.nextDouble());
             position.setSpeed(UnitsConverter.knotsFromKph(parser.nextDouble()));
-
             position.set(Position.KEY_HDOP, parser.nextDouble());
             position.set(Position.KEY_ODOMETER, parser.nextInt() * 1000);
 
             position.setValid(true);
             position.setLatitude(parser.nextCoordinate());
             position.setLongitude(parser.nextCoordinate());
-
         }
         if (channel != null) {
             channel.write("ACK OK\r\n");

--- a/src/org/traccar/protocol/TotemProtocolDecoder.java
+++ b/src/org/traccar/protocol/TotemProtocolDecoder.java
@@ -50,9 +50,9 @@ public class TotemProtocolDecoder extends BaseProtocolDecoder {
             .number("(dd)(dd)(dd)")              // date
             .expression("[^*]*").text("*")
             .number("xx|")                       // checksum
-            .number("(d+.d+)|")                    // pdop
+            .number("(d+.d+)|")                  // pdop
             .number("(d+.d+)|")                  // hdop
-            .number("(d+.d+)|")                    // vdop
+            .number("(d+.d+)|")                  // vdop
             .number("(d+)|")                     // io status
             .number("d+|")                       // time
             .number("d")                         // charged
@@ -242,9 +242,14 @@ public class TotemProtocolDecoder extends BaseProtocolDecoder {
             }
             position.setTime(dateBuilder.getDate());
 
-            position.set("pdop", parser.next());
-            position.set(Position.KEY_HDOP, parser.next());
-            position.set("vdop", parser.next());
+            if (pattern == PATTERN1) {
+                position.set("pdop", parser.next());
+                position.set(Position.KEY_HDOP, parser.next());
+                position.set("vdop", parser.next());
+            } else if (pattern == PATTERN2) {
+                position.set(Position.KEY_HDOP, parser.next());
+            }
+
             position.set(Position.PREFIX_IO + 1, parser.next());
             position.set(Position.KEY_BATTERY, parser.next());
             position.set(Position.KEY_POWER, parser.nextDouble());

--- a/src/org/traccar/protocol/TotemProtocolDecoder.java
+++ b/src/org/traccar/protocol/TotemProtocolDecoder.java
@@ -151,7 +151,7 @@ public class TotemProtocolDecoder extends BaseProtocolDecoder {
             .number("(xxxx)")                    // lac
             .number("(xxxx)")                    // cid
             .number("(dd)")                      // satellites
-            .number("(dd)")                      // gsm
+            .number("(dd)")                      // gsm (rssi)
             .number("(ddd)")                     // course
             .number("(ddd)")                     // speed
             .number("(dd.d)")                    // hdop
@@ -309,11 +309,10 @@ public class TotemProtocolDecoder extends BaseProtocolDecoder {
             position.set(Position.PREFIX_TEMP + 1, parser.next());
             position.set(Position.PREFIX_TEMP + 2, parser.next());
 
-            position.setNetwork(new Network(
-                    CellTower.fromLacCid(parser.nextInt(16), parser.nextInt(16))));
-
+            CellTower cellTower = CellTower.fromLacCid(parser.nextInt(16), parser.nextInt(16));
             position.set(Position.KEY_SATELLITES, parser.nextInt());
-            position.set(Position.KEY_RSSI, parser.nextInt());
+            cellTower.setSignalStrength(parser.nextInt());
+            position.setNetwork(new Network(cellTower));
 
             position.setCourse(parser.nextDouble());
             position.setSpeed(UnitsConverter.knotsFromKph(parser.nextDouble()));

--- a/src/org/traccar/protocol/TotemProtocolDecoder.java
+++ b/src/org/traccar/protocol/TotemProtocolDecoder.java
@@ -50,9 +50,9 @@ public class TotemProtocolDecoder extends BaseProtocolDecoder {
             .number("(dd)(dd)(dd)")              // date
             .expression("[^*]*").text("*")
             .number("xx|")                       // checksum
-            .number("d+.d+|")                    // pdop
+            .number("(d+.d+)|")                    // pdop
             .number("(d+.d+)|")                  // hdop
-            .number("d+.d+|")                    // vdop
+            .number("(d+.d+)|")                    // vdop
             .number("(d+)|")                     // io status
             .number("d+|")                       // time
             .number("d")                         // charged
@@ -242,7 +242,9 @@ public class TotemProtocolDecoder extends BaseProtocolDecoder {
             }
             position.setTime(dateBuilder.getDate());
 
+            position.set("pdop", parser.next());
             position.set(Position.KEY_HDOP, parser.next());
+            position.set("vdop", parser.next());
             position.set(Position.PREFIX_IO + 1, parser.next());
             position.set(Position.KEY_BATTERY, parser.next());
             position.set(Position.KEY_POWER, parser.nextDouble());

--- a/src/org/traccar/protocol/TramigoProtocolDecoder.java
+++ b/src/org/traccar/protocol/TramigoProtocolDecoder.java
@@ -82,9 +82,9 @@ public class TramigoProtocolDecoder extends BaseProtocolDecoder {
             position.setLatitude(buf.readUnsignedInt() * 0.0000001);
             position.setLongitude(buf.readUnsignedInt() * 0.0000001);
 
-            buf.readUnsignedShort(); // GSM signal quality
-            buf.readUnsignedShort(); // satellites in fix
-            buf.readUnsignedShort(); // satellites in track
+            position.set(Position.KEY_RSSI, buf.readUnsignedShort()); // GSM signal quality
+            position.set(Position.KEY_SATELLITES, buf.readUnsignedShort()); // satellites in fix
+            position.set(Position.KEY_SATELLITES_VISIBLE, buf.readUnsignedShort()); // satellites in track
             buf.readUnsignedShort(); // GPS antenna state
 
             position.setSpeed(buf.readUnsignedShort() * 0.194384);
@@ -94,7 +94,7 @@ public class TramigoProtocolDecoder extends BaseProtocolDecoder {
 
             position.set(Position.KEY_BATTERY, buf.readUnsignedShort());
 
-            buf.readUnsignedShort(); // battery charger status
+            position.set(Position.KEY_CHARGE, buf.readUnsignedShort()); // battery charger status
 
             position.setTime(new Date(buf.readUnsignedInt() * 1000));
 

--- a/src/org/traccar/protocol/TrvProtocolDecoder.java
+++ b/src/org/traccar/protocol/TrvProtocolDecoder.java
@@ -140,7 +140,7 @@ public class TrvProtocolDecoder extends BaseProtocolDecoder {
 
             position.setCourse(parser.nextDouble());
 
-            position.set(Position.KEY_RSSI, parser.nextInt());
+            int rssi = parser.nextInt();
             position.set(Position.KEY_SATELLITES, parser.nextInt());
             position.set(Position.KEY_BATTERY, parser.nextInt());
 
@@ -150,7 +150,7 @@ public class TrvProtocolDecoder extends BaseProtocolDecoder {
             }
 
             position.setNetwork(new Network(CellTower.from(
-                    parser.nextInt(), parser.nextInt(), parser.nextInt(), parser.nextInt())));
+                    parser.nextInt(), parser.nextInt(), parser.nextInt(), parser.nextInt(), rssi)));
 
             return position;
         }

--- a/src/org/traccar/protocol/Tt8850ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Tt8850ProtocolDecoder.java
@@ -79,7 +79,9 @@ public class Tt8850ProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(deviceSession.getDeviceId());
 
-        position.setValid(parser.nextInt() < 20);
+        int accuracy = parser.nextInt();
+        position.setValid(accuracy < 20);
+        position.setAccuracy(accuracy);
         position.setSpeed(UnitsConverter.knotsFromKph(parser.nextDouble()));
         position.setCourse(parser.nextDouble());
         position.setAltitude(parser.nextDouble());


### PR DESCRIPTION
I have updated a number of protocols to record CellTower information.  Where CellTower information is reported, I have deleted KEY_RSSI as it is provided with the CellTower and would be redundant.

I have updated a number of protocols to record a number of KEYS as described and matched in the protocol comments.