### PR TITLE
Introduce terms "data" and "text" commands

### DIFF
--- a/src/org/traccar/Protocol.java
+++ b/src/org/traccar/Protocol.java
@@ -10,14 +10,14 @@ public interface Protocol {
 
     String getName();
 
-    Collection<String> getSupportedCommands();
+    Collection<String> getSupportedDataCommands();
 
-    void sendCommand(ActiveDevice activeDevice, Command command);
+    void sendDataCommand(ActiveDevice activeDevice, Command command);
 
     void initTrackerServers(List<TrackerServer> serverList);
 
-    Collection<String> getSupportedSmsCommands();
+    Collection<String> getSupportedTextCommands();
 
-    void sendSmsCommand(String phone, Command command) throws Exception;
+    void sendTextCommand(String destAddress, Command command) throws Exception;
 
 }

--- a/src/org/traccar/api/resource/CommandTypeResource.java
+++ b/src/org/traccar/api/resource/CommandTypeResource.java
@@ -34,9 +34,10 @@ import java.util.Collection;
 public class CommandTypeResource extends BaseResource {
 
     @GET
-    public Collection<CommandType> get(@QueryParam("deviceId") long deviceId, @QueryParam("sms") boolean sms) {
+    public Collection<CommandType> get(@QueryParam("deviceId") long deviceId,
+            @QueryParam("textChannel") boolean textChannel) {
         Context.getPermissionsManager().checkDevice(getUserId(), deviceId);
-        return Context.getDeviceManager().getCommandTypes(deviceId, sms);
+        return Context.getDeviceManager().getCommandTypes(deviceId, textChannel);
     }
 
 }

--- a/src/org/traccar/database/ActiveDevice.java
+++ b/src/org/traccar/database/ActiveDevice.java
@@ -44,7 +44,7 @@ public class ActiveDevice {
     }
 
     public void sendCommand(Command command) {
-        protocol.sendCommand(this, command);
+        protocol.sendDataCommand(this, command);
     }
 
     public void write(Object message) {

--- a/src/org/traccar/model/Command.java
+++ b/src/org/traccar/model/Command.java
@@ -66,14 +66,14 @@ public class Command extends Message {
     public static final String KEY_INDEX = "index";
     public static final String KEY_PHONE = "phone";
 
-    private boolean sms;
+    private boolean textChannel;
 
-    public boolean getSms() {
-        return sms;
+    public boolean getTextChannel() {
+        return textChannel;
     }
 
-    public void setSms(boolean sms) {
-        this.sms = sms;
+    public void setTextChannel(boolean textChannel) {
+        this.textChannel = textChannel;
     }
 
 }

--- a/src/org/traccar/protocol/CarcellProtocol.java
+++ b/src/org/traccar/protocol/CarcellProtocol.java
@@ -30,7 +30,7 @@ public class CarcellProtocol extends BaseProtocol {
 
     public CarcellProtocol() {
         super("carcell");
-        setSupportedCommands(
+        setSupportedDataCommands(
                 Command.TYPE_ENGINE_STOP,
                 Command.TYPE_ENGINE_RESUME);
     }

--- a/src/org/traccar/protocol/CellocatorProtocol.java
+++ b/src/org/traccar/protocol/CellocatorProtocol.java
@@ -29,7 +29,7 @@ public class CellocatorProtocol extends BaseProtocol {
 
     public CellocatorProtocol() {
         super("cellocator");
-        setSupportedCommands(
+        setSupportedDataCommands(
                 Command.TYPE_OUTPUT_CONTROL);
     }
 

--- a/src/org/traccar/protocol/CityeasyProtocol.java
+++ b/src/org/traccar/protocol/CityeasyProtocol.java
@@ -28,7 +28,7 @@ public class CityeasyProtocol extends BaseProtocol {
 
     public CityeasyProtocol() {
         super("cityeasy");
-        setSupportedCommands(
+        setSupportedDataCommands(
                 Command.TYPE_POSITION_SINGLE,
                 Command.TYPE_POSITION_PERIODIC,
                 Command.TYPE_POSITION_STOP,

--- a/src/org/traccar/protocol/EelinkProtocol.java
+++ b/src/org/traccar/protocol/EelinkProtocol.java
@@ -28,7 +28,7 @@ public class EelinkProtocol extends BaseProtocol {
 
     public EelinkProtocol() {
         super("eelink");
-        setSupportedCommands(
+        setSupportedDataCommands(
                 Command.TYPE_CUSTOM,
                 Command.TYPE_ENGINE_STOP,
                 Command.TYPE_ENGINE_RESUME,

--- a/src/org/traccar/protocol/Gl200Protocol.java
+++ b/src/org/traccar/protocol/Gl200Protocol.java
@@ -31,7 +31,7 @@ public class Gl200Protocol extends BaseProtocol {
 
     public Gl200Protocol() {
         super("gl200");
-        setSupportedCommands(
+        setSupportedDataCommands(
                 Command.TYPE_POSITION_SINGLE,
                 Command.TYPE_ENGINE_STOP,
                 Command.TYPE_ENGINE_RESUME,

--- a/src/org/traccar/protocol/Gps103Protocol.java
+++ b/src/org/traccar/protocol/Gps103Protocol.java
@@ -31,7 +31,7 @@ public class Gps103Protocol extends BaseProtocol {
 
     public Gps103Protocol() {
         super("gps103");
-        setSupportedCommands(
+        setSupportedDataCommands(
                 Command.TYPE_CUSTOM,
                 Command.TYPE_POSITION_SINGLE,
                 Command.TYPE_POSITION_PERIODIC,

--- a/src/org/traccar/protocol/GranitProtocol.java
+++ b/src/org/traccar/protocol/GranitProtocol.java
@@ -29,12 +29,12 @@ public class GranitProtocol extends BaseProtocol {
 
     public GranitProtocol() {
         super("granit");
-        setSupportedCommands(
+        setSupportedDataCommands(
                 Command.TYPE_IDENTIFICATION,
                 Command.TYPE_REBOOT_DEVICE,
                 Command.TYPE_POSITION_SINGLE);
-        setSmsEncoder(new GranitProtocolSmsEncoder());
-        setSupportedSmsCommands(
+        setTextCommandEncoder(new GranitProtocolSmsEncoder());
+        setSupportedTextCommands(
                 Command.TYPE_REBOOT_DEVICE,
                 Command.TYPE_POSITION_PERIODIC);
     }

--- a/src/org/traccar/protocol/Gt06Protocol.java
+++ b/src/org/traccar/protocol/Gt06Protocol.java
@@ -27,7 +27,7 @@ public class Gt06Protocol extends BaseProtocol {
 
     public Gt06Protocol() {
         super("gt06");
-        setSupportedCommands(
+        setSupportedDataCommands(
                 Command.TYPE_ENGINE_STOP,
                 Command.TYPE_ENGINE_RESUME);
     }

--- a/src/org/traccar/protocol/H02Protocol.java
+++ b/src/org/traccar/protocol/H02Protocol.java
@@ -29,7 +29,7 @@ public class H02Protocol extends BaseProtocol {
 
     public H02Protocol() {
         super("h02");
-        setSupportedCommands(
+        setSupportedDataCommands(
                 Command.TYPE_ALARM_ARM,
                 Command.TYPE_ALARM_DISARM,
                 Command.TYPE_ENGINE_STOP,

--- a/src/org/traccar/protocol/HuabaoProtocol.java
+++ b/src/org/traccar/protocol/HuabaoProtocol.java
@@ -27,7 +27,7 @@ public class HuabaoProtocol extends BaseProtocol {
 
     public HuabaoProtocol() {
         super("huabao");
-        setSupportedCommands(
+        setSupportedDataCommands(
                 Command.TYPE_ENGINE_STOP,
                 Command.TYPE_ENGINE_RESUME);
     }

--- a/src/org/traccar/protocol/Jt600Protocol.java
+++ b/src/org/traccar/protocol/Jt600Protocol.java
@@ -28,7 +28,7 @@ public class Jt600Protocol extends BaseProtocol {
 
     public Jt600Protocol() {
         super("jt600");
-        setSupportedCommands(
+        setSupportedDataCommands(
                 Command.TYPE_ENGINE_RESUME,
                 Command.TYPE_ENGINE_STOP,
                 Command.TYPE_SET_TIMEZONE,

--- a/src/org/traccar/protocol/KhdProtocol.java
+++ b/src/org/traccar/protocol/KhdProtocol.java
@@ -28,7 +28,7 @@ public class KhdProtocol extends BaseProtocol {
 
     public KhdProtocol() {
         super("khd");
-        setSupportedCommands(
+        setSupportedDataCommands(
                 Command.TYPE_ENGINE_STOP,
                 Command.TYPE_ENGINE_RESUME);
     }

--- a/src/org/traccar/protocol/MeiligaoProtocol.java
+++ b/src/org/traccar/protocol/MeiligaoProtocol.java
@@ -28,7 +28,7 @@ public class MeiligaoProtocol extends BaseProtocol {
 
     public MeiligaoProtocol() {
         super("meiligao");
-        setSupportedCommands(
+        setSupportedDataCommands(
                 Command.TYPE_POSITION_SINGLE,
                 Command.TYPE_POSITION_PERIODIC,
                 Command.TYPE_ENGINE_STOP,

--- a/src/org/traccar/protocol/MeitrackProtocol.java
+++ b/src/org/traccar/protocol/MeitrackProtocol.java
@@ -30,7 +30,7 @@ public class MeitrackProtocol extends BaseProtocol {
 
     public MeitrackProtocol() {
         super("meitrack");
-        setSupportedCommands(
+        setSupportedDataCommands(
                 Command.TYPE_POSITION_SINGLE,
                 Command.TYPE_ENGINE_STOP,
                 Command.TYPE_ENGINE_RESUME,

--- a/src/org/traccar/protocol/MiniFinderProtocol.java
+++ b/src/org/traccar/protocol/MiniFinderProtocol.java
@@ -30,7 +30,7 @@ public class MiniFinderProtocol extends BaseProtocol {
 
     public MiniFinderProtocol() {
         super("minifinder");
-        setSupportedCommands(
+        setSupportedDataCommands(
                 Command.TYPE_SET_TIMEZONE,
                 Command.TYPE_VOICE_MONITORING,
                 Command.TYPE_ALARM_SPEED,

--- a/src/org/traccar/protocol/NoranProtocol.java
+++ b/src/org/traccar/protocol/NoranProtocol.java
@@ -28,7 +28,7 @@ public class NoranProtocol extends BaseProtocol {
 
     public NoranProtocol() {
         super("noran");
-        setSupportedCommands(
+        setSupportedDataCommands(
                 Command.TYPE_POSITION_SINGLE,
                 Command.TYPE_POSITION_PERIODIC,
                 Command.TYPE_POSITION_STOP,

--- a/src/org/traccar/protocol/Pt502Protocol.java
+++ b/src/org/traccar/protocol/Pt502Protocol.java
@@ -30,7 +30,7 @@ public class Pt502Protocol extends BaseProtocol {
 
     public Pt502Protocol() {
         super("pt502");
-        setSupportedCommands(
+        setSupportedDataCommands(
                 Command.TYPE_SET_TIMEZONE,
                 Command.TYPE_ALARM_SPEED,
                 Command.TYPE_OUTPUT_CONTROL,

--- a/src/org/traccar/protocol/RuptelaProtocol.java
+++ b/src/org/traccar/protocol/RuptelaProtocol.java
@@ -28,7 +28,7 @@ public class RuptelaProtocol extends BaseProtocol {
 
     public RuptelaProtocol() {
         super("ruptela");
-        setSupportedCommands(
+        setSupportedDataCommands(
                 Command.TYPE_CUSTOM);
     }
 

--- a/src/org/traccar/protocol/SuntechProtocol.java
+++ b/src/org/traccar/protocol/SuntechProtocol.java
@@ -30,7 +30,7 @@ public class SuntechProtocol extends BaseProtocol {
 
     public SuntechProtocol() {
         super("suntech");
-        setSupportedCommands(
+        setSupportedDataCommands(
                 Command.TYPE_OUTPUT_CONTROL,
                 Command.TYPE_REBOOT_DEVICE,
                 Command.TYPE_POSITION_SINGLE,

--- a/src/org/traccar/protocol/T800xProtocol.java
+++ b/src/org/traccar/protocol/T800xProtocol.java
@@ -28,7 +28,7 @@ public class T800xProtocol extends BaseProtocol {
 
     public T800xProtocol() {
         super("t800x");
-        setSupportedCommands(
+        setSupportedDataCommands(
                 Command.TYPE_CUSTOM);
     }
 

--- a/src/org/traccar/protocol/TeltonikaProtocol.java
+++ b/src/org/traccar/protocol/TeltonikaProtocol.java
@@ -28,7 +28,7 @@ public class TeltonikaProtocol extends BaseProtocol {
 
     public TeltonikaProtocol() {
         super("teltonika");
-        setSupportedCommands(
+        setSupportedDataCommands(
                 Command.TYPE_CUSTOM);
     }
 

--- a/src/org/traccar/protocol/TotemProtocol.java
+++ b/src/org/traccar/protocol/TotemProtocol.java
@@ -29,7 +29,7 @@ public class TotemProtocol extends BaseProtocol {
 
     public TotemProtocol() {
         super("totem");
-        setSupportedCommands(
+        setSupportedDataCommands(
                 Command.TYPE_ENGINE_RESUME,
                 Command.TYPE_ENGINE_STOP
         );

--- a/src/org/traccar/protocol/WatchProtocol.java
+++ b/src/org/traccar/protocol/WatchProtocol.java
@@ -30,7 +30,7 @@ public class WatchProtocol extends BaseProtocol {
 
     public WatchProtocol() {
         super("watch");
-        setSupportedCommands(
+        setSupportedDataCommands(
                 Command.TYPE_POSITION_SINGLE,
                 Command.TYPE_POSITION_PERIODIC,
                 Command.TYPE_SOS_NUMBER,

--- a/src/org/traccar/protocol/WialonProtocol.java
+++ b/src/org/traccar/protocol/WialonProtocol.java
@@ -32,7 +32,7 @@ public class WialonProtocol extends BaseProtocol {
 
     public WialonProtocol() {
         super("wialon");
-        setSupportedCommands(
+        setSupportedDataCommands(
                 Command.TYPE_REBOOT_DEVICE,
                 Command.TYPE_SEND_USSD,
                 Command.TYPE_IDENTIFICATION,

--- a/src/org/traccar/protocol/WondexProtocol.java
+++ b/src/org/traccar/protocol/WondexProtocol.java
@@ -29,12 +29,8 @@ public class WondexProtocol extends BaseProtocol {
 
     public WondexProtocol() {
         super("wondex");
+        setTextCommandEncoder(new WondexProtocolEncoder());
         setSupportedCommands(
-                Command.TYPE_REBOOT_DEVICE,
-                Command.TYPE_POSITION_SINGLE,
-                Command.TYPE_IDENTIFICATION);
-        setSmsEncoder(new WondexProtocolEncoder());
-        setSupportedSmsCommands(
                 Command.TYPE_REBOOT_DEVICE,
                 Command.TYPE_POSITION_SINGLE,
                 Command.TYPE_IDENTIFICATION);

--- a/src/org/traccar/protocol/XexunProtocol.java
+++ b/src/org/traccar/protocol/XexunProtocol.java
@@ -31,7 +31,7 @@ public class XexunProtocol extends BaseProtocol {
 
     public XexunProtocol() {
         super("xexun");
-        setSupportedCommands(
+        setSupportedDataCommands(
                 Command.TYPE_ENGINE_STOP,
                 Command.TYPE_ENGINE_RESUME);
     }


### PR DESCRIPTION
Mostly renaming functions and variables
The only thing was added is `setSupportedCommands` to set both types if they are the same.

Used `destAddress` instead of `phone` in `sendTextCommand` function, just not to lock on SMS as transport.