### PR TITLE
Safely name sheets for excel reports

### DIFF
--- a/src/org/traccar/reports/Events.java
+++ b/src/org/traccar/reports/Events.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.poi.ss.util.WorkbookUtil;
 import org.joda.time.DateTime;
 import org.jxls.area.Area;
 import org.jxls.builder.xls.XlsCommentAreaBuilder;
@@ -98,7 +99,7 @@ public final class Events {
             DeviceReport deviceEvents = new DeviceReport();
             Device device = Context.getIdentityManager().getDeviceById(deviceId);
             deviceEvents.setDeviceName(device.getName());
-            sheetNames.add(deviceEvents.getDeviceName());
+            sheetNames.add(WorkbookUtil.createSafeSheetName(deviceEvents.getDeviceName()));
             if (device.getGroupId() != 0) {
                 Group group = Context.getDeviceManager().getGroupById(device.getGroupId());
                 if (group != null) {

--- a/src/org/traccar/reports/Route.java
+++ b/src/org/traccar/reports/Route.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
+import org.apache.poi.ss.util.WorkbookUtil;
 import org.joda.time.DateTime;
 import org.jxls.area.Area;
 import org.jxls.builder.xls.XlsCommentAreaBuilder;
@@ -67,7 +68,7 @@ public final class Route {
             DeviceReport deviceRoutes = new DeviceReport();
             Device device = Context.getIdentityManager().getDeviceById(deviceId);
             deviceRoutes.setDeviceName(device.getName());
-            sheetNames.add(deviceRoutes.getDeviceName());
+            sheetNames.add(WorkbookUtil.createSafeSheetName(deviceRoutes.getDeviceName()));
             if (device.getGroupId() != 0) {
                 Group group = Context.getDeviceManager().getGroupById(device.getGroupId());
                 if (group != null) {

--- a/src/org/traccar/reports/Trips.java
+++ b/src/org/traccar/reports/Trips.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
+import org.apache.poi.ss.util.WorkbookUtil;
 import org.joda.time.DateTime;
 import org.jxls.area.Area;
 import org.jxls.builder.xls.XlsCommentAreaBuilder;
@@ -201,7 +202,7 @@ public final class Trips {
             DeviceReport deviceTrips = new DeviceReport();
             Device device = Context.getIdentityManager().getDeviceById(deviceId);
             deviceTrips.setDeviceName(device.getName());
-            sheetNames.add(deviceTrips.getDeviceName());
+            sheetNames.add(WorkbookUtil.createSafeSheetName(deviceTrips.getDeviceName()));
             if (device.getGroupId() != 0) {
                 Group group = Context.getDeviceManager().getGroupById(device.getGroupId());
                 if (group != null) {


### PR DESCRIPTION
There is some limitations in worksheet names, we need use safe naming.
http://stackoverflow.com/questions/451452/valid-characters-for-excel-sheet-names

http://poi.apache.org/apidocs/org/apache/poi/ss/util/WorkbookUtil.html#createSafeSheetName(java.lang.String)
> Invalid characters are replaced by one space character ' '

For example device name `Test[2]` will look `Test 2 `

fix #2955 