### PR TITLE
Date/Time Improvements

### DIFF
--- a/src/org/traccar/helper/Parser.java
+++ b/src/org/traccar/helper/Parser.java
@@ -180,8 +180,6 @@ public class Parser {
         DMY_HMSS,    // DDMMYYYYHHMMSS.sss or DDMMYYHHMMSS.sss
         YMD_HMS,     // YYYYMMDDHHMMSS or YYMMDDHHMMSS
         YMD_HMSS,    // YYYYMMDDHHMMSS.sss or YYMMDDHHMMSS.sss
-
-        ISO8601      // YYYY-MM-DDTHH:MM:SS+HH:MM
     }
 
     private static final DateTimeFormat DEFAULT_FORMAT = DateTimeFormat.YMD_HMS;
@@ -223,23 +221,14 @@ public class Parser {
                 break;
             case YMD_HMS:
             case YMD_HMSS:
-            case ISO8601:
             default:
                 year = nextInt(radix); month = nextInt(radix); day = nextInt(radix); // (d{2}|d{4})(d{2})(d{2})
                 hour = nextInt(radix); minute = nextInt(radix); second = nextInt(radix); // (d{2})(d{2})(d{2})
                 break;
         }
 
-        switch (format) {
-            case YMD_HMSS:
-            case DMY_HMSS:
+        if (format == DateTimeFormat.YMD_HMSS || format == DateTimeFormat.DMY_HMSS) {
                 millisecond = nextInt(radix); // (ddd)
-                break;
-            case ISO8601:
-                timeZone = TimeZone.getTimeZone("GMT" + next()); // ([+-]d{2}:d{2})
-                break;
-            default:
-                break;
         }
 
         if (year >= 0 && year < 100) {

--- a/src/org/traccar/helper/Parser.java
+++ b/src/org/traccar/helper/Parser.java
@@ -171,32 +171,20 @@ public class Parser {
         HMS,         // HHMMSS
         SMH,         // SSMMHH
 
-        HMS_Y4MD,    // HHMMSSYYYYMMDD
-        HMS_Y2MD,    // HHMMSSYYMMDD
+        HMS_YMD,     // HHMMSSYYYYMMDD or HHMMSSYYMMDD
+        HMS_DMY,     // HHMMSSDDMMYYYY or HHMMSSDDMMYY
+        SMH_YMD,     // SSMMHHYYYYMMDD or SSMMHHYYMMDD
+        SMH_DMY,     // SSMMHHDDMMYYYY or SSMMHHDDMMYY
 
-        HMS_DMY4,    // HHMMSSDDMMYYYY
-        HMS_DMY2,    // HHMMSSDDMMYY
-
-        SMH_Y4MD,    // SSMMHHYYYYMMD
-        SMH_Y2MD,    // SSMMHHYYMMDD
-
-        SMH_DMY4,    // SSMMHHDDMMYYYY
-        SMH_DMY2,    // SSMMHHDDMMYY
-
-        DMY4_HMS,    // DDMMYYYYHHMMSS
-        DMY4_HMSms,  // DDMMYYYYHHMMSS.m+
-        DMY2_HMS,    // DDMMYYHHMMSS
-        DMY2_HMSms,  // DDMMYYHHMMSS.m+
-
-        Y4MD_HMS,    // YYYYMMDDHHMMSS
-        Y4MD_HMSms,  // YYYYMMDDHHMMSS.m+
-        Y2MD_HMS,    // YYMMDDHHMMSS
-        Y2MD_HMSms,  // YYMMDDHHMMSS.m+
+        DMY_HMS,     // DDMMYYYYHHMMSS or DDMMYYHHMMSS
+        DMY_HMSms,   // DDMMYYYYHHMMSS.sss or DDMMYYHHMMSS.sss
+        YMD_HMS,     // YYYYMMDDHHMMSS or YYMMDDHHMMSS
+        YMD_HMSms,   // YYYYMMDDHHMMSS.sss or YYMMDDHHMMSS.sss
 
         ISO8601      // YYYY-MM-DDTHH:MM:SS+HH:MM
     }
 
-    private static final DateTimeFormat DEFAULT_FORMAT = DateTimeFormat.Y4MD_HMS;
+    private static final DateTimeFormat DEFAULT_FORMAT = DateTimeFormat.YMD_HMS;
     private static final String DEFAULT_TZ = "UTC";
     private static final int DEFAULT_RADIX = 10;
 
@@ -212,37 +200,29 @@ public class Parser {
             case SMH:
                 second = nextInt(radix); minute = nextInt(radix); hour = nextInt(radix); // (d{2})(d{2})(d{2})
                 break;
-            case HMS_Y4MD:
-            case HMS_Y2MD:
+            case HMS_YMD:
                 hour = nextInt(radix); minute = nextInt(radix); second = nextInt(radix); // (d{2})(d{2})(d{2})
                 year = nextInt(radix); month = nextInt(radix); day = nextInt(radix); // (d{2}|d{4})(d{2})(d{2})
                 break;
-            case HMS_DMY4:
-            case HMS_DMY2:
+            case HMS_DMY:
                 hour = nextInt(radix); minute = nextInt(radix); second = nextInt(radix); // (d{2})(d{2})(d{2})
                 day = nextInt(radix); month = nextInt(radix); year = nextInt(radix); // (d{2})(d{2})(d{2}|d{4})
                 break;
-            case SMH_Y4MD:
-            case SMH_Y2MD:
+            case SMH_YMD:
                 second = nextInt(radix); minute = nextInt(radix); hour = nextInt(radix); // (d{2})(d{2})(d{2})
                 year = nextInt(radix); month = nextInt(radix); day = nextInt(radix); // (d{2}|d{4})(d{2})(d{2})
                 break;
-            case SMH_DMY4:
-            case SMH_DMY2:
+            case SMH_DMY:
                 second = nextInt(radix); minute = nextInt(radix); hour = nextInt(radix); // (d{2})(d{2})(d{2})
                 day = nextInt(radix); month = nextInt(radix); year = nextInt(radix); // (d{2})(d{2})(d{2}|d{4})
                 break;
-            case DMY4_HMS:
-            case DMY4_HMSms:
-            case DMY2_HMS:
-            case DMY2_HMSms:
+            case DMY_HMS:
+            case DMY_HMSms:
                 day = nextInt(radix); month = nextInt(radix); year = nextInt(radix); // (d{2})(d{2})(d{2}|d{4})
                 hour = nextInt(radix); minute = nextInt(radix); second = nextInt(radix); // (d{2})(d{2})(d{2})
                 break;
-            case Y4MD_HMS:
-            case Y4MD_HMSms:
-            case Y2MD_HMS:
-            case Y2MD_HMSms:
+            case YMD_HMS:
+            case YMD_HMSms:
             case ISO8601:
             default:
                 year = nextInt(radix); month = nextInt(radix); day = nextInt(radix); // (d{2}|d{4})(d{2})(d{2})
@@ -251,17 +231,9 @@ public class Parser {
         }
 
         switch (format) {
-            case HMS_Y2MD:
-            case HMS_DMY2:
-            case SMH_Y2MD:
-            case SMH_DMY2:
-            case DMY2_HMS:
-            case DMY2_HMSms:
-            case Y2MD_HMS:
-            case Y2MD_HMSms:
-                if (year >= 0 && year < 100) {
-                    year += 2000; // Future Y3K issue :)
-                }
+            case YMD_HMSms:
+            case DMY_HMSms:
+                millisecond = nextInt(radix); // (ddd)
                 break;
             case ISO8601:
                 timeZone = TimeZone.getTimeZone("GMT" + next()); // ([+-]d{2}:d{2})
@@ -270,15 +242,8 @@ public class Parser {
                 break;
         }
 
-        switch (format) {
-            case Y4MD_HMSms:
-            case Y2MD_HMSms:
-            case DMY4_HMSms:
-            case DMY2_HMSms:
-                millisecond = nextInt(radix); // (d+)
-                break;
-            default:
-                break;
+        if (year >= 0 && year < 100) {
+            year += 2000; // Future Y3K issue :)
         }
 
         DateBuilder dateBuilder = new DateBuilder(timeZone);

--- a/src/org/traccar/helper/Parser.java
+++ b/src/org/traccar/helper/Parser.java
@@ -177,9 +177,9 @@ public class Parser {
         SMH_DMY,     // SSMMHHDDMMYYYY or SSMMHHDDMMYY
 
         DMY_HMS,     // DDMMYYYYHHMMSS or DDMMYYHHMMSS
-        DMY_HMSms,   // DDMMYYYYHHMMSS.sss or DDMMYYHHMMSS.sss
+        DMY_HMSS,    // DDMMYYYYHHMMSS.sss or DDMMYYHHMMSS.sss
         YMD_HMS,     // YYYYMMDDHHMMSS or YYMMDDHHMMSS
-        YMD_HMSms,   // YYYYMMDDHHMMSS.sss or YYMMDDHHMMSS.sss
+        YMD_HMSS,    // YYYYMMDDHHMMSS.sss or YYMMDDHHMMSS.sss
 
         ISO8601      // YYYY-MM-DDTHH:MM:SS+HH:MM
     }
@@ -217,12 +217,12 @@ public class Parser {
                 day = nextInt(radix); month = nextInt(radix); year = nextInt(radix); // (d{2})(d{2})(d{2}|d{4})
                 break;
             case DMY_HMS:
-            case DMY_HMSms:
+            case DMY_HMSS:
                 day = nextInt(radix); month = nextInt(radix); year = nextInt(radix); // (d{2})(d{2})(d{2}|d{4})
                 hour = nextInt(radix); minute = nextInt(radix); second = nextInt(radix); // (d{2})(d{2})(d{2})
                 break;
             case YMD_HMS:
-            case YMD_HMSms:
+            case YMD_HMSS:
             case ISO8601:
             default:
                 year = nextInt(radix); month = nextInt(radix); day = nextInt(radix); // (d{2}|d{4})(d{2})(d{2})
@@ -231,8 +231,8 @@ public class Parser {
         }
 
         switch (format) {
-            case YMD_HMSms:
-            case DMY_HMSms:
+            case YMD_HMSS:
+            case DMY_HMSS:
                 millisecond = nextInt(radix); // (ddd)
                 break;
             case ISO8601:

--- a/src/org/traccar/helper/Parser.java
+++ b/src/org/traccar/helper/Parser.java
@@ -171,15 +171,15 @@ public class Parser {
         HMS,         // HHMMSS
         SMH,         // SSMMHH
 
-        HMS_YMD,     // HHMMSSYYYYMMDD or HHMMSSYYMMDD
-        HMS_DMY,     // HHMMSSDDMMYYYY or HHMMSSDDMMYY
-        SMH_YMD,     // SSMMHHYYYYMMDD or SSMMHHYYMMDD
-        SMH_DMY,     // SSMMHHDDMMYYYY or SSMMHHDDMMYY
+        HMS_YMD,     // HHMMSSYYYYMMDD      or  HHMMSSYYMMDD
+        HMS_DMY,     // HHMMSSDDMMYYYY      or  HHMMSSDDMMYY
+        SMH_YMD,     // SSMMHHYYYYMMDD      or  SSMMHHYYMMDD
+        SMH_DMY,     // SSMMHHDDMMYYYY      or  SSMMHHDDMMYY
 
-        DMY_HMS,     // DDMMYYYYHHMMSS or DDMMYYHHMMSS
-        DMY_HMSS,    // DDMMYYYYHHMMSS.sss or DDMMYYHHMMSS.sss
-        YMD_HMS,     // YYYYMMDDHHMMSS or YYMMDDHHMMSS
-        YMD_HMSS,    // YYYYMMDDHHMMSS.sss or YYMMDDHHMMSS.sss
+        DMY_HMS,     // DDMMYYYYHHMMSS      or  DDMMYYHHMMSS
+        DMY_HMSS,    // DDMMYYYYHHMMSS.sss  or  DDMMYYHHMMSS.sss
+        YMD_HMS,     // YYYYMMDDHHMMSS      or  YYMMDDHHMMSS
+        YMD_HMSS,    // YYYYMMDDHHMMSS.sss  or  YYMMDDHHMMSS.sss
     }
 
     private static final DateTimeFormat DEFAULT_FORMAT = DateTimeFormat.YMD_HMS;
@@ -193,37 +193,37 @@ public class Parser {
 
         switch (format) {
             case HMS:
-                hour = nextInt(radix); minute = nextInt(radix); second = nextInt(radix); // (d{2})(d{2})(d{2})
+                hour = nextInt(radix); minute = nextInt(radix); second = nextInt(radix);
                 break;
             case SMH:
-                second = nextInt(radix); minute = nextInt(radix); hour = nextInt(radix); // (d{2})(d{2})(d{2})
+                second = nextInt(radix); minute = nextInt(radix); hour = nextInt(radix);
                 break;
             case HMS_YMD:
-                hour = nextInt(radix); minute = nextInt(radix); second = nextInt(radix); // (d{2})(d{2})(d{2})
-                year = nextInt(radix); month = nextInt(radix); day = nextInt(radix); // (d{2}|d{4})(d{2})(d{2})
+                hour = nextInt(radix); minute = nextInt(radix); second = nextInt(radix);
+                year = nextInt(radix); month = nextInt(radix); day = nextInt(radix);
                 break;
             case HMS_DMY:
-                hour = nextInt(radix); minute = nextInt(radix); second = nextInt(radix); // (d{2})(d{2})(d{2})
-                day = nextInt(radix); month = nextInt(radix); year = nextInt(radix); // (d{2})(d{2})(d{2}|d{4})
+                hour = nextInt(radix); minute = nextInt(radix); second = nextInt(radix);
+                day = nextInt(radix); month = nextInt(radix); year = nextInt(radix);
                 break;
             case SMH_YMD:
-                second = nextInt(radix); minute = nextInt(radix); hour = nextInt(radix); // (d{2})(d{2})(d{2})
-                year = nextInt(radix); month = nextInt(radix); day = nextInt(radix); // (d{2}|d{4})(d{2})(d{2})
+                second = nextInt(radix); minute = nextInt(radix); hour = nextInt(radix);
+                year = nextInt(radix); month = nextInt(radix); day = nextInt(radix);
                 break;
             case SMH_DMY:
-                second = nextInt(radix); minute = nextInt(radix); hour = nextInt(radix); // (d{2})(d{2})(d{2})
-                day = nextInt(radix); month = nextInt(radix); year = nextInt(radix); // (d{2})(d{2})(d{2}|d{4})
+                second = nextInt(radix); minute = nextInt(radix); hour = nextInt(radix);
+                day = nextInt(radix); month = nextInt(radix); year = nextInt(radix);
                 break;
             case DMY_HMS:
             case DMY_HMSS:
-                day = nextInt(radix); month = nextInt(radix); year = nextInt(radix); // (d{2})(d{2})(d{2}|d{4})
-                hour = nextInt(radix); minute = nextInt(radix); second = nextInt(radix); // (d{2})(d{2})(d{2})
+                day = nextInt(radix); month = nextInt(radix); year = nextInt(radix);
+                hour = nextInt(radix); minute = nextInt(radix); second = nextInt(radix);
                 break;
             case YMD_HMS:
             case YMD_HMSS:
             default:
-                year = nextInt(radix); month = nextInt(radix); day = nextInt(radix); // (d{2}|d{4})(d{2})(d{2})
-                hour = nextInt(radix); minute = nextInt(radix); second = nextInt(radix); // (d{2})(d{2})(d{2})
+                year = nextInt(radix); month = nextInt(radix); day = nextInt(radix);
+                hour = nextInt(radix); minute = nextInt(radix); second = nextInt(radix);
                 break;
         }
 
@@ -232,7 +232,7 @@ public class Parser {
         }
 
         if (year >= 0 && year < 100) {
-            year += 2000; // Future Y3K issue :)
+            year += 2000;
         }
 
         DateBuilder dateBuilder = new DateBuilder(timeZone);

--- a/src/org/traccar/protocol/AppelloProtocolDecoder.java
+++ b/src/org/traccar/protocol/AppelloProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.Position;
@@ -71,10 +70,7 @@ public class AppelloProtocolDecoder extends BaseProtocolDecoder {
         position.setDeviceId(deviceSession.getDeviceId());
 
         if (parser.hasNext(6)) {
-            DateBuilder dateBuilder = new DateBuilder()
-                    .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                    .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-            position.setTime(dateBuilder.getDate());
+            position.setTime(parser.nextDateTime());
         } else {
             getLastLocation(position, null);
         }

--- a/src/org/traccar/protocol/AppelloProtocolDecoder.java
+++ b/src/org/traccar/protocol/AppelloProtocolDecoder.java
@@ -35,8 +35,8 @@ public class AppelloProtocolDecoder extends BaseProtocolDecoder {
             .text("FOLLOWIT,")                   // brand
             .number("(d+),")                     // imei
             .groupBegin()
-            .number("(dd)(dd)(dd)")              // date
-            .number("(dd)(dd)(dd).?d*,")         // time
+            .number("(dd)(dd)(dd)")              // date (yymmdd)
+            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss.ms)
             .or()
             .text("UTCTIME,")
             .groupEnd()

--- a/src/org/traccar/protocol/AppelloProtocolDecoder.java
+++ b/src/org/traccar/protocol/AppelloProtocolDecoder.java
@@ -36,7 +36,7 @@ public class AppelloProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+),")                     // imei
             .groupBegin()
             .number("(dd)(dd)(dd)")              // date (yymmdd)
-            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss.ms)
+            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss)
             .or()
             .text("UTCTIME,")
             .groupEnd()

--- a/src/org/traccar/protocol/AquilaProtocolDecoder.java
+++ b/src/org/traccar/protocol/AquilaProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
@@ -121,10 +120,7 @@ public class AquilaProtocolDecoder extends BaseProtocolDecoder {
         position.setLatitude(parser.nextDouble());
         position.setLongitude(parser.nextDouble());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
 
         position.setValid(parser.next().equals("A"));
 

--- a/src/org/traccar/protocol/AquilaProtocolDecoder.java
+++ b/src/org/traccar/protocol/AquilaProtocolDecoder.java
@@ -120,7 +120,7 @@ public class AquilaProtocolDecoder extends BaseProtocolDecoder {
         position.setLatitude(parser.nextDouble());
         position.setLongitude(parser.nextDouble());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
+        position.setTime(parser.nextDateTime());
 
         position.setValid(parser.next().equals("A"));
 

--- a/src/org/traccar/protocol/Ardi01ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Ardi01ProtocolDecoder.java
@@ -34,8 +34,8 @@ public class Ardi01ProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN = new PatternBuilder()
             .number("(d+),")                     // imei
-            .number("(dddd)(dd)(dd)")            // date
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dddd)(dd)(dd)")            // date (yyyymmdd)
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("(-?d+.d+),")                // longitude
             .number("(-?d+.d+),")                // latitude
             .number("(d+.?d*),")                 // speed

--- a/src/org/traccar/protocol/Ardi01ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Ardi01ProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
@@ -66,10 +65,7 @@ public class Ardi01ProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(deviceSession.getDeviceId());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime());
 
         position.setLongitude(parser.nextDouble());
         position.setLatitude(parser.nextDouble());

--- a/src/org/traccar/protocol/ArknavProtocolDecoder.java
+++ b/src/org/traccar/protocol/ArknavProtocolDecoder.java
@@ -75,7 +75,7 @@ public class ArknavProtocolDecoder extends BaseProtocolDecoder {
 
         position.set(Position.KEY_HDOP, parser.nextDouble());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY2));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY));
 
         return position;
     }

--- a/src/org/traccar/protocol/ArknavProtocolDecoder.java
+++ b/src/org/traccar/protocol/ArknavProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.Position;
@@ -45,8 +44,8 @@ public class ArknavProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+.?d*),")                 // speed
             .number("(d+.?d*),")                 // course
             .number("(d+.?d*),")                 // hdop
-            .number("(dd):(dd):(dd) ")           // time
-            .number("(dd)-(dd)-(dd),")           // date
+            .number("(dd):(dd):(dd) ")           // time (hh:mm:ss)
+            .number("(dd)-(dd)-(dd),")           // date (dd-mm-yy)
             .any()
             .compile();
 
@@ -76,10 +75,7 @@ public class ArknavProtocolDecoder extends BaseProtocolDecoder {
 
         position.set(Position.KEY_HDOP, parser.nextDouble());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY2));
 
         return position;
     }

--- a/src/org/traccar/protocol/ArknavX8ProtocolDecoder.java
+++ b/src/org/traccar/protocol/ArknavX8ProtocolDecoder.java
@@ -71,7 +71,7 @@ public class ArknavX8ProtocolDecoder extends BaseProtocolDecoder {
 
         position.set(Position.KEY_TYPE, parser.next());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
+        position.setTime(parser.nextDateTime());
 
         position.setValid(parser.next().equals("A"));
         position.setLatitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/ArknavX8ProtocolDecoder.java
+++ b/src/org/traccar/protocol/ArknavX8ProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.Position;
@@ -35,7 +34,7 @@ public class ArknavX8ProtocolDecoder extends BaseProtocolDecoder {
     private static final Pattern PATTERN = new PatternBuilder()
             .expression("(..),")                 // type
             .number("(dd)(dd)(dd)")              // date (yymmdd)
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .expression("([AV]),")               // validity
             .number("(d+)(dd.d+)([NS]),")        // latitude
             .number("(d+)(dd.d+)([EW]),")        // longitude
@@ -72,10 +71,7 @@ public class ArknavX8ProtocolDecoder extends BaseProtocolDecoder {
 
         position.set(Position.KEY_TYPE, parser.next());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
 
         position.setValid(parser.next().equals("A"));
         position.setLatitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/ArnaviProtocolDecoder.java
+++ b/src/org/traccar/protocol/ArnaviProtocolDecoder.java
@@ -47,12 +47,12 @@ public class ArnaviProtocolDecoder extends BaseProtocolDecoder {
             .number("d+,d+,").optional()         // input 2
             .expression("[01],")                 // fix type
             .number("(d+),")                     // satellites
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("(dd)(dd.d+)([NS]),")        // latitude
             .number("(ddd)(dd.d+)([EW]),")       // longitude
             .number("(d+.d+),")                  // speed
             .number("(d+.d+),")                  // course
-            .number("(dd)(dd)(dd)")              // date
+            .number("(dd)(dd)(dd)")              // date (ddmmyy)
             .any()
             .compile();
 

--- a/src/org/traccar/protocol/AuroProtocolDecoder.java
+++ b/src/org/traccar/protocol/AuroProtocolDecoder.java
@@ -77,7 +77,7 @@ public class AuroProtocolDecoder extends BaseProtocolDecoder {
         position.setLongitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN_MIN));
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN_MIN));
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY4_HMS));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY_HMS));
 
         position.setCourse(parser.nextDouble());
         position.setSpeed(UnitsConverter.knotsFromKph(parser.nextDouble()));

--- a/src/org/traccar/protocol/AuroProtocolDecoder.java
+++ b/src/org/traccar/protocol/AuroProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
@@ -44,8 +43,8 @@ public class AuroProtocolDecoder extends BaseProtocolDecoder {
             .number("d{10}")                     // status
             .number("([-+])(ddd)(dd)(dddd)")     // longitude
             .number("([-+])(ddd)(dd)(dddd)")     // latitude
-            .number("(dd)(dd)(dddd)")            // date
-            .number("(dd)(dd)(dd)")              // time
+            .number("(dd)(dd)(dddd)")            // date (ddmmyyyy)
+            .number("(dd)(dd)(dd)")              // time (hhmmss)
             .number("(ddd)")                     // course
             .number("d{6}")
             .number("(ddd)")                     // speed
@@ -78,10 +77,7 @@ public class AuroProtocolDecoder extends BaseProtocolDecoder {
         position.setLongitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN_MIN));
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN_MIN));
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY4_HMS));
 
         position.setCourse(parser.nextDouble());
         position.setSpeed(UnitsConverter.knotsFromKph(parser.nextDouble()));

--- a/src/org/traccar/protocol/AutoGradeProtocolDecoder.java
+++ b/src/org/traccar/protocol/AutoGradeProtocolDecoder.java
@@ -37,12 +37,12 @@ public class AutoGradeProtocolDecoder extends BaseProtocolDecoder {
             .text("(")
             .number("d{12}")                     // index
             .number("(d{15})")                   // imei
-            .number("(dd)(dd)(dd)")              // date
+            .number("(dd)(dd)(dd)")              // date (ddmmyy)
             .expression("([AV])")                // validity
             .number("(d+)(dd.d+)([NS])")         // latitude
             .number("(d+)(dd.d+)([EW])")         // longitude
             .number("([d.]{5})")                 // speed
-            .number("(dd)(dd)(dd)")              // time
+            .number("(dd)(dd)(dd)")              // time (hhmmss)
             .number("([d.]{6})")                 // course
             .expression("(.)")                   // status
             .number("A(xxxx)")

--- a/src/org/traccar/protocol/BoxProtocolDecoder.java
+++ b/src/org/traccar/protocol/BoxProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
@@ -35,8 +34,8 @@ public class BoxProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN = new PatternBuilder()
             .text("L,")
-            .number("(dd)(dd)(dd)")              // date
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd)")              // date (yymmdd)
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .text("G,")
             .number("(-?d+.d+),")                // latitude
             .number("(-?d+.d+),")                // longitude
@@ -82,10 +81,7 @@ public class BoxProtocolDecoder extends BaseProtocolDecoder {
             position.setDeviceId(deviceSession.getDeviceId());
             position.setProtocol(getProtocolName());
 
-            DateBuilder dateBuilder = new DateBuilder()
-                    .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                    .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-            position.setTime(dateBuilder.getDate());
+            position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
 
             position.setLatitude(parser.nextDouble());
             position.setLongitude(parser.nextDouble());

--- a/src/org/traccar/protocol/BoxProtocolDecoder.java
+++ b/src/org/traccar/protocol/BoxProtocolDecoder.java
@@ -81,7 +81,7 @@ public class BoxProtocolDecoder extends BaseProtocolDecoder {
             position.setDeviceId(deviceSession.getDeviceId());
             position.setProtocol(getProtocolName());
 
-            position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
+            position.setTime(parser.nextDateTime());
 
             position.setLatitude(parser.nextDouble());
             position.setLongitude(parser.nextDouble());

--- a/src/org/traccar/protocol/CarTrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/CarTrackProtocolDecoder.java
@@ -40,7 +40,7 @@ public class CarTrackProtocolDecoder extends BaseProtocolDecoder {
             .text("&A")
             .number("(dddd)")                    // command
             .text("&B")
-            .number("(dd)(dd)(dd).(ddd),")       // time (hhmmss.ms)
+            .number("(dd)(dd)(dd).(ddd),")       // time (hhmmss.sss)
             .expression("([AV]),")               // validity
             .number("(dd)(dd.dddd),")            // latitude
             .expression("([NS]),")

--- a/src/org/traccar/protocol/CarTrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/CarTrackProtocolDecoder.java
@@ -40,7 +40,7 @@ public class CarTrackProtocolDecoder extends BaseProtocolDecoder {
             .text("&A")
             .number("(dddd)")                    // command
             .text("&B")
-            .number("(dd)(dd)(dd).(ddd),")       // time
+            .number("(dd)(dd)(dd).(ddd),")       // time (hhmmss.ms)
             .expression("([AV]),")               // validity
             .number("(dd)(dd.dddd),")            // latitude
             .expression("([NS]),")

--- a/src/org/traccar/protocol/CarcellProtocolDecoder.java
+++ b/src/org/traccar/protocol/CarcellProtocolDecoder.java
@@ -21,7 +21,6 @@ import java.util.regex.Pattern;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.Parser.CoordinateFormat;
 import org.traccar.helper.PatternBuilder;
@@ -57,8 +56,8 @@ public class CarcellProtocolDecoder extends BaseProtocolDecoder {
             .number("(d),")                      // jamming
             .number("(d+),")                     // hdop
             .expression("([CG]),?")                // clock type
-            .number("(dd)(dd)(dd),")             // date
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd),")             // date (ddmmyy)
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("(d),")                      // block
             .number("(d),")                      // ignition
             .groupBegin()
@@ -129,10 +128,7 @@ public class CarcellProtocolDecoder extends BaseProtocolDecoder {
 
         position.set("clockType", parser.next());
 
-        DateBuilder dateBuilder = new DateBuilder().
-                setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
 
         position.set("blocked", parser.next().equals("1"));
         position.set(Position.KEY_IGNITION, parser.next().equals("1"));

--- a/src/org/traccar/protocol/CarcellProtocolDecoder.java
+++ b/src/org/traccar/protocol/CarcellProtocolDecoder.java
@@ -128,7 +128,7 @@ public class CarcellProtocolDecoder extends BaseProtocolDecoder {
 
         position.set("clockType", parser.next());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY_HMS));
 
         position.set("blocked", parser.next().equals("1"));
         position.set(Position.KEY_IGNITION, parser.next().equals("1"));

--- a/src/org/traccar/protocol/CarcellProtocolDecoder.java
+++ b/src/org/traccar/protocol/CarcellProtocolDecoder.java
@@ -66,7 +66,7 @@ public class CarcellProtocolDecoder extends BaseProtocolDecoder {
             .number("(d),")                      // painel
             .number("(d+),")                     // battery voltage
             .or()
-            .number("(dd),")                     // time
+            .number("(dd),")                     // time until delivery
             .expression("([AF])")                // panic
             .number("(d),")                      // aux
             .number("(d{2,4}),")                 // battery voltage

--- a/src/org/traccar/protocol/CarscopProtocolDecoder.java
+++ b/src/org/traccar/protocol/CarscopProtocolDecoder.java
@@ -35,7 +35,7 @@ public class CarscopProtocolDecoder extends BaseProtocolDecoder {
     private static final Pattern PATTERN = new PatternBuilder()
             .text("*")
             .any()
-            .number("(dd)(dd)(dd)")              // time
+            .number("(dd)(dd)(dd)")              // time (hhmmss)
             .expression("([AV])")                // validity
             .number("(dd)(dd.dddd)")             // latitude
             .expression("([NS])")

--- a/src/org/traccar/protocol/CguardProtocolDecoder.java
+++ b/src/org/traccar/protocol/CguardProtocolDecoder.java
@@ -62,7 +62,7 @@ public class CguardProtocolDecoder extends BaseProtocolDecoder {
         position.setProtocol(getProtocolName());
         position.setDeviceId(deviceSession.getDeviceId());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
+        position.setTime(parser.nextDateTime());
 
         position.setValid(true);
         position.setLatitude(parser.nextDouble());
@@ -88,7 +88,7 @@ public class CguardProtocolDecoder extends BaseProtocolDecoder {
         position.setProtocol(getProtocolName());
         position.setDeviceId(deviceSession.getDeviceId());
 
-        getLastLocation(position, parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
+        getLastLocation(position, parser.nextDateTime());
 
         String[] data = parser.next().split(":");
         for (int i = 0; i < data.length / 2; i++) {

--- a/src/org/traccar/protocol/CguardProtocolDecoder.java
+++ b/src/org/traccar/protocol/CguardProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
@@ -35,8 +34,8 @@ public class CguardProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN_NV = new PatternBuilder()
             .text("NV:")
-            .number("(dd)(dd)(dd) ")             // date
-            .number("(dd)(dd)(dd):")             // time
+            .number("(dd)(dd)(dd) ")             // date (yymmdd)
+            .number("(dd)(dd)(dd):")             // time (hhmmss)
             .number("(-?d+.d+):")                // longitude
             .number("(-?d+.d+):")                // latitude
             .number("(d+.?d*):")                 // speed
@@ -47,8 +46,8 @@ public class CguardProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN_BC = new PatternBuilder()
             .text("BC:")
-            .number("(dd)(dd)(dd) ")             // date
-            .number("(dd)(dd)(dd):")             // time
+            .number("(dd)(dd)(dd) ")             // date (yymmdd)
+            .number("(dd)(dd)(dd):")             // time (hhmmss)
             .expression("(.+)")                  // data
             .compile();
 
@@ -63,10 +62,7 @@ public class CguardProtocolDecoder extends BaseProtocolDecoder {
         position.setProtocol(getProtocolName());
         position.setDeviceId(deviceSession.getDeviceId());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
 
         position.setValid(true);
         position.setLatitude(parser.nextDouble());
@@ -92,11 +88,7 @@ public class CguardProtocolDecoder extends BaseProtocolDecoder {
         position.setProtocol(getProtocolName());
         position.setDeviceId(deviceSession.getDeviceId());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-
-        getLastLocation(position, dateBuilder.getDate());
+        getLastLocation(position, parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
 
         String[] data = parser.next().split(":");
         for (int i = 0; i < data.length / 2; i++) {

--- a/src/org/traccar/protocol/CityeasyProtocolDecoder.java
+++ b/src/org/traccar/protocol/CityeasyProtocolDecoder.java
@@ -21,7 +21,6 @@ import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
 import org.traccar.helper.Checksum;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.CellTower;
@@ -40,8 +39,8 @@ public class CityeasyProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN = new PatternBuilder()
             .groupBegin()
-            .number("(dddd)(dd)(dd)")            // date
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dddd)(dd)(dd)")            // date (yyyymmdd)
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("([AV]),")                   // validity
             .number("(d+),")                     // satellites
             .number("([NS]),(d+.d+),")           // latitude
@@ -98,10 +97,7 @@ public class CityeasyProtocolDecoder extends BaseProtocolDecoder {
 
             if (parser.hasNext(15)) {
 
-                DateBuilder dateBuilder = new DateBuilder()
-                        .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                        .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-                position.setTime(dateBuilder.getDate());
+                position.setTime(parser.nextDateTime());
 
                 position.setValid(parser.next().equals("A"));
                 position.set(Position.KEY_SATELLITES, parser.next());

--- a/src/org/traccar/protocol/CradlepointProtocolDecoder.java
+++ b/src/org/traccar/protocol/CradlepointProtocolDecoder.java
@@ -18,13 +18,11 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.Position;
 
 import java.net.SocketAddress;
-import java.util.Date;
 import java.util.regex.Pattern;
 
 public class CradlepointProtocolDecoder extends BaseProtocolDecoder {
@@ -35,7 +33,7 @@ public class CradlepointProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN = new PatternBuilder()
             .expression("([^,]+),")              // id
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("(d+)(dd.d+),")              // latitude
             .expression("([NS]),")
             .number("(d+)(dd.d+),")              // longitude
@@ -69,9 +67,7 @@ public class CradlepointProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(deviceSession.getDeviceId());
 
-        DateBuilder dateBuilder = new DateBuilder(new Date())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMS));
 
         position.setValid(true);
         position.setLatitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/DishaProtocolDecoder.java
+++ b/src/org/traccar/protocol/DishaProtocolDecoder.java
@@ -76,7 +76,7 @@ public class DishaProtocolDecoder extends BaseProtocolDecoder {
 
         position.setValid(parser.next().equals("A"));
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY2));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY));
 
         position.setLatitude(parser.nextCoordinate());
         position.setLongitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/DishaProtocolDecoder.java
+++ b/src/org/traccar/protocol/DishaProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.Position;
@@ -36,7 +35,7 @@ public class DishaProtocolDecoder extends BaseProtocolDecoder {
             .text("$A#A#")
             .number("(d+)#")                     // imei
             .expression("([AVMX])#")             // validity
-            .number("(dd)(dd)(dd)#")             // time
+            .number("(dd)(dd)(dd)#")             // time (hhmmss)
             .number("(dd)(dd)(dd)#")             // date (ddmmyy)
             .number("(dd)(dd.d+)#")              // latitude
             .expression("([NS])#")
@@ -77,10 +76,7 @@ public class DishaProtocolDecoder extends BaseProtocolDecoder {
 
         position.setValid(parser.next().equals("A"));
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY2));
 
         position.setLatitude(parser.nextCoordinate());
         position.setLongitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/EasyTrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/EasyTrackProtocolDecoder.java
@@ -74,7 +74,7 @@ public class EasyTrackProtocolDecoder extends BaseProtocolDecoder {
 
         position.setValid(parser.next().equals("A"));
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS, 16));
+        position.setTime(parser.nextDateTime(16));
 
         if (BitUtil.check(parser.nextInt(16), 3)) {
             position.setLatitude(-parser.nextInt(16) / 600000.0);

--- a/src/org/traccar/protocol/EasyTrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/EasyTrackProtocolDecoder.java
@@ -19,7 +19,6 @@ import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
 import org.traccar.helper.BitUtil;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.Position;
@@ -38,16 +37,10 @@ public class EasyTrackProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+),")                     // imei
             .expression("([^,]{2}),")            // command
             .expression("([AV]),")               // validity
-            .number("(xx)")                      // year
-            .number("(xx)")                      // month
-            .number("(xx),")                     // day
-            .number("(xx)")                      // hours
-            .number("(xx)")                      // minutes
-            .number("(xx),")                     // seconds
-            .number("(x)")
-            .number("(x{7}),")                   // latitude
-            .number("(x)")
-            .number("(x{7}),")                   // longitude
+            .number("(xx)(xx)(xx),")             // date (yymmdd)
+            .number("(xx)(xx)(xx),")             // time (hhmmss)
+            .number("(x)(x{7}),")                // latitude
+            .number("(x)(x{7}),")                // longitude
             .number("(x{4}),")                   // speed
             .number("(x{4}),")                   // course
             .number("(x{8}),")                   // status
@@ -81,10 +74,7 @@ public class EasyTrackProtocolDecoder extends BaseProtocolDecoder {
 
         position.setValid(parser.next().equals("A"));
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(16), parser.nextInt(16), parser.nextInt(16))
-                .setTime(parser.nextInt(16), parser.nextInt(16), parser.nextInt(16));
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS, 16));
 
         if (BitUtil.check(parser.nextInt(16), 3)) {
             position.setLatitude(-parser.nextInt(16) / 600000.0);

--- a/src/org/traccar/protocol/EnforaProtocolDecoder.java
+++ b/src/org/traccar/protocol/EnforaProtocolDecoder.java
@@ -38,7 +38,7 @@ public class EnforaProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN = new PatternBuilder()
             .text("GPRMC,")
-            .number("(dd)(dd)(dd).(ddd),")       // time (hhmmss.sss)
+            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss.sss)
             .expression("([AV]),")               // validity
             .number("(dd)(dd.d+),")              // latitude
             .expression("([NS]),")
@@ -100,7 +100,7 @@ public class EnforaProtocolDecoder extends BaseProtocolDecoder {
         position.setDeviceId(deviceSession.getDeviceId());
 
         DateBuilder dateBuilder = new DateBuilder()
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt(), parser.nextInt());
+                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
 
         position.setValid(parser.next().equals("A"));
         position.setLatitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/EnforaProtocolDecoder.java
+++ b/src/org/traccar/protocol/EnforaProtocolDecoder.java
@@ -38,7 +38,7 @@ public class EnforaProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN = new PatternBuilder()
             .text("GPRMC,")
-            .number("(dd)(dd)(dd).(d+),")        // time
+            .number("(dd)(dd)(dd).(d+),")        // time (hhmmss.ms)
             .expression("([AV]),")               // validity
             .number("(dd)(dd.d+),")              // latitude
             .expression("([NS]),")

--- a/src/org/traccar/protocol/EnforaProtocolDecoder.java
+++ b/src/org/traccar/protocol/EnforaProtocolDecoder.java
@@ -38,7 +38,7 @@ public class EnforaProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN = new PatternBuilder()
             .text("GPRMC,")
-            .number("(dd)(dd)(dd).(d+),")        // time (hhmmss.ms)
+            .number("(dd)(dd)(dd).(ddd),")       // time (hhmmss.sss)
             .expression("([AV]),")               // validity
             .number("(dd)(dd.d+),")              // latitude
             .expression("([NS]),")

--- a/src/org/traccar/protocol/EnforaProtocolDecoder.java
+++ b/src/org/traccar/protocol/EnforaProtocolDecoder.java
@@ -38,7 +38,7 @@ public class EnforaProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN = new PatternBuilder()
             .text("GPRMC,")
-            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss.sss)
+            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss)
             .expression("([AV]),")               // validity
             .number("(dd)(dd.d+),")              // latitude
             .expression("([NS]),")

--- a/src/org/traccar/protocol/ExtremTracProtocolDecoder.java
+++ b/src/org/traccar/protocol/ExtremTracProtocolDecoder.java
@@ -35,7 +35,7 @@ public class ExtremTracProtocolDecoder extends BaseProtocolDecoder {
     private static final Pattern PATTERN = new PatternBuilder()
             .text("$GPRMC,")
             .number("(d+),")                     // device id
-            .number("(dd)(dd)(dd).d+,")          // time (hhmmss.ms)
+            .number("(dd)(dd)(dd).(ddd),")       // time (hhmmss.sss)
             .expression("([AV]),")               // validity
             .number("(d+)(dd.d+),")              // latitude
             .expression("([NS]),")
@@ -66,7 +66,7 @@ public class ExtremTracProtocolDecoder extends BaseProtocolDecoder {
         position.setDeviceId(deviceSession.getDeviceId());
 
         DateBuilder dateBuilder = new DateBuilder()
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
+                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt(), parser.nextInt());
 
         position.setValid(parser.next().equals("A"));
         position.setLatitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/ExtremTracProtocolDecoder.java
+++ b/src/org/traccar/protocol/ExtremTracProtocolDecoder.java
@@ -35,7 +35,7 @@ public class ExtremTracProtocolDecoder extends BaseProtocolDecoder {
     private static final Pattern PATTERN = new PatternBuilder()
             .text("$GPRMC,")
             .number("(d+),")                     // device id
-            .number("(dd)(dd)(dd).d+,")          // time
+            .number("(dd)(dd)(dd).d+,")          // time (hhmmss.ms)
             .expression("([AV]),")               // validity
             .number("(d+)(dd.d+),")              // latitude
             .expression("([NS]),")
@@ -43,7 +43,7 @@ public class ExtremTracProtocolDecoder extends BaseProtocolDecoder {
             .expression("([EW]),")
             .number("(d+.?d*),")                 // speed
             .number("(d+.?d*),")                 // course
-            .number("(dd)(dd)(dd),")             // date
+            .number("(dd)(dd)(dd),")             // date (ddmmyy)
             .any()
             .compile();
 

--- a/src/org/traccar/protocol/FifotrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/FifotrackProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
@@ -42,8 +41,8 @@ public class FifotrackProtocolDecoder extends BaseProtocolDecoder {
             .number("x+,")                       // index
             .expression("[^,]+,")                // type
             .number("(d+)?,")                    // alarm
-            .number("(dd)(dd)(dd)")              // date
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd)")              // date (yymmdd)
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("([AV]),")                   // validity
             .number("(-?d+.d+),")                // latitude
             .number("(-?d+.d+),")                // longitude
@@ -85,10 +84,7 @@ public class FifotrackProtocolDecoder extends BaseProtocolDecoder {
 
         position.set(Position.KEY_ALARM, parser.next());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
 
         position.setValid(parser.next().equals("A"));
         position.setLatitude(parser.nextDouble());

--- a/src/org/traccar/protocol/FifotrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/FifotrackProtocolDecoder.java
@@ -84,7 +84,7 @@ public class FifotrackProtocolDecoder extends BaseProtocolDecoder {
 
         position.set(Position.KEY_ALARM, parser.next());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
+        position.setTime(parser.nextDateTime());
 
         position.setValid(parser.next().equals("A"));
         position.setLatitude(parser.nextDouble());

--- a/src/org/traccar/protocol/FlextrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/FlextrackProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
@@ -45,8 +44,8 @@ public class FlextrackProtocolDecoder extends BaseProtocolDecoder {
     private static final Pattern PATTERN = new PatternBuilder()
             .number("(-?d+),")                   // index
             .text("UNITSTAT,")
-            .number("(dddd)(dd)(dd),")           // date
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dddd)(dd)(dd),")           // date (yyyymmdd)
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("d+,")                       // node id
             .number("([NS])(d+).(d+.d+),")       // latitude
             .number("([EW])(d+).(d+.d+),")       // longitude
@@ -110,10 +109,7 @@ public class FlextrackProtocolDecoder extends BaseProtocolDecoder {
 
             sendAcknowledgement(channel, parser.next());
 
-            DateBuilder dateBuilder = new DateBuilder()
-                    .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                    .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-            position.setTime(dateBuilder.getDate());
+            position.setTime(parser.nextDateTime());
 
             position.setValid(true);
             position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN));

--- a/src/org/traccar/protocol/FoxProtocolDecoder.java
+++ b/src/org/traccar/protocol/FoxProtocolDecoder.java
@@ -96,7 +96,7 @@ public class FoxProtocolDecoder extends BaseProtocolDecoder {
 
             position.setValid(parser.next().equals("A"));
 
-            position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
+            position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY_HMS));
             position.setLatitude(parser.nextCoordinate());
             position.setLongitude(parser.nextCoordinate());
             position.setSpeed(UnitsConverter.knotsFromKph(parser.nextDouble()));

--- a/src/org/traccar/protocol/FoxProtocolDecoder.java
+++ b/src/org/traccar/protocol/FoxProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
@@ -36,8 +35,8 @@ public class FoxProtocolDecoder extends BaseProtocolDecoder {
     private static final Pattern PATTERN = new PatternBuilder()
             .number("(d+),")                     // status id
             .expression("([AV]),")               // validity
-            .number("(dd)(dd)(dd),")             // date
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd),")             // date (ddmmyy)
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("(dd)(dd.d+),")              // latitude
             .expression("([NS]),")
             .number("(ddd)(dd.d+),")             // longitude
@@ -97,11 +96,7 @@ public class FoxProtocolDecoder extends BaseProtocolDecoder {
 
             position.setValid(parser.next().equals("A"));
 
-            DateBuilder dateBuilder = new DateBuilder()
-                    .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                    .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-            position.setTime(dateBuilder.getDate());
-
+            position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
             position.setLatitude(parser.nextCoordinate());
             position.setLongitude(parser.nextCoordinate());
             position.setSpeed(UnitsConverter.knotsFromKph(parser.nextDouble()));

--- a/src/org/traccar/protocol/FreedomProtocolDecoder.java
+++ b/src/org/traccar/protocol/FreedomProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.Position;
@@ -35,8 +34,8 @@ public class FreedomProtocolDecoder extends BaseProtocolDecoder {
     private static final Pattern PATTERN = new PatternBuilder()
             .text("IMEI,")
             .number("(d+),")                     // imei
-            .number("(dddd)/(dd)/(dd), ")        // date
-            .number("(dd):(dd):(dd), ")          // time
+            .number("(dddd)/(dd)/(dd), ")        // date (yyyy/dd/mm)
+            .number("(dd):(dd):(dd), ")          // time (hh:mm:ss)
             .expression("([NS]), ")
             .number("Lat:(dd)(d+.d+), ")         // latitude
             .expression("([EW]), ")
@@ -65,10 +64,7 @@ public class FreedomProtocolDecoder extends BaseProtocolDecoder {
 
         position.setValid(true);
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime());
 
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN));
         position.setLongitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN));

--- a/src/org/traccar/protocol/Gl100ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gl100ProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.Position;
@@ -50,8 +49,8 @@ public class Gl100ProtocolDecoder extends BaseProtocolDecoder {
             .number("d*,")                       // gps accuracy
             .number("(-?d+.d+),")                // longitude
             .number("(-?d+.d+),")                // latitude
-            .number("(dddd)(dd)(dd)")            // date
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dddd)(dd)(dd)")            // date (yyyymmdd)
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .any()
             .compile();
 
@@ -89,10 +88,7 @@ public class Gl100ProtocolDecoder extends BaseProtocolDecoder {
         position.setLongitude(parser.nextDouble());
         position.setLatitude(parser.nextDouble());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime());
 
         return position;
     }

--- a/src/org/traccar/protocol/Gl200ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gl200ProtocolDecoder.java
@@ -20,7 +20,6 @@ import org.traccar.BaseProtocolDecoder;
 import org.traccar.Context;
 import org.traccar.DeviceSession;
 import org.traccar.helper.BitUtil;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
@@ -30,6 +29,7 @@ import org.traccar.model.Position;
 import org.traccar.model.WifiAccessPoint;
 
 import java.net.SocketAddress;
+import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -47,8 +47,8 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
             .number("([0-9A-Z]{2}xxxx),")        // protocol version
             .number("(d{15}|x{14}),")            // imei
             .any().text(",")
-            .number("(dddd)(dd)(dd)")            // date
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dddd)(dd)(dd)")            // date (yyyymmdd)
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("(xxxx)")                    // counter
             .text("$").optional()
             .compile();
@@ -86,8 +86,8 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
             .number("[-+]dddd,")                 // timezone
             .expression("[01],")                 // daylight saving
             .groupEnd()
-            .number("(dddd)(dd)(dd)")            // date
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dddd)(dd)(dd)")            // date (yyyymmdd)
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("(xxxx)")                    // counter
             .text("$").optional()
             .compile();
@@ -100,8 +100,8 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
             .expression("([^,]*),")              // device type
             .number("(xxxx),")                   // firmware version
             .number("(xxxx),")                   // hardware version
-            .number("(dddd)(dd)(dd)")            // date
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dddd)(dd)(dd)")            // date (yyyymmdd)
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("(xxxx)")                    // counter
             .text("$").optional()
             .compile();
@@ -113,8 +113,8 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
             .number("(-?d{1,5}.d)?,")            // altitude
             .number("(-?d{1,3}.d{6})?,")         // longitude
             .number("(-?d{1,2}.d{6})?,")         // latitude
-            .number("(dddd)(dd)(dd)")            // date
-            .number("(dd)(dd)(dd)").optional(2)  // time
+            .number("(dddd)(dd)(dd)")            // date (yyyymmdd)
+            .number("(dd)(dd)(dd)").optional(2)  // time (hhmmss)
             .text(",")
             .groupBegin()
             .number("(0ddd)?,")                  // mcc
@@ -158,8 +158,8 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+),")                     // odometer
             .expression(PATTERN_LOCATION.pattern())
             .number("(d{1,7}.d)?,")              // odometer
-            .number("(dddd)(dd)(dd)")            // date
-            .number("(dd)(dd)(dd)").optional(2)  // time
+            .number("(dddd)(dd)(dd)")            // date (yyyymmdd)
+            .number("(dd)(dd)(dd)").optional(2)  // time (hhmmss)
             .text(",")
             .number("(xxxx)")                    // count number
             .text("$").optional()
@@ -191,8 +191,8 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
             .number("(?:d+.?d*|Inf|NaN)?,")      // fuel consumption
             .number("(d+)?,")                    // fuel level
             .groupEnd()
-            .number("(dddd)(dd)(dd)")            // date
-            .number("(dd)(dd)(dd)").optional(2)  // time
+            .number("(dddd)(dd)(dd)")            // date (yyyymmdd)
+            .number("(dd)(dd)(dd)").optional(2)  // time (hhmmss)
             .text(",")
             .number("(xxxx)")                    // count number
             .text("$").optional()
@@ -207,8 +207,8 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
             .expression(PATTERN_LOCATION.pattern())
             .number("(d{5}:dd:dd)?,")            // hour meter
             .number("(d{1,7}.d)?,")              // odometer
-            .number("(dddd)(dd)(dd)")            // date
-            .number("(dd)(dd)(dd)").optional(2)  // time
+            .number("(dddd)(dd)(dd)")            // date (yyyymmdd)
+            .number("(dd)(dd)(dd)").optional(2)  // time (hhmmss)
             .text(",")
             .number("(xxxx)")                    // count number
             .text("$").optional()
@@ -225,8 +225,8 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
             .expression(PATTERN_LOCATION.pattern())
             .number("(d+.d),")                   // odometer
             .text(",,,,")
-            .number("(dddd)(dd)(dd)")            // date
-            .number("(dd)(dd)(dd)").optional(2)  // time
+            .number("(dddd)(dd)(dd)")            // date (yyyymmdd)
+            .number("(dd)(dd)(dd)").optional(2)  // time (hhmmss)
             .text(",")
             .number("(xxxx)")                    // count number
             .text("$").optional()
@@ -240,8 +240,8 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+),")                     // count
             .number("((?:x{12},-?d+,,,,)+),,,,") // wifi
             .number("(d{1,3}),")                 // battery
-            .number("(dddd)(dd)(dd)")            // date
-            .number("(dd)(dd)(dd)").optional(2)  // time
+            .number("(dddd)(dd)(dd)")            // date (yyyymmdd)
+            .number("(dd)(dd)(dd)").optional(2)  // time (hhmmss)
             .text(",")
             .number("(xxxx)")                    // count number
             .text("$").optional()
@@ -262,8 +262,8 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
             .or()
             .number("(d{1,7}.d)?,")              // odometer
             .groupEnd()
-            .number("(dddd)(dd)(dd)")            // date
-            .number("(dd)(dd)(dd)").optional(2)  // time
+            .number("(dddd)(dd)(dd)")            // date (yyyymmdd)
+            .number("(dd)(dd)(dd)").optional(2)  // time (hhmmss)
             .text(",")
             .number("(xxxx)")                    // count number
             .text("$").optional()
@@ -281,16 +281,16 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
             .number("(-?d{1,5}.d)?,")            // altitude
             .number("(-?d{1,3}.d{6})?,")         // longitude
             .number("(-?d{1,2}.d{6})?,")         // latitude
-            .number("(dddd)(dd)(dd)")            // date
-            .number("(dd)(dd)(dd)").optional(2)  // time
+            .number("(dddd)(dd)(dd)")            // date (yyyymmdd)
+            .number("(dd)(dd)(dd)").optional(2)  // time (hhmmss)
             .text(",")
             .number("(0ddd),")                   // mcc
             .number("(0ddd),")                   // mnc
             .number("(xxxx),")                   // lac
             .number("(xxxx),").optional(4)       // cell
             .any()
-            .number("(dddd)(dd)(dd)")            // date
-            .number("(dd)(dd)(dd)").optional(2)  // time
+            .number("(dddd)(dd)(dd)")            // date (yyyymmdd)
+            .number("(dd)(dd)(dd)").optional(2)  // time (hhmmss)
             .text(",")
             .number("(xxxx)")                    // count number
             .text("$").optional()
@@ -313,10 +313,7 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
                 Position position = new Position();
                 position.setProtocol(getProtocolName());
                 position.setDeviceId(deviceSession.getDeviceId());
-                DateBuilder dateBuilder = new DateBuilder()
-                        .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                        .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-                getLastLocation(position, dateBuilder.getDate());
+                getLastLocation(position, parser.nextDateTime());
                 position.setValid(false);
                 position.set(Position.KEY_RESULT, "Command " + type + " accepted");
                 return position;
@@ -360,11 +357,7 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
         position.set(Position.KEY_INPUT, parser.next());
         position.set(Position.KEY_OUTPUT, parser.next());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-
-        getLastLocation(position, dateBuilder.getDate());
+        getLastLocation(position, parser.nextDateTime());
 
         position.set(Position.KEY_INDEX, parser.nextInt(16));
 
@@ -390,11 +383,7 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
         position.set(Position.KEY_VERSION_FW, parser.nextInt(16));
         position.set(Position.KEY_VERSION_HW, parser.nextInt(16));
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-
-        getLastLocation(position, dateBuilder.getDate());
+        getLastLocation(position, parser.nextDateTime());
 
         return position;
     }
@@ -412,11 +401,7 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
             position.setValid(true);
             position.setLongitude(parser.nextDouble());
             position.setLatitude(parser.nextDouble());
-
-            DateBuilder dateBuilder = new DateBuilder()
-                    .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                    .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-            position.setTime(dateBuilder.getDate());
+            position.setTime(parser.nextDateTime());
         } else {
             getLastLocation(position, null);
         }
@@ -463,11 +448,9 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
         position.set(Position.KEY_ODOMETER, parser.nextDouble() * 1000);
 
         if (parser.hasNext(6)) {
-            DateBuilder dateBuilder = new DateBuilder()
-                    .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                    .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-            if (!position.getOutdated() && position.getFixTime().after(dateBuilder.getDate())) {
-                position.setTime(dateBuilder.getDate());
+            Date date = parser.nextDateTime();
+            if (!position.getOutdated() && position.getFixTime().after(date)) {
+                position.setTime(date);
             }
         }
 
@@ -537,11 +520,9 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
 
         // workaround for wrong location time
         if (parser.hasNext(6)) {
-            DateBuilder dateBuilder = new DateBuilder()
-                    .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                    .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-            if (!position.getOutdated() && position.getFixTime().after(dateBuilder.getDate())) {
-                position.setTime(dateBuilder.getDate());
+            Date date = parser.nextDateTime();
+            if (!position.getOutdated() && position.getFixTime().after(date)) {
+                position.setTime(date);
             }
         }
 
@@ -569,11 +550,9 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
         position.set(Position.KEY_ODOMETER, parser.nextDouble() * 1000);
 
         if (parser.hasNext(6)) {
-            DateBuilder dateBuilder = new DateBuilder()
-                    .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                    .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-            if (!position.getOutdated() && position.getFixTime().after(dateBuilder.getDate())) {
-                position.setTime(dateBuilder.getDate());
+            Date date = parser.nextDateTime();
+            if (!position.getOutdated() && position.getFixTime().after(date)) {
+                position.setTime(date);
             }
         }
 
@@ -602,11 +581,9 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
         position.set(Position.KEY_ODOMETER, parser.nextDouble() * 1000);
 
         if (parser.hasNext(6)) {
-            DateBuilder dateBuilder = new DateBuilder()
-                    .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                    .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-            if (!position.getOutdated() && position.getFixTime().after(dateBuilder.getDate())) {
-                position.setTime(dateBuilder.getDate());
+            Date date = parser.nextDateTime();
+            if (!position.getOutdated() && position.getFixTime().after(date)) {
+                position.setTime(date);
             }
         }
 
@@ -678,11 +655,9 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
 
         // workaround for wrong location time
         if (parser.hasNext(6)) {
-            DateBuilder dateBuilder = new DateBuilder()
-                    .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                    .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-            if (!position.getOutdated() && position.getFixTime().after(dateBuilder.getDate())) {
-                position.setTime(dateBuilder.getDate());
+            Date date = parser.nextDateTime();
+            if (!position.getOutdated() && position.getFixTime().after(date)) {
+                position.setTime(date);
             }
         }
 
@@ -724,10 +699,7 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
         }
 
         if (parser.hasNext(6)) {
-            DateBuilder dateBuilder = new DateBuilder()
-                    .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                    .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-            position.setTime(dateBuilder.getDate());
+            position.setTime(parser.nextDateTime());
         }
 
         if (parser.hasNext(4)) {
@@ -736,11 +708,9 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
         }
 
         if (parser.hasNext(6)) {
-            DateBuilder dateBuilder = new DateBuilder()
-                    .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                    .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-            if (!position.getOutdated() && position.getFixTime().after(dateBuilder.getDate())) {
-                position.setTime(dateBuilder.getDate());
+            Date date = parser.nextDateTime();
+            if (!position.getOutdated() && position.getFixTime().after(date)) {
+                position.setTime(date);
             }
         }
 

--- a/src/org/traccar/protocol/GlobalSatProtocolDecoder.java
+++ b/src/org/traccar/protocol/GlobalSatProtocolDecoder.java
@@ -212,12 +212,7 @@ public class GlobalSatProtocolDecoder extends BaseProtocolDecoder {
         position.setDeviceId(deviceSession.getDeviceId());
 
         position.setValid(!parser.next().equals("1"));
-
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
-
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
         position.setLongitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN));
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN));
         position.setAltitude(parser.nextDouble());

--- a/src/org/traccar/protocol/GlobalSatProtocolDecoder.java
+++ b/src/org/traccar/protocol/GlobalSatProtocolDecoder.java
@@ -212,7 +212,7 @@ public class GlobalSatProtocolDecoder extends BaseProtocolDecoder {
         position.setDeviceId(deviceSession.getDeviceId());
 
         position.setValid(!parser.next().equals("1"));
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY_HMS));
         position.setLongitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN));
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN));
         position.setAltitude(parser.nextDouble());

--- a/src/org/traccar/protocol/GnxProtocolDecoder.java
+++ b/src/org/traccar/protocol/GnxProtocolDecoder.java
@@ -18,13 +18,11 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.Position;
 
 import java.net.SocketAddress;
-import java.util.TimeZone;
 import java.util.regex.Pattern;
 
 public class GnxProtocolDecoder extends BaseProtocolDecoder {
@@ -37,10 +35,10 @@ public class GnxProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+),")                     // imei
             .number("d+,")                       // length
             .expression("([01]),")               // history
-            .number("(dd)(dd)(dd),")             // device time
-            .number("(dd)(dd)(dd),")             // device date
-            .number("(dd)(dd)(dd),")             // fix time
-            .number("(dd)(dd)(dd),")             // fix date
+            .number("(dd)(dd)(dd),")             // device time (hhmmss)
+            .number("(dd)(dd)(dd),")             // device date (ddmmyy)
+            .number("(dd)(dd)(dd),")             // fix time (hhmmss)
+            .number("(dd)(dd)(dd),")             // fix date (ddmmyy)
             .number("(d),")                      // valid
             .number("(dd.d+),")                  // latitude
             .expression("([NS]),")
@@ -95,17 +93,8 @@ public class GnxProtocolDecoder extends BaseProtocolDecoder {
             position.set(Position.KEY_ARCHIVE, true);
         }
 
-        DateBuilder dateBuilder;
-
-        dateBuilder = new DateBuilder(TimeZone.getTimeZone("GMT+5:30"))
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setDeviceTime(dateBuilder.getDate());
-
-        dateBuilder = new DateBuilder(TimeZone.getTimeZone("GMT+5:30"))
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setFixTime(dateBuilder.getDate());
+        position.setDeviceTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY2, "GMT+5:30"));
+        position.setFixTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY2, "GMT+5:30"));
 
         position.setValid(parser.nextInt() != 0);
 

--- a/src/org/traccar/protocol/GnxProtocolDecoder.java
+++ b/src/org/traccar/protocol/GnxProtocolDecoder.java
@@ -93,8 +93,8 @@ public class GnxProtocolDecoder extends BaseProtocolDecoder {
             position.set(Position.KEY_ARCHIVE, true);
         }
 
-        position.setDeviceTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY2, "GMT+5:30"));
-        position.setFixTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY2, "GMT+5:30"));
+        position.setDeviceTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY, "GMT+5:30"));
+        position.setFixTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY, "GMT+5:30"));
 
         position.setValid(parser.nextInt() != 0);
 

--- a/src/org/traccar/protocol/GoSafeProtocolDecoder.java
+++ b/src/org/traccar/protocol/GoSafeProtocolDecoder.java
@@ -43,8 +43,8 @@ public class GoSafeProtocolDecoder extends BaseProtocolDecoder {
             .text("*GS")                         // header
             .number("d+,")                       // protocol version
             .number("(d+),")                     // imei
-            .number("(dd)(dd)(dd)")              // time
-            .number("(dd)(dd)(dd),")             // date
+            .number("(dd)(dd)(dd)")              // time (hhmmss)
+            .number("(dd)(dd)(dd),")             // date (ddmmyy)
             .expression("(.*)#?")                // data
             .compile();
 
@@ -242,10 +242,7 @@ public class GoSafeProtocolDecoder extends BaseProtocolDecoder {
 
             Date time = null;
             if (parser.hasNext(6)) {
-                DateBuilder dateBuilder = new DateBuilder()
-                        .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                        .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt());
-                time = dateBuilder.getDate();
+                time = parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY2);
             }
 
             List<Position> positions = new LinkedList<>();

--- a/src/org/traccar/protocol/GoSafeProtocolDecoder.java
+++ b/src/org/traccar/protocol/GoSafeProtocolDecoder.java
@@ -242,7 +242,7 @@ public class GoSafeProtocolDecoder extends BaseProtocolDecoder {
 
             Date time = null;
             if (parser.hasNext(6)) {
-                time = parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY2);
+                time = parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY);
             }
 
             List<Position> positions = new LinkedList<>();

--- a/src/org/traccar/protocol/GoSafeProtocolDecoder.java
+++ b/src/org/traccar/protocol/GoSafeProtocolDecoder.java
@@ -121,7 +121,7 @@ public class GoSafeProtocolDecoder extends BaseProtocolDecoder {
             .number("d+,")                       // protocol version
             .number("(d+),")                     // imei
             .text("GPS:")
-            .number("(dd)(dd)(dd);")             // time
+            .number("(dd)(dd)(dd);")             // time (hhmmss)
             .number("d;").optional()             // fix type
             .expression("([AV]);")               // validity
             .number("([NS])(d+.d+);")            // latitude
@@ -129,7 +129,7 @@ public class GoSafeProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+)?;")                    // speed
             .number("(d+);")                     // course
             .number("(d+.?d*)").optional()       // hdop
-            .number("(dd)(dd)(dd)")              // date
+            .number("(dd)(dd)(dd)")              // date (ddmmyy)
             .any()
             .compile();
 

--- a/src/org/traccar/protocol/GotopProtocolDecoder.java
+++ b/src/org/traccar/protocol/GotopProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
@@ -38,7 +37,7 @@ public class GotopProtocolDecoder extends BaseProtocolDecoder {
             .expression("[^,]+,")                // type
             .expression("([AV]),")               // validity
             .number("DATE:(dd)(dd)(dd),")        // date (yyddmm)
-            .number("TIME:(dd)(dd)(dd),")        // time
+            .number("TIME:(dd)(dd)(dd),")        // time (hhmmss)
             .number("LAT:(d+.d+)([NS]),")        // latitude
             .number("LOT:(d+.d+)([EW]),")        // longitude
             .text("Speed:").number("(d+.d+),")   // speed
@@ -67,10 +66,7 @@ public class GotopProtocolDecoder extends BaseProtocolDecoder {
 
         position.setValid(parser.next().equals("A"));
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
 
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.DEG_HEM));
         position.setLongitude(parser.nextCoordinate(Parser.CoordinateFormat.DEG_HEM));

--- a/src/org/traccar/protocol/GotopProtocolDecoder.java
+++ b/src/org/traccar/protocol/GotopProtocolDecoder.java
@@ -66,7 +66,7 @@ public class GotopProtocolDecoder extends BaseProtocolDecoder {
 
         position.setValid(parser.next().equals("A"));
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
+        position.setTime(parser.nextDateTime());
 
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.DEG_HEM));
         position.setLongitude(parser.nextCoordinate(Parser.CoordinateFormat.DEG_HEM));

--- a/src/org/traccar/protocol/Gps103ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gps103ProtocolDecoder.java
@@ -85,8 +85,8 @@ public class Gps103ProtocolDecoder extends BaseProtocolDecoder {
             .text("imei:")
             .number("(d+),")                     // imei
             .expression("OBD,")                  // type
-            .number("(dd)(dd)(dd)")              // date
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd)")              // date (yymmdd)
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("(d+),")                     // odometer
             .number("(d+.d+)?,")                 // fuel instant
             .number("(d+.d+)?,")                 // fuel average
@@ -204,11 +204,7 @@ public class Gps103ProtocolDecoder extends BaseProtocolDecoder {
             }
             position.setDeviceId(deviceSession.getDeviceId());
 
-            DateBuilder dateBuilder = new DateBuilder()
-                    .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                    .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-
-            getLastLocation(position, dateBuilder.getDate());
+            getLastLocation(position, parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
 
             position.set(Position.KEY_ODOMETER, parser.nextInt());
             parser.next(); // instant fuel consumption

--- a/src/org/traccar/protocol/Gps103ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gps103ProtocolDecoder.java
@@ -43,7 +43,7 @@ public class Gps103ProtocolDecoder extends BaseProtocolDecoder {
             .expression("([^,]+)?,")             // rfid
             .expression("[FL],")                 // full / low
             .groupBegin()
-            .number("(dd)(dd)(dd).(d+)")         // time utc (hhmmss.sss)
+            .number("(dd)(dd)(dd).d+")           // time utc (hhmmss)
             .or()
             .number("(?:d{1,5}.d+)?")
             .groupEnd()
@@ -263,7 +263,7 @@ public class Gps103ProtocolDecoder extends BaseProtocolDecoder {
         String utcHours = parser.next();
         String utcMinutes = parser.next();
 
-        dateBuilder.setTime(localHours, localMinutes, parser.nextInt(), parser.nextInt());
+        dateBuilder.setTime(localHours, localMinutes, parser.nextInt());
 
         // Timezone calculation
         if (utcHours != null && utcMinutes != null) {

--- a/src/org/traccar/protocol/Gps103ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gps103ProtocolDecoder.java
@@ -204,7 +204,7 @@ public class Gps103ProtocolDecoder extends BaseProtocolDecoder {
             }
             position.setDeviceId(deviceSession.getDeviceId());
 
-            getLastLocation(position, parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
+            getLastLocation(position, parser.nextDateTime());
 
             position.set(Position.KEY_ODOMETER, parser.nextInt());
             parser.next(); // instant fuel consumption

--- a/src/org/traccar/protocol/Gps103ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gps103ProtocolDecoder.java
@@ -38,8 +38,8 @@ public class Gps103ProtocolDecoder extends BaseProtocolDecoder {
             .text("imei:")
             .number("(d+),")                     // imei
             .expression("([^,]+),")              // alarm
-            .number("(dd)/?(dd)/?(dd) ?")        // local date
-            .number("(dd):?(dd)(?:dd)?,")        // local time
+            .number("(dd)/?(dd)/?(dd) ?")        // local date (yymmdd)
+            .number("(dd):?(dd)(?:dd)?,")        // local time (hhmmss)
             .expression("([^,]+)?,")             // rfid
             .expression("[FL],")                 // full / low
             .groupBegin()

--- a/src/org/traccar/protocol/GpsGateProtocolDecoder.java
+++ b/src/org/traccar/protocol/GpsGateProtocolDecoder.java
@@ -35,7 +35,7 @@ public class GpsGateProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN_GPRMC = new PatternBuilder()
             .text("$GPRMC,")
-            .number("(dd)(dd)(dd).?(d+)?,")      // time
+            .number("(dd)(dd)(dd).?(d+)?,")      // time (hhmmss.ms)
             .expression("([AV]),")               // validity
             .number("(dd)(dd.d+),")              // latitude
             .expression("([NS]),")
@@ -60,7 +60,7 @@ public class GpsGateProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+.?d*),")                 // speed
             .number("(d+.?d*)?,")                // course
             .number("(dd)(dd)(dd),")             // date (ddmmyy)
-            .number("(dd)(dd)(dd).?(d+)?,")      // time
+            .number("(dd)(dd)(dd).?(d+)?,")      // time (hhmmss.ms)
             .expression("([01])")                // validity
             .any()
             .compile();
@@ -158,10 +158,7 @@ public class GpsGateProtocolDecoder extends BaseProtocolDecoder {
             position.setSpeed(parser.nextDouble());
             position.setCourse(parser.nextDouble());
 
-            DateBuilder dateBuilder = new DateBuilder()
-                    .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                    .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt(), parser.nextInt());
-            position.setTime(dateBuilder.getDate());
+            position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMSms));
 
             position.setValid(parser.next().equals("1"));
 

--- a/src/org/traccar/protocol/GpsGateProtocolDecoder.java
+++ b/src/org/traccar/protocol/GpsGateProtocolDecoder.java
@@ -158,7 +158,7 @@ public class GpsGateProtocolDecoder extends BaseProtocolDecoder {
             position.setSpeed(parser.nextDouble());
             position.setCourse(parser.nextDouble());
 
-            position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
+            position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY_HMS));
 
             position.setValid(parser.next().equals("1"));
 

--- a/src/org/traccar/protocol/GpsGateProtocolDecoder.java
+++ b/src/org/traccar/protocol/GpsGateProtocolDecoder.java
@@ -35,7 +35,7 @@ public class GpsGateProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN_GPRMC = new PatternBuilder()
             .text("$GPRMC,")
-            .number("(dd)(dd)(dd).?(ddd)?,")     // time (hhmmss.sss)
+            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss)
             .expression("([AV]),")               // validity
             .number("(dd)(dd.d+),")              // latitude
             .expression("([NS]),")
@@ -60,7 +60,7 @@ public class GpsGateProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+.?d*),")                 // speed
             .number("(d+.?d*)?,")                // course
             .number("(dd)(dd)(dd),")             // date (ddmmyy)
-            .number("(dd)(dd)(dd).?(d+)?,")      // time (hhmmss.ms)
+            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss)
             .expression("([01])")                // validity
             .any()
             .compile();
@@ -123,7 +123,7 @@ public class GpsGateProtocolDecoder extends BaseProtocolDecoder {
             position.setDeviceId(deviceSession.getDeviceId());
 
             DateBuilder dateBuilder = new DateBuilder()
-                    .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt(), parser.nextInt());
+                    .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
 
             position.setValid(parser.next().equals("A"));
             position.setLatitude(parser.nextCoordinate());
@@ -158,7 +158,7 @@ public class GpsGateProtocolDecoder extends BaseProtocolDecoder {
             position.setSpeed(parser.nextDouble());
             position.setCourse(parser.nextDouble());
 
-            position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMSms));
+            position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
 
             position.setValid(parser.next().equals("1"));
 

--- a/src/org/traccar/protocol/GpsGateProtocolDecoder.java
+++ b/src/org/traccar/protocol/GpsGateProtocolDecoder.java
@@ -35,7 +35,7 @@ public class GpsGateProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN_GPRMC = new PatternBuilder()
             .text("$GPRMC,")
-            .number("(dd)(dd)(dd).?(d+)?,")      // time (hhmmss.ms)
+            .number("(dd)(dd)(dd).?(ddd)?,")     // time (hhmmss.sss)
             .expression("([AV]),")               // validity
             .number("(dd)(dd.d+),")              // latitude
             .expression("([NS]),")

--- a/src/org/traccar/protocol/GpsMarkerProtocolDecoder.java
+++ b/src/org/traccar/protocol/GpsMarkerProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.Position;
@@ -37,8 +36,8 @@ public class GpsMarkerProtocolDecoder extends BaseProtocolDecoder {
             .number("d")                         // type
             .number("(?:xx)?")                   // index
             .number("(d{15})")                   // imei
-            .number("T(dd)(dd)(dd)")             // date
-            .number("(dd)(dd)(dd)?")             // time
+            .number("T(dd)(dd)(dd)")             // date (ddmmyy)
+            .number("(dd)(dd)(dd)?")             // time (hhmmss)
             .expression("([NS])")
             .number("(dd)(dd)(dddd)")            // latitude
             .expression("([EW])")
@@ -71,10 +70,7 @@ public class GpsMarkerProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(deviceSession.getDeviceId());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
 
         position.setValid(true);
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN_MIN));

--- a/src/org/traccar/protocol/GpsMarkerProtocolDecoder.java
+++ b/src/org/traccar/protocol/GpsMarkerProtocolDecoder.java
@@ -70,7 +70,7 @@ public class GpsMarkerProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(deviceSession.getDeviceId());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY_HMS));
 
         position.setValid(true);
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN_MIN));

--- a/src/org/traccar/protocol/GpsmtaProtocolDecoder.java
+++ b/src/org/traccar/protocol/GpsmtaProtocolDecoder.java
@@ -34,7 +34,7 @@ public class GpsmtaProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN = new PatternBuilder()
             .expression("([^ ]+) ")              // uid
-            .number("(d+) ")                     // time
+            .number("(d+) ")                     // time (unix time)
             .number("(d+.d+) ")                  // latitude
             .number("(d+.d+) ")                  // longitude
             .number("(d+) ")                     // speed

--- a/src/org/traccar/protocol/Gt30ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gt30ProtocolDecoder.java
@@ -38,7 +38,7 @@ public class Gt30ProtocolDecoder extends BaseProtocolDecoder {
             .expression("(.{14})")               // device id
             .number("x{4}")                      // type
             .expression("(.)?")                  // alarm
-            .number("(dd)(dd)(dd).(d+),")        // time
+            .number("(dd)(dd)(dd).(d+),")        // time (hhmmss.ms)
             .expression("([AV]),")               // validity
             .number("(d+)(dd.d+),")              // latitude
             .expression("([NS]),")

--- a/src/org/traccar/protocol/Gt30ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gt30ProtocolDecoder.java
@@ -38,7 +38,7 @@ public class Gt30ProtocolDecoder extends BaseProtocolDecoder {
             .expression("(.{14})")               // device id
             .number("x{4}")                      // type
             .expression("(.)?")                  // alarm
-            .number("(dd)(dd)(dd).(d+),")        // time (hhmmss.ms)
+            .number("(dd)(dd)(dd).(ddd),")       // time (hhmmss.sss)
             .expression("([AV]),")               // validity
             .number("(d+)(dd.d+),")              // latitude
             .expression("([NS]),")

--- a/src/org/traccar/protocol/H02ProtocolDecoder.java
+++ b/src/org/traccar/protocol/H02ProtocolDecoder.java
@@ -149,7 +149,7 @@ public class H02ProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+),")                     // imei
             .expression("[^,]+,")
             .any()
-            .number("(?:(dd)(dd)(dd))?,")        // time
+            .number("(?:(dd)(dd)(dd))?,")        // time (hhmmss)
             .expression("([AV])?,")              // validity
             .groupBegin()
             .number("-(d+)-(d+.d+),")            // latitude
@@ -176,7 +176,7 @@ public class H02ProtocolDecoder extends BaseProtocolDecoder {
             .expression("..,")                   // manufacturer
             .number("(d+),")                     // imei
             .text("NBR,")
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("(d+),")                     // mcc
             .number("(d+),")                     // mnc
             .number("d+,")                       // gsm delay time

--- a/src/org/traccar/protocol/HaicomProtocolDecoder.java
+++ b/src/org/traccar/protocol/HaicomProtocolDecoder.java
@@ -73,7 +73,7 @@ public class HaicomProtocolDecoder extends BaseProtocolDecoder {
 
         position.set(Position.KEY_VERSION_FW, parser.next());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
+        position.setTime(parser.nextDateTime());
 
         int flags = parser.nextInt();
 

--- a/src/org/traccar/protocol/HaicomProtocolDecoder.java
+++ b/src/org/traccar/protocol/HaicomProtocolDecoder.java
@@ -19,7 +19,6 @@ import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
 import org.traccar.helper.BitUtil;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.Position;
@@ -37,8 +36,8 @@ public class HaicomProtocolDecoder extends BaseProtocolDecoder {
             .text("$GPRS")
             .number("(d+),")                     // imei
             .expression("([^,]+),")              // version
-            .number("(dd)(dd)(dd),")             // date
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd),")             // date (yymmdd)
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("(d)")                       // flags
             .number("(dd)(d{5})")                // latitude
             .number("(ddd)(d{5}),")              // longitude
@@ -74,10 +73,7 @@ public class HaicomProtocolDecoder extends BaseProtocolDecoder {
 
         position.set(Position.KEY_VERSION_FW, parser.next());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
 
         int flags = parser.nextInt();
 

--- a/src/org/traccar/protocol/HomtecsProtocolDecoder.java
+++ b/src/org/traccar/protocol/HomtecsProtocolDecoder.java
@@ -63,7 +63,7 @@ public class HomtecsProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(deviceSession.getDeviceId());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMSms));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.YMD_HMSms));
 
         position.setValid(true);
         position.set(Position.KEY_SATELLITES, parser.nextInt());

--- a/src/org/traccar/protocol/HomtecsProtocolDecoder.java
+++ b/src/org/traccar/protocol/HomtecsProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.Position;
@@ -34,8 +33,8 @@ public class HomtecsProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN = new PatternBuilder()
             .expression("([^,]+),")              // id
-            .number("(dd)(dd)(dd),")             // date
-            .number("(dd)(dd)(dd).(d+),")        // time
+            .number("(dd)(dd)(dd),")             // date (yymmdd)
+            .number("(dd)(dd)(dd).(d+),")        // time (hhmmss.ms)
             .number("(d+),")                     // satellites
             .number("(dd)(dd.d+),")              // latitude
             .expression("([NS]),")
@@ -64,11 +63,7 @@ public class HomtecsProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(deviceSession.getDeviceId());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt(), parser.nextInt());
-
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMSms));
 
         position.setValid(true);
         position.set(Position.KEY_SATELLITES, parser.nextInt());

--- a/src/org/traccar/protocol/HomtecsProtocolDecoder.java
+++ b/src/org/traccar/protocol/HomtecsProtocolDecoder.java
@@ -34,7 +34,7 @@ public class HomtecsProtocolDecoder extends BaseProtocolDecoder {
     private static final Pattern PATTERN = new PatternBuilder()
             .expression("([^,]+),")              // id
             .number("(dd)(dd)(dd),")             // date (yymmdd)
-            .number("(dd)(dd)(dd).(d+),")        // time (hhmmss.ms)
+            .number("(dd)(dd)(dd).d+,")          // time (hhmmss)
             .number("(d+),")                     // satellites
             .number("(dd)(dd.d+),")              // latitude
             .expression("([NS]),")
@@ -63,7 +63,7 @@ public class HomtecsProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(deviceSession.getDeviceId());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.YMD_HMSS));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.YMD_HMS));
 
         position.setValid(true);
         position.set(Position.KEY_SATELLITES, parser.nextInt());

--- a/src/org/traccar/protocol/HomtecsProtocolDecoder.java
+++ b/src/org/traccar/protocol/HomtecsProtocolDecoder.java
@@ -63,7 +63,7 @@ public class HomtecsProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(deviceSession.getDeviceId());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.YMD_HMSms));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.YMD_HMSS));
 
         position.setValid(true);
         position.set(Position.KEY_SATELLITES, parser.nextInt());

--- a/src/org/traccar/protocol/HunterProProtocolDecoder.java
+++ b/src/org/traccar/protocol/HunterProProtocolDecoder.java
@@ -35,7 +35,7 @@ public class HunterProProtocolDecoder extends BaseProtocolDecoder {
     private static final Pattern PATTERN = new PatternBuilder()
             .number(">(d+)<")                    // identifier
             .text("$GPRMC,")
-            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss.ms)
+            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss)
             .expression("([AV]),")               // validity
             .number("(dd)(dd.d+),")              // latitude
             .expression("([NS]),")

--- a/src/org/traccar/protocol/HunterProProtocolDecoder.java
+++ b/src/org/traccar/protocol/HunterProProtocolDecoder.java
@@ -35,7 +35,7 @@ public class HunterProProtocolDecoder extends BaseProtocolDecoder {
     private static final Pattern PATTERN = new PatternBuilder()
             .number(">(d+)<")                    // identifier
             .text("$GPRMC,")
-            .number("(dd)(dd)(dd).?d*,")         // time
+            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss.ms)
             .expression("([AV]),")               // validity
             .number("(dd)(dd.d+),")              // latitude
             .expression("([NS]),")

--- a/src/org/traccar/protocol/IdplProtocolDecoder.java
+++ b/src/org/traccar/protocol/IdplProtocolDecoder.java
@@ -22,7 +22,6 @@ import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
 import org.traccar.Protocol;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.Parser.CoordinateFormat;
 import org.traccar.helper.PatternBuilder;
@@ -38,8 +37,8 @@ public class IdplProtocolDecoder extends BaseProtocolDecoder {
             .text("*ID")                         // start of frame
             .number("(d+),")                     // command code
             .number("(d+),")                     // imei
-            .number("(dd)(dd)(dd),")             // current date
-            .number("(dd)(dd)(dd),")             // current time
+            .number("(dd)(dd)(dd),")             // current date (ddmmyy)
+            .number("(dd)(dd)(dd),")             // current time (hhmmss)
             .expression("([A|V]),")              // gps fix
             .number("(dd)(dd).?(d+),([NS]),")    // latitude
             .number("(ddd)(dd).?(d+),([EW]),")   // longitude
@@ -81,10 +80,7 @@ public class IdplProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(deviceSession.getDeviceId());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
 
         position.setValid(parser.next().equals("A"));
         position.setLatitude(parser.nextCoordinate(CoordinateFormat.DEG_MIN_MIN_HEM));

--- a/src/org/traccar/protocol/IdplProtocolDecoder.java
+++ b/src/org/traccar/protocol/IdplProtocolDecoder.java
@@ -80,7 +80,7 @@ public class IdplProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(deviceSession.getDeviceId());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY_HMS));
 
         position.setValid(parser.next().equals("A"));
         position.setLatitude(parser.nextCoordinate(CoordinateFormat.DEG_MIN_MIN_HEM));

--- a/src/org/traccar/protocol/IntellitracProtocolDecoder.java
+++ b/src/org/traccar/protocol/IntellitracProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.Position;
@@ -35,8 +34,8 @@ public class IntellitracProtocolDecoder extends BaseProtocolDecoder {
     private static final Pattern PATTERN = new PatternBuilder()
             .expression(".+,").optional()
             .number("(d+),")                     // identifier
-            .number("(dddd)(dd)(dd)")            // date
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dddd)(dd)(dd)")            // date (yyyymmdd)
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("(-?d+.d+),")                // longitude
             .number("(-?d+.d+),")                // latitude
             .number("(d+.?d*),")                 // speed
@@ -82,10 +81,7 @@ public class IntellitracProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(deviceSession.getDeviceId());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime());
 
         position.setLongitude(parser.nextDouble());
         position.setLatitude(parser.nextDouble());

--- a/src/org/traccar/protocol/JpKorjarProtocolDecoder.java
+++ b/src/org/traccar/protocol/JpKorjarProtocolDecoder.java
@@ -69,7 +69,7 @@ public class JpKorjarProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(deviceSession.getDeviceId());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
+        position.setTime(parser.nextDateTime());
 
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.DEG_HEM));
         position.setLongitude(parser.nextCoordinate(Parser.CoordinateFormat.DEG_HEM));

--- a/src/org/traccar/protocol/JpKorjarProtocolDecoder.java
+++ b/src/org/traccar/protocol/JpKorjarProtocolDecoder.java
@@ -19,7 +19,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.CellTower;
@@ -38,8 +37,8 @@ public class JpKorjarProtocolDecoder extends BaseProtocolDecoder {
     private static final Pattern PATTERN = new PatternBuilder()
             .text("KORJAR.PL,")
             .number("(d+),")                     // imei
-            .number("(dd)(dd)(dd)")              // date
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd)")              // date (yymmdd)
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("(d+.d+)([NS]),")            // latitude
             .number("(d+.d+)([EW]),")            // longitude
             .number("(d+.d+),")                  // speed
@@ -70,10 +69,7 @@ public class JpKorjarProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(deviceSession.getDeviceId());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
 
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.DEG_HEM));
         position.setLongitude(parser.nextCoordinate(Parser.CoordinateFormat.DEG_HEM));

--- a/src/org/traccar/protocol/Jt600ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Jt600ProtocolDecoder.java
@@ -162,7 +162,7 @@ public class Jt600ProtocolDecoder extends BaseProtocolDecoder {
             .expression("([NS]),")
             .expression("([AV]),")               // validity
             .number("(dd)(dd)(dd),")             // date (ddmmyy)
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("(d+),")                     // speed
             .number("(d+),")                     // course
             .number("(d+),")                     // power
@@ -192,10 +192,7 @@ public class Jt600ProtocolDecoder extends BaseProtocolDecoder {
         position.setLatitude(parser.nextCoordinate());
         position.setValid(parser.next().equals("A"));
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
 
         position.setSpeed(UnitsConverter.knotsFromKph(parser.nextDouble()));
         position.setCourse(parser.nextDouble());
@@ -214,7 +211,7 @@ public class Jt600ProtocolDecoder extends BaseProtocolDecoder {
             .number("(Udd),")                    // type
             .number("d+,").optional()            // alarm
             .number("(dd)(dd)(dd),")             // date (ddmmyy)
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .expression("([TF]),")               // validity
             .number("(d+.d+),([NS]),")           // latitude
             .number("(d+.d+),([EW]),")           // longitude
@@ -250,10 +247,7 @@ public class Jt600ProtocolDecoder extends BaseProtocolDecoder {
         position.setProtocol(getProtocolName());
         position.setDeviceId(deviceSession.getDeviceId());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
 
         position.setValid(parser.next().equals("T"));
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.DEG_HEM));

--- a/src/org/traccar/protocol/Jt600ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Jt600ProtocolDecoder.java
@@ -192,7 +192,7 @@ public class Jt600ProtocolDecoder extends BaseProtocolDecoder {
         position.setLatitude(parser.nextCoordinate());
         position.setValid(parser.next().equals("A"));
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY_HMS));
 
         position.setSpeed(UnitsConverter.knotsFromKph(parser.nextDouble()));
         position.setCourse(parser.nextDouble());
@@ -247,7 +247,7 @@ public class Jt600ProtocolDecoder extends BaseProtocolDecoder {
         position.setProtocol(getProtocolName());
         position.setDeviceId(deviceSession.getDeviceId());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY_HMS));
 
         position.setValid(parser.next().equals("T"));
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.DEG_HEM));

--- a/src/org/traccar/protocol/KenjiProtocolDecoder.java
+++ b/src/org/traccar/protocol/KenjiProtocolDecoder.java
@@ -39,13 +39,13 @@ public class KenjiProtocolDecoder extends BaseProtocolDecoder {
             .number("M(x{6}),")                  // alarm
             .number("O(x{4}),")                  // output
             .number("I(x{4}),")                  // input
-            .number("D(dd)(dd)(dd),")            // time
+            .number("D(dd)(dd)(dd),")            // time (hhmmss)
             .expression("([AV]),")               // valid
             .number("([NS])(dd)(dd.d+),")        // latitude
             .number("([EW])(ddd)(dd.d+),")       // longitude
             .number("T(d+.d+),")                 // speed
             .number("H(d+.d+),")                 // course
-            .number("Y(dd)(dd)(dd),")            // date
+            .number("Y(dd)(dd)(dd),")            // date (ddmmyy)
             .number("G(d+)")                     // satellites
             .any()
             .compile();

--- a/src/org/traccar/protocol/L100ProtocolDecoder.java
+++ b/src/org/traccar/protocol/L100ProtocolDecoder.java
@@ -40,7 +40,7 @@ public class L100ProtocolDecoder extends BaseProtocolDecoder {
             .text("ATL")
             .number("(d{15}),")                  // imei
             .text("$GPRMC,")
-            .number("(dd)(dd)(dd).ddd,")         // time
+            .number("(dd)(dd)(dd).ddd,")         // time (hhmmss.ms)
             .expression("([AV]),")               // validity
             .number("(dd)(dd.d+),")              // latitude
             .expression("([NS]),")
@@ -48,7 +48,7 @@ public class L100ProtocolDecoder extends BaseProtocolDecoder {
             .expression("([EW]),")
             .number("(d+.?d*)?,")                // speed
             .number("(d+.?d*)?,")                // course
-            .number("(dd)(dd)(dd),")             // date
+            .number("(dd)(dd)(dd),")             // date (ddmmyy)
             .any()
             .text("#")
             .number("([01]+),")                  // io status

--- a/src/org/traccar/protocol/L100ProtocolDecoder.java
+++ b/src/org/traccar/protocol/L100ProtocolDecoder.java
@@ -40,7 +40,7 @@ public class L100ProtocolDecoder extends BaseProtocolDecoder {
             .text("ATL")
             .number("(d{15}),")                  // imei
             .text("$GPRMC,")
-            .number("(dd)(dd)(dd).ddd,")         // time (hhmmss.ms)
+            .number("(dd)(dd)(dd).(ddd),")       // time (hhmmss.sss)
             .expression("([AV]),")               // validity
             .number("(dd)(dd.d+),")              // latitude
             .expression("([NS]),")
@@ -92,7 +92,7 @@ public class L100ProtocolDecoder extends BaseProtocolDecoder {
         position.setDeviceId(deviceSession.getDeviceId());
 
         DateBuilder dateBuilder = new DateBuilder()
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
+                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt(), parser.nextInt());
 
         position.setValid(parser.next().equals("A"));
         position.setLatitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/LaipacProtocolDecoder.java
+++ b/src/org/traccar/protocol/LaipacProtocolDecoder.java
@@ -36,7 +36,7 @@ public class LaipacProtocolDecoder extends BaseProtocolDecoder {
     private static final Pattern PATTERN = new PatternBuilder()
             .text("$AVRMC,")
             .expression("([^,]+),")              // identifier
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .expression("([AVRPavrp]),")         // validity
             .number("(dd)(dd.d+),")              // latitude
             .expression("([NS]),")

--- a/src/org/traccar/protocol/MaestroProtocolDecoder.java
+++ b/src/org/traccar/protocol/MaestroProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
@@ -43,8 +42,8 @@ public class MaestroProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+),")                     // gsm
             .expression("([01]),")               // starter
             .expression("([01]),")               // ignition
-            .number("(dd)/(dd)/(dd),")           // date
-            .number("(dd):(dd):(dd),")           // time
+            .number("(dd)/(dd)/(dd),")           // date (yy/mm/dd)
+            .number("(dd):(dd):(dd),")           // time (hh:mm:ss)
             .number("(-?d+.d+),")                // longitude
             .number("(-?d+.d+),")                // latitude
             .number("(d+.?d*),")                 // altitude
@@ -82,10 +81,7 @@ public class MaestroProtocolDecoder extends BaseProtocolDecoder {
         position.set(Position.KEY_CHARGE, parser.nextInt() == 1);
         position.set(Position.KEY_IGNITION, parser.nextInt() == 1);
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
 
         position.setLatitude(parser.nextDouble());
         position.setLongitude(parser.nextDouble());

--- a/src/org/traccar/protocol/MaestroProtocolDecoder.java
+++ b/src/org/traccar/protocol/MaestroProtocolDecoder.java
@@ -81,7 +81,7 @@ public class MaestroProtocolDecoder extends BaseProtocolDecoder {
         position.set(Position.KEY_CHARGE, parser.nextInt() == 1);
         position.set(Position.KEY_IGNITION, parser.nextInt() == 1);
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
+        position.setTime(parser.nextDateTime());
 
         position.setLatitude(parser.nextDouble());
         position.setLongitude(parser.nextDouble());

--- a/src/org/traccar/protocol/ManPowerProtocolDecoder.java
+++ b/src/org/traccar/protocol/ManPowerProtocolDecoder.java
@@ -68,7 +68,7 @@ public class ManPowerProtocolDecoder extends BaseProtocolDecoder {
 
         position.set(Position.KEY_STATUS, parser.next());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
+        position.setTime(parser.nextDateTime());
 
         position.setValid(parser.next().equals("A"));
         position.setLatitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/ManPowerProtocolDecoder.java
+++ b/src/org/traccar/protocol/ManPowerProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.Position;
@@ -38,8 +37,8 @@ public class ManPowerProtocolDecoder extends BaseProtocolDecoder {
             .expression("[^,]*,[^,]*,")
             .expression("([^,]*),")              // status
             .number("d+,d+,d+.?d*,")
-            .number("(dd)(dd)(dd)")              // date
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd)")              // date (yymmdd)
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .expression("([AV]),")               // validity
             .number("(dd)(dd.dddd),")            // latitude
             .expression("([NS]),")
@@ -69,10 +68,7 @@ public class ManPowerProtocolDecoder extends BaseProtocolDecoder {
 
         position.set(Position.KEY_STATUS, parser.next());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
 
         position.setValid(parser.next().equals("A"));
         position.setLatitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/MegastekProtocolDecoder.java
+++ b/src/org/traccar/protocol/MegastekProtocolDecoder.java
@@ -230,7 +230,7 @@ public class MegastekProtocolDecoder extends BaseProtocolDecoder {
             .expression("[^,]*,")                // name
             .expression("([RS]),")
             .number("(dd)(dd)(dd),")             // date (ddmmyy)
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .expression("([AV]),")               // validity
             .number("(d+)(dd.d+),([NS]),")       // latitude
             .number("(d+)(dd.d+),([EW]),")       // longitude
@@ -287,10 +287,7 @@ public class MegastekProtocolDecoder extends BaseProtocolDecoder {
             position.set(Position.KEY_ARCHIVE, true);
         }
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
 
         position.setValid(parser.next().equals("A"));
         position.setLatitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/MegastekProtocolDecoder.java
+++ b/src/org/traccar/protocol/MegastekProtocolDecoder.java
@@ -36,7 +36,7 @@ public class MegastekProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN_GPRMC = new PatternBuilder()
             .text("$GPRMC,")
-            .number("(dd)(dd)(dd).d+,")          // time (hhmmss.ms)
+            .number("(dd)(dd)(dd).(ddd),")       // time (hhmmss.sss)
             .expression("([AV]),")               // validity
             .number("(d+)(dd.d+),([NS]),")       // latitude
             .number("(d+)(dd.d+),([EW]),")       // longitude
@@ -88,7 +88,7 @@ public class MegastekProtocolDecoder extends BaseProtocolDecoder {
         }
 
         DateBuilder dateBuilder = new DateBuilder()
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
+                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt(), parser.nextInt());
 
         position.setValid(parser.next().equals("A"));
         position.setLatitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/MegastekProtocolDecoder.java
+++ b/src/org/traccar/protocol/MegastekProtocolDecoder.java
@@ -36,7 +36,7 @@ public class MegastekProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN_GPRMC = new PatternBuilder()
             .text("$GPRMC,")
-            .number("(dd)(dd)(dd).d+,")          // time
+            .number("(dd)(dd)(dd).d+,")          // time (hhmmss.ms)
             .expression("([AV]),")               // validity
             .number("(d+)(dd.d+),([NS]),")       // latitude
             .number("(d+)(dd.d+),([EW]),")       // longitude

--- a/src/org/traccar/protocol/MegastekProtocolDecoder.java
+++ b/src/org/traccar/protocol/MegastekProtocolDecoder.java
@@ -287,7 +287,7 @@ public class MegastekProtocolDecoder extends BaseProtocolDecoder {
             position.set(Position.KEY_ARCHIVE, true);
         }
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY_HMS));
 
         position.setValid(parser.next().equals("A"));
         position.setLatitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/MeiligaoProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeiligaoProtocolDecoder.java
@@ -265,7 +265,7 @@ public class MeiligaoProtocolDecoder extends BaseProtocolDecoder {
             return null;
         }
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY2));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY));
 
         position.setValid(true);
         position.setLatitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/MeiligaoProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeiligaoProtocolDecoder.java
@@ -39,7 +39,7 @@ public class MeiligaoProtocolDecoder extends BaseProtocolDecoder {
     }
 
     private static final Pattern PATTERN = new PatternBuilder()
-            .number("(dd)(dd)(dd).?(ddd)?,")     // time (hhmmss.sss)
+            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss.sss)
             .expression("([AV]),")               // validity
             .number("(d+)(dd.d+),")              // latitude
             .expression("([NS]),")
@@ -211,9 +211,6 @@ public class MeiligaoProtocolDecoder extends BaseProtocolDecoder {
 
         DateBuilder dateBuilder = new DateBuilder()
                 .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        if (parser.hasNext()) {
-            dateBuilder.setMillis(parser.nextInt());
-        }
 
         position.setValid(parser.next().equals("A"));
         position.setLatitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/MeiligaoProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeiligaoProtocolDecoder.java
@@ -39,7 +39,7 @@ public class MeiligaoProtocolDecoder extends BaseProtocolDecoder {
     }
 
     private static final Pattern PATTERN = new PatternBuilder()
-            .number("(dd)(dd)(dd).?(d+)?,")      // time
+            .number("(dd)(dd)(dd).?(d+)?,")      // time (hhmmss.ms)
             .expression("([AV]),")               // validity
             .number("(d+)(dd.d+),")              // latitude
             .expression("([NS]),")

--- a/src/org/traccar/protocol/MeiligaoProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeiligaoProtocolDecoder.java
@@ -39,7 +39,7 @@ public class MeiligaoProtocolDecoder extends BaseProtocolDecoder {
     }
 
     private static final Pattern PATTERN = new PatternBuilder()
-            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss.sss)
+            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss)
             .expression("([AV]),")               // validity
             .number("(d+)(dd.d+),")              // latitude
             .expression("([NS]),")

--- a/src/org/traccar/protocol/MeiligaoProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeiligaoProtocolDecoder.java
@@ -72,7 +72,7 @@ public class MeiligaoProtocolDecoder extends BaseProtocolDecoder {
             .compile();
 
     private static final Pattern PATTERN_RFID = new PatternBuilder()
-            .number("|(dd)(dd)(dd),")            // time
+            .number("|(dd)(dd)(dd),")            // time (hhmmss)
             .number("(dd)(dd)(dd),")             // date (ddmmyy)
             .number("(d+)(dd.d+),")              // latitude
             .expression("([NS]),")
@@ -268,10 +268,7 @@ public class MeiligaoProtocolDecoder extends BaseProtocolDecoder {
             return null;
         }
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY2));
 
         position.setValid(true);
         position.setLatitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/MeiligaoProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeiligaoProtocolDecoder.java
@@ -39,7 +39,7 @@ public class MeiligaoProtocolDecoder extends BaseProtocolDecoder {
     }
 
     private static final Pattern PATTERN = new PatternBuilder()
-            .number("(dd)(dd)(dd).?(d+)?,")      // time (hhmmss.ms)
+            .number("(dd)(dd)(dd).?(ddd)?,")     // time (hhmmss.sss)
             .expression("([AV]),")               // validity
             .number("(d+)(dd.d+),")              // latitude
             .expression("([NS]),")

--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -106,7 +106,7 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
         position.setLatitude(parser.nextDouble());
         position.setLongitude(parser.nextDouble());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
+        position.setTime(parser.nextDateTime());
 
         position.setValid(parser.next().equals("A"));
 

--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -20,7 +20,6 @@ import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.Context;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
@@ -51,7 +50,7 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
             .number("(-?d+.d+),")                // latitude
             .number("(-?d+.d+),")                // longitude
             .number("(dd)(dd)(dd)")              // date (ddmmyy)
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("([AV]),")                   // validity
             .number("(d+),")                     // satellites
             .number("(d+),")                     // rssi
@@ -107,10 +106,7 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
         position.setLatitude(parser.nextDouble());
         position.setLongitude(parser.nextDouble());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
 
         position.setValid(parser.next().equals("A"));
 

--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -49,7 +49,7 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+),")                     // event
             .number("(-?d+.d+),")                // latitude
             .number("(-?d+.d+),")                // longitude
-            .number("(dd)(dd)(dd)")              // date (ddmmyy)
+            .number("(dd)(dd)(dd)")              // date (yymmdd)
             .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("([AV]),")                   // validity
             .number("(d+),")                     // satellites

--- a/src/org/traccar/protocol/MiniFinderProtocolDecoder.java
+++ b/src/org/traccar/protocol/MiniFinderProtocolDecoder.java
@@ -77,7 +77,7 @@ public class MiniFinderProtocolDecoder extends BaseProtocolDecoder {
 
     private void decodeFix(Position position, Parser parser) {
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY_HMS));
         position.setLatitude(parser.nextDouble());
         position.setLongitude(parser.nextDouble());
     }

--- a/src/org/traccar/protocol/MiniFinderProtocolDecoder.java
+++ b/src/org/traccar/protocol/MiniFinderProtocolDecoder.java
@@ -19,7 +19,6 @@ import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
 import org.traccar.helper.BitUtil;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
@@ -35,8 +34,8 @@ public class MiniFinderProtocolDecoder extends BaseProtocolDecoder {
     }
 
     private static final Pattern PATTERN_FIX = new PatternBuilder()
-            .number("(d+)/(d+)/(d+),")           // date
-            .number("(d+):(d+):(d+),")           // time
+            .number("(d+)/(d+)/(d+),")           // date (dd/mm/yy)
+            .number("(d+):(d+):(d+),")           // time (hh:mm:ss)
             .number("(-?d+.d+),")                // latitude
             .number("(-?d+.d+),")                // longitude
             .compile();
@@ -78,11 +77,7 @@ public class MiniFinderProtocolDecoder extends BaseProtocolDecoder {
 
     private void decodeFix(Position position, Parser parser) {
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
-
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
         position.setLatitude(parser.nextDouble());
         position.setLongitude(parser.nextDouble());
     }

--- a/src/org/traccar/protocol/MtxProtocolDecoder.java
+++ b/src/org/traccar/protocol/MtxProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.Position;
@@ -35,8 +34,8 @@ public class MtxProtocolDecoder extends BaseProtocolDecoder {
     private static final Pattern PATTERN = new PatternBuilder()
             .text("#MTX,")
             .number("(d+),")                     // imei
-            .number("(dddd)(dd)(dd),")           // date
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dddd)(dd)(dd),")           // date (yyyymmdd)
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("(-?d+.d+),")                // latitude
             .number("(-?d+.d+),")                // longitude
             .number("(d+.?d*),")                 // speed
@@ -78,10 +77,7 @@ public class MtxProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(deviceSession.getDeviceId());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime());
 
         position.setValid(true);
         position.setLatitude(parser.nextDouble());

--- a/src/org/traccar/protocol/PathAwayProtocolDecoder.java
+++ b/src/org/traccar/protocol/PathAwayProtocolDecoder.java
@@ -25,7 +25,6 @@ import org.jboss.netty.handler.codec.http.HttpVersion;
 import org.jboss.netty.handler.codec.http.QueryStringDecoder;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.Position;
@@ -46,7 +45,7 @@ public class PathAwayProtocolDecoder extends BaseProtocolDecoder {
             .expression("[^,]*,")                // icon
             .expression("[^,]*,")                // color
             .number("(dd)(dd)(dd),")             // date (ddmmyy)
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("(-?d+.d+),")                // latitude
             .number("(-?d+.d+),")                // longitude
             .number("(-?d+.?d*),")               // altitude
@@ -77,10 +76,7 @@ public class PathAwayProtocolDecoder extends BaseProtocolDecoder {
         position.setProtocol(getProtocolName());
         position.setDeviceId(deviceSession.getDeviceId());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
 
         position.setValid(true);
         position.setLatitude(parser.nextDouble());

--- a/src/org/traccar/protocol/PathAwayProtocolDecoder.java
+++ b/src/org/traccar/protocol/PathAwayProtocolDecoder.java
@@ -76,7 +76,7 @@ public class PathAwayProtocolDecoder extends BaseProtocolDecoder {
         position.setProtocol(getProtocolName());
         position.setDeviceId(deviceSession.getDeviceId());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY_HMS));
 
         position.setValid(true);
         position.setLatitude(parser.nextDouble());

--- a/src/org/traccar/protocol/PretraceProtocolDecoder.java
+++ b/src/org/traccar/protocol/PretraceProtocolDecoder.java
@@ -77,7 +77,7 @@ public class PretraceProtocolDecoder extends BaseProtocolDecoder {
 
         position.setValid(parser.next().equals("A"));
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
+        position.setTime(parser.nextDateTime());
 
         position.setLatitude(parser.nextCoordinate());
         position.setLongitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/PretraceProtocolDecoder.java
+++ b/src/org/traccar/protocol/PretraceProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
@@ -39,8 +38,8 @@ public class PretraceProtocolDecoder extends BaseProtocolDecoder {
             .number("Uddd")                      // type
             .number("d")                         // gps type
             .expression("([AV])")                // validity
-            .number("(dd)(dd)(dd)")              // date
-            .number("(dd)(dd)(dd)")              // time
+            .number("(dd)(dd)(dd)")              // date (yymmdd)
+            .number("(dd)(dd)(dd)")              // time (hhmmss)
             .number("(dd)(dd.dddd)")             // latitude
             .expression("([NS])")
             .number("(ddd)(dd.dddd)")            // longitude
@@ -78,10 +77,7 @@ public class PretraceProtocolDecoder extends BaseProtocolDecoder {
 
         position.setValid(parser.next().equals("A"));
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
 
         position.setLatitude(parser.nextCoordinate());
         position.setLongitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/Pt3000ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Pt3000ProtocolDecoder.java
@@ -35,7 +35,7 @@ public class Pt3000ProtocolDecoder extends BaseProtocolDecoder {
     private static final Pattern PATTERN = new PatternBuilder()
             .number("%(d+),")                    // imei
             .text("$GPRMC,")
-            .number("(dd)(dd)(dd).?d*,")         // time
+            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss.ms)
             .expression("([AV]),")               // validity
             .number("(dd)(dd.d+),")              // latitude
             .expression("([NS]),")

--- a/src/org/traccar/protocol/Pt3000ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Pt3000ProtocolDecoder.java
@@ -35,7 +35,7 @@ public class Pt3000ProtocolDecoder extends BaseProtocolDecoder {
     private static final Pattern PATTERN = new PatternBuilder()
             .number("%(d+),")                    // imei
             .text("$GPRMC,")
-            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss.ms)
+            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss)
             .expression("([AV]),")               // validity
             .number("(dd)(dd.d+),")              // latitude
             .expression("([NS]),")

--- a/src/org/traccar/protocol/Pt502ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Pt502ProtocolDecoder.java
@@ -41,7 +41,7 @@ public class Pt502ProtocolDecoder extends BaseProtocolDecoder {
             .any().text("$")
             .expression("([^,]+),")              // type
             .number("(d+),")                     // id
-            .number("(dd)(dd)(dd).(ddd),")       // time
+            .number("(dd)(dd)(dd).(ddd),")       // time (hhmmss.ms)
             .expression("([AV]),")               // validity
             .number("(dd)(dd.dddd),")            // latitude
             .expression("([NS]),")
@@ -49,7 +49,7 @@ public class Pt502ProtocolDecoder extends BaseProtocolDecoder {
             .expression("([EW]),")
             .number("(d+.d+)?,")                 // speed
             .number("(d+.d+)?,")                 // course
-            .number("(dd)(dd)(dd),,,")           // date
+            .number("(dd)(dd)(dd),,,")           // date (ddmmyy)
             .expression("./")
             .expression("([01])+,")              // input
             .expression("([01])+/")              // output

--- a/src/org/traccar/protocol/Pt502ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Pt502ProtocolDecoder.java
@@ -41,7 +41,7 @@ public class Pt502ProtocolDecoder extends BaseProtocolDecoder {
             .any().text("$")
             .expression("([^,]+),")              // type
             .number("(d+),")                     // id
-            .number("(dd)(dd)(dd).(ddd),")       // time (hhmmss.ms)
+            .number("(dd)(dd)(dd).(ddd),")       // time (hhmmss.sss)
             .expression("([AV]),")               // validity
             .number("(dd)(dd.dddd),")            // latitude
             .expression("([NS]),")

--- a/src/org/traccar/protocol/RaveonProtocolDecoder.java
+++ b/src/org/traccar/protocol/RaveonProtocolDecoder.java
@@ -18,14 +18,12 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
 import org.traccar.model.Position;
 
 import java.net.SocketAddress;
-import java.util.Date;
 import java.util.regex.Pattern;
 
 public class RaveonProtocolDecoder extends BaseProtocolDecoder {
@@ -40,7 +38,7 @@ public class RaveonProtocolDecoder extends BaseProtocolDecoder {
             .number("d+,")
             .number("(-?)(d+)(dd.d+),")          // latitude
             .number("(-?)(d+)(dd.d+),")          // longitude
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("(d),")                      // validity
             .number("(d+),")                     // satellites
             .number("(-?d+),")                   // altitude
@@ -77,9 +75,7 @@ public class RaveonProtocolDecoder extends BaseProtocolDecoder {
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN));
         position.setLongitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN));
 
-        DateBuilder dateBuilder = new DateBuilder(new Date())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMS));
 
         position.setValid(parser.nextInt() != 0);
 

--- a/src/org/traccar/protocol/RitiProtocolDecoder.java
+++ b/src/org/traccar/protocol/RitiProtocolDecoder.java
@@ -36,7 +36,7 @@ public class RitiProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN = new PatternBuilder()
             .text("$GPRMC,")
-            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss.ms)
+            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss)
             .expression("([AV]),")               // validity
             .number("(dd)(dd.d+),")              // latitude
             .expression("([NS]),")

--- a/src/org/traccar/protocol/RitiProtocolDecoder.java
+++ b/src/org/traccar/protocol/RitiProtocolDecoder.java
@@ -36,7 +36,7 @@ public class RitiProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN = new PatternBuilder()
             .text("$GPRMC,")
-            .number("(dd)(dd)(dd).?d*,")         // time
+            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss.ms)
             .expression("([AV]),")               // validity
             .number("(dd)(dd.d+),")              // latitude
             .expression("([NS]),")

--- a/src/org/traccar/protocol/SanavProtocolDecoder.java
+++ b/src/org/traccar/protocol/SanavProtocolDecoder.java
@@ -38,7 +38,7 @@ public class SanavProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+)")                      // imei
             .expression("&?rmc[:=]")
             .text("$GPRMC,")
-            .number("(dd)(dd)(dd).(d+),")        // time (hhmmss.ms)
+            .number("(dd)(dd)(dd).(ddd),")       // time (hhmmss.sss)
             .expression("([AV]),")               // validity
             .number("(d+)(dd.d+),")              // latitude
             .expression("([NS]),")

--- a/src/org/traccar/protocol/SanavProtocolDecoder.java
+++ b/src/org/traccar/protocol/SanavProtocolDecoder.java
@@ -38,7 +38,7 @@ public class SanavProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+)")                      // imei
             .expression("&?rmc[:=]")
             .text("$GPRMC,")
-            .number("(dd)(dd)(dd).(d+),")        // time
+            .number("(dd)(dd)(dd).(d+),")        // time (hhmmss.ms)
             .expression("([AV]),")               // validity
             .number("(d+)(dd.d+),")              // latitude
             .expression("([NS]),")

--- a/src/org/traccar/protocol/SiwiProtocolDecoder.java
+++ b/src/org/traccar/protocol/SiwiProtocolDecoder.java
@@ -88,7 +88,7 @@ public class SiwiProtocolDecoder extends BaseProtocolDecoder {
         position.setAltitude(parser.nextDouble());
         position.setCourse(parser.nextInt());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY2, "IST"));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY, "IST"));
 
         return position;
     }

--- a/src/org/traccar/protocol/SiwiProtocolDecoder.java
+++ b/src/org/traccar/protocol/SiwiProtocolDecoder.java
@@ -88,7 +88,7 @@ public class SiwiProtocolDecoder extends BaseProtocolDecoder {
         position.setAltitude(parser.nextDouble());
         position.setCourse(parser.nextInt());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY4, "IST"));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY2, "IST"));
 
         return position;
     }

--- a/src/org/traccar/protocol/SiwiProtocolDecoder.java
+++ b/src/org/traccar/protocol/SiwiProtocolDecoder.java
@@ -18,14 +18,12 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
 import org.traccar.model.Position;
 
 import java.net.SocketAddress;
-import java.util.TimeZone;
 import java.util.regex.Pattern;
 
 public class SiwiProtocolDecoder extends BaseProtocolDecoder {
@@ -53,8 +51,8 @@ public class SiwiProtocolDecoder extends BaseProtocolDecoder {
             .number("(-?d+.d+),")                // longitude
             .number("(-?d+),")                   // altitude
             .number("(d+),")                     // course
-            .number("(dd)(dd)(dd),")             // time
-            .number("(dd)(dd)(dd),")             // date
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
+            .number("(dd)(dd)(dd),")             // date (ddmmyy)
             .any()
             .compile();
 
@@ -90,10 +88,7 @@ public class SiwiProtocolDecoder extends BaseProtocolDecoder {
         position.setAltitude(parser.nextDouble());
         position.setCourse(parser.nextInt());
 
-        DateBuilder dateBuilder = new DateBuilder(TimeZone.getTimeZone("IST"))
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY4, "IST"));
 
         return position;
     }

--- a/src/org/traccar/protocol/StarLinkProtocolDecoder.java
+++ b/src/org/traccar/protocol/StarLinkProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.CellTower;
@@ -78,17 +77,11 @@ public class StarLinkProtocolDecoder extends BaseProtocolDecoder {
         position.set(Position.KEY_TYPE, parser.nextInt());
         position.set(Position.KEY_INDEX, parser.nextInt());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setDeviceTime(dateBuilder.getDate());
+        position.setDeviceTime(parser.nextDateTime());
 
         position.set(Position.KEY_EVENT, parser.nextInt());
 
-        dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setFixTime(dateBuilder.getDate());
+        position.setFixTime(parser.nextDateTime());
 
         position.setValid(true);
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN));

--- a/src/org/traccar/protocol/StarLinkProtocolDecoder.java
+++ b/src/org/traccar/protocol/StarLinkProtocolDecoder.java
@@ -18,6 +18,7 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
+import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.CellTower;
@@ -77,11 +78,17 @@ public class StarLinkProtocolDecoder extends BaseProtocolDecoder {
         position.set(Position.KEY_TYPE, parser.nextInt());
         position.set(Position.KEY_INDEX, parser.nextInt());
 
-        position.setDeviceTime(parser.nextDateTime());
+        DateBuilder dateBuilder = new DateBuilder()
+                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
+                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
+        position.setDeviceTime(dateBuilder.getDate());
 
         position.set(Position.KEY_EVENT, parser.nextInt());
 
-        position.setFixTime(parser.nextDateTime());
+        dateBuilder = new DateBuilder()
+                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
+                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
+        position.setFixTime(dateBuilder.getDate());
 
         position.setValid(true);
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN));

--- a/src/org/traccar/protocol/Stl060ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Stl060ProtocolDecoder.java
@@ -84,7 +84,7 @@ public class Stl060ProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(deviceSession.getDeviceId());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY_HMS));
 
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.DEG_MIN_MIN_HEM));
         position.setLongitude(parser.nextCoordinate(Parser.CoordinateFormat.DEG_MIN_MIN_HEM));

--- a/src/org/traccar/protocol/Stl060ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Stl060ProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.Position;
@@ -85,10 +84,7 @@ public class Stl060ProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(deviceSession.getDeviceId());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
 
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.DEG_MIN_MIN_HEM));
         position.setLongitude(parser.nextCoordinate(Parser.CoordinateFormat.DEG_MIN_MIN_HEM));

--- a/src/org/traccar/protocol/Stl060ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Stl060ProtocolDecoder.java
@@ -37,8 +37,8 @@ public class Stl060ProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+),")                     // imei
             .text("D001,")                       // type
             .expression("[^,]*,")                // vehicle
-            .number("(dd)/(dd)/(dd),")           // date
-            .number("(dd):(dd):(dd),")           // time
+            .number("(dd)/(dd)/(dd),")           // date (dd/mm/yy)
+            .number("(dd):(dd):(dd),")           // time (hh:mm:ss)
             .number("(dd)(dd).?(d+)([NS]),")     // latitude
             .number("(ddd)(dd).?(d+)([EW]),")    // longitude
             .number("(d+.?d*),")                 // speed

--- a/src/org/traccar/protocol/SupermateProtocolDecoder.java
+++ b/src/org/traccar/protocol/SupermateProtocolDecoder.java
@@ -79,7 +79,7 @@ public class SupermateProtocolDecoder extends BaseProtocolDecoder {
 
         position.setValid(parser.next().equals("A"));
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS, 16));
+        position.setTime(parser.nextDateTime(16));
 
         if (parser.nextInt(16) == 8) {
             position.setLatitude(-parser.nextInt(16) / 600000.0);

--- a/src/org/traccar/protocol/SupermateProtocolDecoder.java
+++ b/src/org/traccar/protocol/SupermateProtocolDecoder.java
@@ -19,7 +19,6 @@ import org.jboss.netty.buffer.ChannelBuffers;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.Position;
@@ -42,16 +41,10 @@ public class SupermateProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+),")                     // command id
             .expression("([^,]{2}),")            // command
             .expression("([AV]),")               // validity
-            .number("(xx)")                      // year
-            .number("(xx)")                      // month
-            .number("(xx),")                     // day
-            .number("(xx)")                      // hours
-            .number("(xx)")                      // minutes
-            .number("(xx),")                     // seconds
-            .number("(x)")
-            .number("(x{7}),")                   // latitude
-            .number("(x)")
-            .number("(x{7}),")                   // longitude
+            .number("(xx)(xx)(xx),")             // date (yymmdd)
+            .number("(xx)(xx)(xx),")             // time (hhmmss)
+            .number("(x)(x{7}),")                // latitude
+            .number("(x)(x{7}),")                // longitude
             .number("(x{4}),")                   // speed
             .number("(x{4}),")                   // course
             .number("(x{12}),")                  // status
@@ -86,10 +79,7 @@ public class SupermateProtocolDecoder extends BaseProtocolDecoder {
 
         position.setValid(parser.next().equals("A"));
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(16), parser.nextInt(16), parser.nextInt(16))
-                .setTime(parser.nextInt(16), parser.nextInt(16), parser.nextInt(16));
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS, 16));
 
         if (parser.nextInt(16) == 8) {
             position.setLatitude(-parser.nextInt(16) / 600000.0);

--- a/src/org/traccar/protocol/T55ProtocolDecoder.java
+++ b/src/org/traccar/protocol/T55ProtocolDecoder.java
@@ -36,7 +36,7 @@ public class T55ProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN_GPRMC = new PatternBuilder()
             .text("$GPRMC,")
-            .number("(dd)(dd)(dd).?d*,")         // time
+            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss.ms)
             .expression("([AV]),")               // validity
             .number("(dd)(dd.d+),")              // latitude
             .expression("([NS]),")
@@ -44,7 +44,7 @@ public class T55ProtocolDecoder extends BaseProtocolDecoder {
             .expression("([EW]),")
             .number("(d+.?d*)?,")                // speed
             .number("(d+.?d*)?,")                // course
-            .number("(dd)(dd)(dd),")             // date
+            .number("(dd)(dd)(dd),")             // date (ddmmyy)
             .expression("[^*]+")
             .text("*")
             .expression("[^,]+")
@@ -59,7 +59,7 @@ public class T55ProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN_GPGGA = new PatternBuilder()
             .text("$GPGGA,")
-            .number("(dd)(dd)(dd).?d*,")         // time
+            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss.ms)
             .number("(d+)(dd.d+),")              // latitude
             .expression("([NS]),")
             .number("(d+)(dd.d+),")              // longitude

--- a/src/org/traccar/protocol/T55ProtocolDecoder.java
+++ b/src/org/traccar/protocol/T55ProtocolDecoder.java
@@ -36,7 +36,7 @@ public class T55ProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN_GPRMC = new PatternBuilder()
             .text("$GPRMC,")
-            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss.ms)
+            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss)
             .expression("([AV]),")               // validity
             .number("(dd)(dd.d+),")              // latitude
             .expression("([NS]),")
@@ -59,7 +59,7 @@ public class T55ProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN_GPGGA = new PatternBuilder()
             .text("$GPGGA,")
-            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss.ms)
+            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss)
             .number("(d+)(dd.d+),")              // latitude
             .expression("([NS]),")
             .number("(d+)(dd.d+),")              // longitude
@@ -82,7 +82,7 @@ public class T55ProtocolDecoder extends BaseProtocolDecoder {
     private static final Pattern PATTERN_TRCCR = new PatternBuilder()
             .text("$TRCCR,")
             .number("(dddd)(dd)(dd)")            // date (yyyymmdd)
-            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss.ms)
+            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss)
             .expression("([AV]),")               // validity
             .number("(-?d+.d+),")                // latitude
             .number("(-?d+.d+),")                // longitude

--- a/src/org/traccar/protocol/T55ProtocolDecoder.java
+++ b/src/org/traccar/protocol/T55ProtocolDecoder.java
@@ -81,8 +81,8 @@ public class T55ProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN_TRCCR = new PatternBuilder()
             .text("$TRCCR,")
-            .number("(dddd)(dd)(dd)")            // date
-            .number("(dd)(dd)(dd).?d*,")         // time
+            .number("(dddd)(dd)(dd)")            // date (yyyymmdd)
+            .number("(dd)(dd)(dd).?d*,")         // time (hhmmss.ms)
             .expression("([AV]),")               // validity
             .number("(-?d+.d+),")                // latitude
             .number("(-?d+.d+),")                // longitude
@@ -210,10 +210,7 @@ public class T55ProtocolDecoder extends BaseProtocolDecoder {
         position.setProtocol(getProtocolName());
         position.setDeviceId(deviceSession.getDeviceId());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime());
 
         position.setValid(parser.next().equals("A"));
         position.setLatitude(parser.nextDouble());

--- a/src/org/traccar/protocol/TaipProtocolDecoder.java
+++ b/src/org/traccar/protocol/TaipProtocolDecoder.java
@@ -50,8 +50,8 @@ public class TaipProtocolDecoder extends BaseProtocolDecoder {
             .or()
             .expression("(?:RGP|RCQ|RBR)")       // type
             .number("(?:dd)?")
-            .number("(dd)(dd)(dd)")              // date
-            .number("(dd)(dd)(dd)")              // time
+            .number("(dd)(dd)(dd)")              // date (mmddyy)
+            .number("(dd)(dd)(dd)")              // time (hhmmss)
             .groupEnd()
             .number("([-+]dd)(d{5})")            // latitude
             .number("([-+]ddd)(d{5})")           // longitude
@@ -108,10 +108,7 @@ public class TaipProtocolDecoder extends BaseProtocolDecoder {
         }
 
         if (parser.hasNext(6)) {
-            DateBuilder dateBuilder = new DateBuilder()
-                    .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                    .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-            position.setTime(dateBuilder.getDate());
+            position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
         }
 
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.DEG_DEG));

--- a/src/org/traccar/protocol/TaipProtocolDecoder.java
+++ b/src/org/traccar/protocol/TaipProtocolDecoder.java
@@ -108,7 +108,7 @@ public class TaipProtocolDecoder extends BaseProtocolDecoder {
         }
 
         if (parser.hasNext(6)) {
-            position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
+            position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY_HMS));
         }
 
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.DEG_DEG));

--- a/src/org/traccar/protocol/TelicProtocolDecoder.java
+++ b/src/org/traccar/protocol/TelicProtocolDecoder.java
@@ -81,7 +81,7 @@ public class TelicProtocolDecoder extends BaseProtocolDecoder {
 
         position.set(Position.KEY_ALARM, decodeAlarm(event));
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY_HMS));
 
         if (parser.hasNext(6)) {
             position.setLongitude(parser.nextCoordinate(Parser.CoordinateFormat.DEG_MIN_MIN));

--- a/src/org/traccar/protocol/TelicProtocolDecoder.java
+++ b/src/org/traccar/protocol/TelicProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
@@ -39,8 +38,8 @@ public class TelicProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+),")                     // type
             .number("d{12},")                    // event time
             .number("d+,")
-            .number("(dd)(dd)(dd)")              // date
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd)")              // date (ddmmyy)
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .groupBegin()
             .number("(ddd)(dd)(dddd),")          // longitude
             .number("(dd)(dd)(dddd),")           // latitude
@@ -82,10 +81,7 @@ public class TelicProtocolDecoder extends BaseProtocolDecoder {
 
         position.set(Position.KEY_ALARM, decodeAlarm(event));
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
 
         if (parser.hasNext(6)) {
             position.setLongitude(parser.nextCoordinate(Parser.CoordinateFormat.DEG_MIN_MIN));

--- a/src/org/traccar/protocol/Tk102ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Tk102ProtocolDecoder.java
@@ -49,7 +49,7 @@ public class Tk102ProtocolDecoder extends BaseProtocolDecoder {
     private static final Pattern PATTERN = new PatternBuilder()
             .text("(")
             .expression("[A-Z]+")
-            .number("(dd)(dd)(dd)")              // time
+            .number("(dd)(dd)(dd)")              // time (hhmmss)
             .expression("([AV])")                // validity
             .number("(dd)(dd.dddd)([NS])")       // latitude
             .number("(ddd)(dd.dddd)([EW])")      // longitude

--- a/src/org/traccar/protocol/Tk103ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Tk103ProtocolDecoder.java
@@ -41,14 +41,14 @@ public class Tk103ProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+)(,)?")                  // device id
             .expression(".{4},?")                // command
             .number("d*")                        // imei?
-            .number("(dd)(dd)(dd),?")            // date
+            .number("(dd)(dd)(dd),?")            // date (yymmdd or mmddyy?)
             .expression("([AV]),?")              // validity
             .number("(d+)(dd.d+)")               // latitude
             .expression("([NS]),?")
             .number("(d+)(dd.d+)")               // longitude
             .expression("([EW]),?")
             .number("(d+.d)(?:d*,)?")            // speed
-            .number("(dd)(dd)(dd),?")            // time
+            .number("(dd)(dd)(dd),?")            // time (hhmmss)
             .number("(d+.?d{1,2}),?")            // course
             .number("(?:([01]{8})|(x{8}))?,?")   // state
             .number("(?:L(x+))?")                // odometer

--- a/src/org/traccar/protocol/Tk103ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Tk103ProtocolDecoder.java
@@ -61,7 +61,7 @@ public class Tk103ProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+),")                     // device id
             .text("ZC20,")
             .number("(dd)(dd)(dd),")             // date (ddmmyy)
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("d+,")                       // battery level
             .number("(d+),")                     // battery voltage
             .number("(d+),")                     // power voltage
@@ -138,11 +138,7 @@ public class Tk103ProtocolDecoder extends BaseProtocolDecoder {
             }
             position.setDeviceId(deviceSession.getDeviceId());
 
-            DateBuilder dateBuilder = new DateBuilder()
-                    .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                    .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-
-            getLastLocation(position, dateBuilder.getDate());
+            getLastLocation(position, parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
 
             int battery = parser.nextInt();
             if (battery != 65535) {

--- a/src/org/traccar/protocol/Tk103ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Tk103ProtocolDecoder.java
@@ -41,7 +41,7 @@ public class Tk103ProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+)(,)?")                  // device id
             .expression(".{4},?")                // command
             .number("d*")                        // imei?
-            .number("(dd)(dd)(dd),?")            // date (yymmdd or mmddyy?)
+            .number("(dd)(dd)(dd),?")            // date (mmddyy if comma-delimited, otherwise yyddmm)
             .expression("([AV]),?")              // validity
             .number("(d+)(dd.d+)")               // latitude
             .expression("([NS]),?")

--- a/src/org/traccar/protocol/Tk103ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Tk103ProtocolDecoder.java
@@ -138,7 +138,7 @@ public class Tk103ProtocolDecoder extends BaseProtocolDecoder {
             }
             position.setDeviceId(deviceSession.getDeviceId());
 
-            getLastLocation(position, parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
+            getLastLocation(position, parser.nextDateTime(Parser.DateTimeFormat.DMY_HMS));
 
             int battery = parser.nextInt();
             if (battery != 65535) {

--- a/src/org/traccar/protocol/Tlt2hProtocolDecoder.java
+++ b/src/org/traccar/protocol/Tlt2hProtocolDecoder.java
@@ -45,7 +45,7 @@ public class Tlt2hProtocolDecoder extends BaseProtocolDecoder {
     private static final Pattern PATTERN_POSITION = new PatternBuilder()
             .number("#(x+)?")                    // cell info
             .text("$GPRMC,")
-            .number("(dd)(dd)(dd).(d+),")        // time (hhmmss.ms)
+            .number("(dd)(dd)(dd).(ddd),")       // time (hhmmss)
             .expression("([AV]),")               // validity
             .number("(d+)(dd.d+),")              // latitude
             .expression("([NS]),")

--- a/src/org/traccar/protocol/Tlt2hProtocolDecoder.java
+++ b/src/org/traccar/protocol/Tlt2hProtocolDecoder.java
@@ -45,7 +45,7 @@ public class Tlt2hProtocolDecoder extends BaseProtocolDecoder {
     private static final Pattern PATTERN_POSITION = new PatternBuilder()
             .number("#(x+)?")                    // cell info
             .text("$GPRMC,")
-            .number("(dd)(dd)(dd).(ddd),")       // time (hhmmss)
+            .number("(dd)(dd)(dd).(ddd),")       // time (hhmmss.sss)
             .expression("([AV]),")               // validity
             .number("(d+)(dd.d+),")              // latitude
             .expression("([NS]),")
@@ -91,8 +91,7 @@ public class Tlt2hProtocolDecoder extends BaseProtocolDecoder {
                 parser.next(); // base station info
 
                 DateBuilder dateBuilder = new DateBuilder()
-                        .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-                parser.next();
+                        .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt(), parser.nextInt());
 
                 position.setValid(parser.next().equals("A"));
                 position.setLatitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/Tlt2hProtocolDecoder.java
+++ b/src/org/traccar/protocol/Tlt2hProtocolDecoder.java
@@ -45,7 +45,7 @@ public class Tlt2hProtocolDecoder extends BaseProtocolDecoder {
     private static final Pattern PATTERN_POSITION = new PatternBuilder()
             .number("#(x+)?")                    // cell info
             .text("$GPRMC,")
-            .number("(dd)(dd)(dd).(d+),")        // time
+            .number("(dd)(dd)(dd).(d+),")        // time (hhmmss.ms)
             .expression("([AV]),")               // validity
             .number("(d+)(dd.d+),")              // latitude
             .expression("([NS]),")

--- a/src/org/traccar/protocol/TmgProtocolDecoder.java
+++ b/src/org/traccar/protocol/TmgProtocolDecoder.java
@@ -19,7 +19,6 @@ import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
 import org.traccar.helper.BitUtil;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
@@ -39,8 +38,8 @@ public class TmgProtocolDecoder extends BaseProtocolDecoder {
             .expression("(...),")                // type
             .expression("[LH],")                 // history
             .number("(d+),")                     // imei
-            .number("(dd)(dd)(dddd),")           // date
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dddd),")           // date (ddmmyyyy)
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("(d),")                      // status
             .number("(dd)(dd.d+),")              // latitude
             .expression("([NS]),")
@@ -114,10 +113,7 @@ public class TmgProtocolDecoder extends BaseProtocolDecoder {
                 break;
         }
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY4_HMS));
 
         position.setValid(parser.nextInt() > 0);
         position.setLatitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/TmgProtocolDecoder.java
+++ b/src/org/traccar/protocol/TmgProtocolDecoder.java
@@ -113,7 +113,7 @@ public class TmgProtocolDecoder extends BaseProtocolDecoder {
                 break;
         }
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY4_HMS));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY_HMS));
 
         position.setValid(parser.nextInt() > 0);
         position.setLatitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/TopflytechProtocolDecoder.java
+++ b/src/org/traccar/protocol/TopflytechProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.Position;
@@ -37,7 +36,7 @@ public class TopflytechProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+)")                      // imei
             .any()
             .number("(dd)(dd)(dd)")              // date (yymmdd)
-            .number("(dd)(dd)(dd)")              // time
+            .number("(dd)(dd)(dd)")              // time (hhmmss)
             .expression("([AV])")
             .number("(dd)(dd.dddd)([NS])")       // latitude
             .number("(ddd)(dd.dddd)([EW])")      // longitude
@@ -63,10 +62,7 @@ public class TopflytechProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(deviceSession.getDeviceId());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
 
         position.setValid(parser.next().equals("A"));
         position.setLatitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/TopflytechProtocolDecoder.java
+++ b/src/org/traccar/protocol/TopflytechProtocolDecoder.java
@@ -62,7 +62,7 @@ public class TopflytechProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(deviceSession.getDeviceId());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
+        position.setTime(parser.nextDateTime());
 
         position.setValid(parser.next().equals("A"));
         position.setLatitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/TotemProtocolDecoder.java
+++ b/src/org/traccar/protocol/TotemProtocolDecoder.java
@@ -270,7 +270,7 @@ public class TotemProtocolDecoder extends BaseProtocolDecoder {
                 position.set(Position.KEY_ALARM, decodeAlarm(Short.parseShort(parser.next(), 16)));
             }
 
-            position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
+            position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY_HMS));
 
             position.set(Position.PREFIX_IO + 1, parser.next());
             position.set(Position.KEY_BATTERY, parser.nextDouble() * 0.1);

--- a/src/org/traccar/protocol/TotemProtocolDecoder.java
+++ b/src/org/traccar/protocol/TotemProtocolDecoder.java
@@ -54,7 +54,7 @@ public class TotemProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+.d+)|")                  // hdop
             .number("(d+.d+)|")                  // vdop
             .number("(d+)|")                     // io status
-            .number("d+|")                       // battery time (units?)
+            .number("d+|")                       // battery time
             .number("d")                         // charged
             .number("(ddd)")                     // battery
             .number("(dddd)|")                   // power

--- a/src/org/traccar/protocol/TotemProtocolDecoder.java
+++ b/src/org/traccar/protocol/TotemProtocolDecoder.java
@@ -41,7 +41,7 @@ public class TotemProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+)|")                     // imei
             .expression("(..)")                  // alarm
             .text("$GPRMC,")
-            .number("(dd)(dd)(dd).d+,")          // time (hhmmss.ms)
+            .number("(dd)(dd)(dd).d+,")          // time (hhmmss)
             .expression("([AV]),")               // validity
             .number("(d+)(dd.d+),([NS]),")       // latitude
             .number("(d+)(dd.d+),([EW]),")       // longitude

--- a/src/org/traccar/protocol/TotemProtocolDecoder.java
+++ b/src/org/traccar/protocol/TotemProtocolDecoder.java
@@ -41,13 +41,13 @@ public class TotemProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+)|")                     // imei
             .expression("(..)")                  // alarm
             .text("$GPRMC,")
-            .number("(dd)(dd)(dd).d+,")          // time
+            .number("(dd)(dd)(dd).d+,")          // time (hhmmss.ms)
             .expression("([AV]),")               // validity
             .number("(d+)(dd.d+),([NS]),")       // latitude
             .number("(d+)(dd.d+),([EW]),")       // longitude
             .number("(d+.?d*)?,")                // speed
             .number("(d+.?d*)?,")                // course
-            .number("(dd)(dd)(dd)")              // date
+            .number("(dd)(dd)(dd)")              // date (ddmmyy)
             .expression("[^*]*").text("*")
             .number("xx|")                       // checksum
             .number("(d+.d+)|")                  // pdop
@@ -75,7 +75,7 @@ public class TotemProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+)|")                     // imei
             .expression("(..)")                  // alarm type
             .number("(dd)(dd)(dd)")              // date (ddmmyy)
-            .number("(dd)(dd)(dd)|")             // time
+            .number("(dd)(dd)(dd)|")             // time (hhmmss)
             .expression("([AV])|")               // validity
             .number("(d+)(dd.d+)|")              // latitude
             .expression("([NS])|")
@@ -104,7 +104,7 @@ public class TotemProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+)|")                     // imei
             .expression("(..)")                  // alarm type
             .number("(dd)(dd)(dd)")              // date (yymmdd)
-            .number("(dd)(dd)(dd)")              // time
+            .number("(dd)(dd)(dd)")              // time (hhmmss)
             .number("(xxxx)")                    // io status
             .expression("[01]")                  // charging
             .number("(dd)")                      // battery
@@ -135,7 +135,7 @@ public class TotemProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+)|")                     // imei
             .number("(x{8})")                    // status
             .number("(dd)(dd)(dd)")              // date (yymmdd)
-            .number("(dd)(dd)(dd)")              // time
+            .number("(dd)(dd)(dd)")              // time (hhmmss)
             .number("(dd)")                      // battery
             .number("(dd)")                      // external power
             .number("(dddd)")                    // adc 1
@@ -269,10 +269,8 @@ public class TotemProtocolDecoder extends BaseProtocolDecoder {
             if (parser.hasNext()) {
                 position.set(Position.KEY_ALARM, decodeAlarm(Short.parseShort(parser.next(), 16)));
             }
-            DateBuilder dateBuilder = new DateBuilder()
-                    .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                    .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-            position.setTime(dateBuilder.getDate());
+
+            position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
 
             position.set(Position.PREFIX_IO + 1, parser.next());
             position.set(Position.KEY_BATTERY, parser.nextDouble() * 0.1);
@@ -298,10 +296,7 @@ public class TotemProtocolDecoder extends BaseProtocolDecoder {
         } else if (pattern == PATTERN4) {
             position.set(Position.KEY_STATUS, parser.next());
 
-            DateBuilder dateBuilder = new DateBuilder()
-                    .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                    .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-            position.setTime(dateBuilder.getDate());
+            position.setTime(parser.nextDateTime());
 
             position.set(Position.KEY_BATTERY, parser.nextDouble() * 0.1);
             position.set(Position.KEY_POWER, parser.nextDouble());

--- a/src/org/traccar/protocol/TotemProtocolDecoder.java
+++ b/src/org/traccar/protocol/TotemProtocolDecoder.java
@@ -54,7 +54,7 @@ public class TotemProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+.d+)|")                  // hdop
             .number("(d+.d+)|")                  // vdop
             .number("(d+)|")                     // io status
-            .number("d+|")                       // time
+            .number("d+|")                       // battery time (units?)
             .number("d")                         // charged
             .number("(ddd)")                     // battery
             .number("(dddd)|")                   // power

--- a/src/org/traccar/protocol/TotemProtocolDecoder.java
+++ b/src/org/traccar/protocol/TotemProtocolDecoder.java
@@ -103,7 +103,7 @@ public class TotemProtocolDecoder extends BaseProtocolDecoder {
             .number("xx")                        // length
             .number("(d+)|")                     // imei
             .expression("(..)")                  // alarm type
-            .number("(dd)(dd)(dd)")              // date (yymmdd)
+            .number("(dd)(dd)(dd)")              // date (ddmmyy)
             .number("(dd)(dd)(dd)")              // time (hhmmss)
             .number("(xxxx)")                    // io status
             .expression("[01]")                  // charging

--- a/src/org/traccar/protocol/Tr20ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Tr20ProtocolDecoder.java
@@ -81,7 +81,7 @@ public class Tr20ProtocolDecoder extends BaseProtocolDecoder {
 
         position.setValid(parser.next().equals("A"));
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
+        position.setTime(parser.nextDateTime());
 
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN));
         position.setLongitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN));

--- a/src/org/traccar/protocol/Tr20ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Tr20ProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
@@ -44,7 +43,7 @@ public class Tr20ProtocolDecoder extends BaseProtocolDecoder {
             .expression("([^,]+),")              // id
             .expression("([AL]),")               // validity
             .number("(dd)(dd)(dd)")              // date (yymmdd)
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .expression("([NS])")
             .number("(dd)(dd.d+)")               // latitude
             .expression("([EW])")
@@ -82,10 +81,7 @@ public class Tr20ProtocolDecoder extends BaseProtocolDecoder {
 
         position.setValid(parser.next().equals("A"));
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
 
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN));
         position.setLongitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN));

--- a/src/org/traccar/protocol/Tr900ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Tr900ProtocolDecoder.java
@@ -74,7 +74,7 @@ public class Tr900ProtocolDecoder extends BaseProtocolDecoder {
 
         position.setValid(parser.nextInt() == 1);
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
+        position.setTime(parser.nextDateTime());
 
         position.setLongitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN));
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN));

--- a/src/org/traccar/protocol/Tr900ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Tr900ProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.Position;
@@ -37,7 +36,7 @@ public class Tr900ProtocolDecoder extends BaseProtocolDecoder {
             .number("d+,")                       // period
             .number("(d),")                      // fix
             .number("(dd)(dd)(dd),")             // date (yymmdd)
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .expression("([EW])")
             .number("(ddd)(dd.d+),")             // longitude
             .expression("([NS])")
@@ -75,10 +74,7 @@ public class Tr900ProtocolDecoder extends BaseProtocolDecoder {
 
         position.setValid(parser.nextInt() == 1);
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
 
         position.setLongitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN));
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG_MIN));

--- a/src/org/traccar/protocol/TrackboxProtocolDecoder.java
+++ b/src/org/traccar/protocol/TrackboxProtocolDecoder.java
@@ -33,7 +33,7 @@ public class TrackboxProtocolDecoder extends BaseProtocolDecoder {
     }
 
     private static final Pattern PATTERN = new PatternBuilder()
-            .number("(dd)(dd)(dd).(ddd),")       // time
+            .number("(dd)(dd)(dd).(ddd),")       // time (hhmmss.ms)
             .number("(dd)(dd.dddd)([NS]),")      // latitude
             .number("(ddd)(dd.dddd)([EW]),")     // longitude
             .number("(d+.d),")                   // hdop
@@ -42,7 +42,7 @@ public class TrackboxProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+.d+),")                  // course
             .number("d+.d+,")                    // speed (kph)
             .number("(d+.d+),")                  // speed (knots)
-            .number("(dd)(dd)(dd),")             // date
+            .number("(dd)(dd)(dd),")             // date (ddmmyy)
             .number("(d+)")                      // satellites
             .compile();
 

--- a/src/org/traccar/protocol/TrackboxProtocolDecoder.java
+++ b/src/org/traccar/protocol/TrackboxProtocolDecoder.java
@@ -33,7 +33,7 @@ public class TrackboxProtocolDecoder extends BaseProtocolDecoder {
     }
 
     private static final Pattern PATTERN = new PatternBuilder()
-            .number("(dd)(dd)(dd).(ddd),")       // time (hhmmss.ms)
+            .number("(dd)(dd)(dd).(ddd),")       // time (hhmmss.sss)
             .number("(dd)(dd.dddd)([NS]),")      // latitude
             .number("(ddd)(dd.dddd)([EW]),")     // longitude
             .number("(d+.d),")                   // hdop

--- a/src/org/traccar/protocol/TrakMateProtocolDecoder.java
+++ b/src/org/traccar/protocol/TrakMateProtocolDecoder.java
@@ -119,7 +119,7 @@ public class TrakMateProtocolDecoder extends BaseProtocolDecoder {
         position.setLatitude(parser.nextDouble());
         position.setLongitude(parser.nextDouble());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY2));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY));
 
         position.set(Position.KEY_VERSION_FW, parser.next());
         position.set(Position.KEY_VERSION_HW, parser.next());
@@ -150,7 +150,7 @@ public class TrakMateProtocolDecoder extends BaseProtocolDecoder {
         position.setLatitude(parser.nextDouble());
         position.setLongitude(parser.nextDouble());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY2));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY));
 
         position.setSpeed(parser.nextDouble());
         position.setCourse(parser.nextDouble());
@@ -179,7 +179,7 @@ public class TrakMateProtocolDecoder extends BaseProtocolDecoder {
         position.setLatitude(parser.nextDouble());
         position.setLongitude(parser.nextDouble());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY2));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY));
 
         position.setSpeed(parser.nextDouble());
         position.setCourse(parser.nextDouble());

--- a/src/org/traccar/protocol/TrakMateProtocolDecoder.java
+++ b/src/org/traccar/protocol/TrakMateProtocolDecoder.java
@@ -19,7 +19,6 @@ import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.Context;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.Position;
@@ -42,8 +41,8 @@ public class TrakMateProtocolDecoder extends BaseProtocolDecoder {
             .expression("([^ ]+)|")              // uid
             .number("(d+.d+)|")                  // latitude
             .number("(d+.d+)|")                  // longitude
-            .number("(dd)(dd)(dd)|")             // time
-            .number("(dd)(dd)(dd)|")             // date
+            .number("(dd)(dd)(dd)|")             // time (hhmmss)
+            .number("(dd)(dd)(dd)|")             // date (ddmmyy)
             .number("(d+.d+)|")                  // software ver
             .number("(d+.d+)|")                  // Hardware ver
             .any()
@@ -55,8 +54,8 @@ public class TrakMateProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+)|")                     // seq
             .number("(d+.d+)|")                  // latitude
             .number("(d+.d+)|")                  // longitude
-            .number("(dd)(dd)(dd)|")             // time
-            .number("(dd)(dd)(dd)|")             // date
+            .number("(dd)(dd)(dd)|")             // time (hhmmss)
+            .number("(dd)(dd)(dd)|")             // date (ddmmyy)
             .number("(d+.d+)|")                  // speed
             .number("(d+.d+)|")                  // heading
             .number("(d+)|")                     // ignition
@@ -81,8 +80,8 @@ public class TrakMateProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+)|")                     // Alert status
             .number("(d+.d+)|")                  // latitude
             .number("(d+.d+)|")                  // longitude
-            .number("(dd)(dd)(dd)|")             // time
-            .number("(dd)(dd)(dd)|")             // date
+            .number("(dd)(dd)(dd)|")             // time (hhmmss)
+            .number("(dd)(dd)(dd)|")             // date (ddmmyy)
             .number("(d+.d+)|")                  // speed
             .number("(d+.d+)|")                  // heading
             .any()
@@ -120,10 +119,7 @@ public class TrakMateProtocolDecoder extends BaseProtocolDecoder {
         position.setLatitude(parser.nextDouble());
         position.setLongitude(parser.nextDouble());
 
-        DateBuilder dateBuilder = new DateBuilder(timeZone)
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY2));
 
         position.set(Position.KEY_VERSION_FW, parser.next());
         position.set(Position.KEY_VERSION_HW, parser.next());
@@ -154,10 +150,7 @@ public class TrakMateProtocolDecoder extends BaseProtocolDecoder {
         position.setLatitude(parser.nextDouble());
         position.setLongitude(parser.nextDouble());
 
-        DateBuilder dateBuilder = new DateBuilder(timeZone)
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY2));
 
         position.setSpeed(parser.nextDouble());
         position.setCourse(parser.nextDouble());
@@ -186,10 +179,7 @@ public class TrakMateProtocolDecoder extends BaseProtocolDecoder {
         position.setLatitude(parser.nextDouble());
         position.setLongitude(parser.nextDouble());
 
-        DateBuilder dateBuilder = new DateBuilder(timeZone)
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMS_DMY2));
 
         position.setSpeed(parser.nextDouble());
         position.setCourse(parser.nextDouble());

--- a/src/org/traccar/protocol/TrvProtocolDecoder.java
+++ b/src/org/traccar/protocol/TrvProtocolDecoder.java
@@ -38,14 +38,14 @@ public class TrvProtocolDecoder extends BaseProtocolDecoder {
     private static final Pattern PATTERN = new PatternBuilder()
             .text("TRV")
             .number("APdd")
-            .number("(dd)(dd)(dd)")              // date
+            .number("(dd)(dd)(dd)")              // date (yymmdd)
             .expression("([AV])")                // validity
             .number("(dd)(dd.d+)")               // latitude
             .expression("([NS])")
             .number("(ddd)(dd.d+)")              // longitude
             .expression("([EW])")
             .number("(ddd.d)")                   // speed
-            .number("(dd)(dd)(dd)")              // time
+            .number("(dd)(dd)(dd)")              // time (hhmmss)
             .number("([d.]{6})")                 // course
             .number("(ddd)")                     // gsm
             .number("(ddd)")                     // satellites

--- a/src/org/traccar/protocol/Tt8850ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Tt8850ProtocolDecoder.java
@@ -55,8 +55,8 @@ public class Tt8850ProtocolDecoder extends BaseProtocolDecoder {
             .number("(xxxx)?,")                  // lac
             .number("(xxxx)?,")                  // cell
             .any()
-            .number("(dddd)(dd)(dd)")            // date
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dddd)(dd)(dd)")            // date (yyyymmdd)
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("(xxxx)")
             .compile();
 

--- a/src/org/traccar/protocol/Tt8850ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Tt8850ProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
@@ -49,8 +48,8 @@ public class Tt8850ProtocolDecoder extends BaseProtocolDecoder {
             .number("(-?d{1,5}.d)?,")            // altitude
             .number("(-?d{1,3}.d{6}),")          // longitude
             .number("(-?d{1,2}.d{6}),")          // latitude
-            .number("(dddd)(dd)(dd)")            // date
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dddd)(dd)(dd)")            // date (yyyymmdd)
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("(0ddd)?,")                  // mcc
             .number("(0ddd)?,")                  // mnc
             .number("(xxxx)?,")                  // lac
@@ -87,10 +86,7 @@ public class Tt8850ProtocolDecoder extends BaseProtocolDecoder {
         position.setLongitude(parser.nextDouble());
         position.setLatitude(parser.nextDouble());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime());
 
         if (parser.hasNext(4)) {
             position.setNetwork(new Network(

--- a/src/org/traccar/protocol/UproProtocolDecoder.java
+++ b/src/org/traccar/protocol/UproProtocolDecoder.java
@@ -50,13 +50,13 @@ public class UproProtocolDecoder extends BaseProtocolDecoder {
             .compile();
 
     private static final Pattern PATTERN_LOCATION = new PatternBuilder()
-            .number("(dd)(dd)(dd)")              // time
+            .number("(dd)(dd)(dd)")              // time (hhmmss)
             .number("(dd)(dd)(dddd)")            // latitude
             .number("(ddd)(dd)(dddd)")           // longitude
             .number("(d)")                       // flags
             .number("(dd)")                      // speed
             .number("(dd)")                      // course
-            .number("(dd)(dd)(dd)")              // date
+            .number("(dd)(dd)(dd)")              // date (ddmmyy)
             .compile();
 
     private void decodeLocation(Position position, String data) {

--- a/src/org/traccar/protocol/V680ProtocolDecoder.java
+++ b/src/org/traccar/protocol/V680ProtocolDecoder.java
@@ -47,8 +47,8 @@ public class V680ProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+.d+),([NS]),")           // latitude
             .number("(d+.d+),")                  // speed
             .number("(d+.?d*)?#")                // course
-            .number("(dd)(dd)(dd)#")             // date
-            .number("(dd)(dd)(dd)")              // time
+            .number("(dd)(dd)(dd)#")             // date (ddmmyy)
+            .number("(dd)(dd)(dd)")              // time (hhmmss)
             .any()
             .compile();
 

--- a/src/org/traccar/protocol/VisiontekProtocolDecoder.java
+++ b/src/org/traccar/protocol/VisiontekProtocolDecoder.java
@@ -90,7 +90,7 @@ public class VisiontekProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(deviceSession.getDeviceId());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY_HMS));
 
         if (parser.hasNext(8)) {
             position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.DEG_MIN_MIN_HEM));

--- a/src/org/traccar/protocol/VisiontekProtocolDecoder.java
+++ b/src/org/traccar/protocol/VisiontekProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
@@ -37,8 +36,8 @@ public class VisiontekProtocolDecoder extends BaseProtocolDecoder {
             .text("$1,")
             .expression("([^,]+),")              // identifier
             .number("(d+),").optional()          // imei
-            .number("(dd),(dd),(dd),")           // date
-            .number("(dd),(dd),(dd),")           // time
+            .number("(dd),(dd),(dd),")           // date (dd,mm,yy)
+            .number("(dd),(dd),(dd),")           // time (hh,mm,ss)
             .groupBegin()
             .number("(dd)(dd).?(d+)([NS]),")     // latitude
             .number("(ddd)(dd).?(d+)([EW]),")    // longitude
@@ -91,10 +90,7 @@ public class VisiontekProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(deviceSession.getDeviceId());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
 
         if (parser.hasNext(8)) {
             position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.DEG_MIN_MIN_HEM));

--- a/src/org/traccar/protocol/WatchProtocolDecoder.java
+++ b/src/org/traccar/protocol/WatchProtocolDecoder.java
@@ -181,7 +181,7 @@ public class WatchProtocolDecoder extends BaseProtocolDecoder {
             position.setProtocol(getProtocolName());
             position.setDeviceId(deviceSession.getDeviceId());
 
-            position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
+            position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY_HMS));
 
             position.setValid(parser.next().equals("A"));
             position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.DEG_HEM));

--- a/src/org/traccar/protocol/WatchProtocolDecoder.java
+++ b/src/org/traccar/protocol/WatchProtocolDecoder.java
@@ -19,7 +19,6 @@ import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
 import org.traccar.helper.BitUtil;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
@@ -50,7 +49,7 @@ public class WatchProtocolDecoder extends BaseProtocolDecoder {
     private static final Pattern PATTERN_POSITION = new PatternBuilder()
             .text(",")
             .number("(dd)(dd)(dd),")             // date (ddmmyy)
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .expression("([AV]),")               // validity
             .number(" *(-?d+.d+),")              // latitude
             .expression("([NS]),")
@@ -182,10 +181,7 @@ public class WatchProtocolDecoder extends BaseProtocolDecoder {
             position.setProtocol(getProtocolName());
             position.setDeviceId(deviceSession.getDeviceId());
 
-            DateBuilder dateBuilder = new DateBuilder()
-                    .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                    .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-            position.setTime(dateBuilder.getDate());
+            position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
 
             position.setValid(parser.next().equals("A"));
             position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.DEG_HEM));

--- a/src/org/traccar/protocol/WialonProtocolDecoder.java
+++ b/src/org/traccar/protocol/WialonProtocolDecoder.java
@@ -84,7 +84,7 @@ public class WialonProtocolDecoder extends BaseProtocolDecoder {
         position.setProtocol(getProtocolName());
         position.setDeviceId(deviceSession.getDeviceId());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY_HMS));
 
         position.setLatitude(parser.nextCoordinate());
         position.setLongitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/WialonProtocolDecoder.java
+++ b/src/org/traccar/protocol/WialonProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
@@ -39,7 +38,7 @@ public class WialonProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN = new PatternBuilder()
             .number("(dd)(dd)(dd);")             // date (ddmmyy)
-            .number("(dd)(dd)(dd);")             // time
+            .number("(dd)(dd)(dd);")             // time (hhmmss)
             .number("(dd)(dd.d+);")              // latitude
             .expression("([NS]);")
             .number("(ddd)(dd.d+);")             // longitude
@@ -85,10 +84,7 @@ public class WialonProtocolDecoder extends BaseProtocolDecoder {
         position.setProtocol(getProtocolName());
         position.setDeviceId(deviceSession.getDeviceId());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDateReverse(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.DMY2_HMS));
 
         position.setLatitude(parser.nextCoordinate());
         position.setLongitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/WondexProtocolDecoder.java
+++ b/src/org/traccar/protocol/WondexProtocolDecoder.java
@@ -19,7 +19,6 @@ import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
@@ -39,8 +38,8 @@ public class WondexProtocolDecoder extends BaseProtocolDecoder {
     private static final Pattern PATTERN = new PatternBuilder()
             .number("[^d]*")                     // deader
             .number("(d+),")                     // device identifier
-            .number("(dddd)(dd)(dd)")            // date
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dddd)(dd)(dd)")            // date (yyyymmdd)
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("(-?d+.d+),")                // longitude
             .number("(-?d+.d+),")                // latitude
             .number("(d+),")                     // speed
@@ -98,10 +97,7 @@ public class WondexProtocolDecoder extends BaseProtocolDecoder {
             }
             position.setDeviceId(deviceSession.getDeviceId());
 
-            DateBuilder dateBuilder = new DateBuilder()
-                    .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                    .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-            position.setTime(dateBuilder.getDate());
+            position.setTime(parser.nextDateTime());
 
             position.setLongitude(parser.nextDouble());
             position.setLatitude(parser.nextDouble());

--- a/src/org/traccar/protocol/XexunProtocolDecoder.java
+++ b/src/org/traccar/protocol/XexunProtocolDecoder.java
@@ -37,7 +37,7 @@ public class XexunProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN_BASIC = new PatternBuilder()
             .expression("G[PN]RMC,")
-            .number("(?:(dd)(dd)(dd))?.?d*,")    // time (hhmmss.sss)
+            .number("(?:(dd)(dd)(dd))?.?d*,")    // time (hhmmss)
             .expression("([AV]),")               // validity
             .number("(d*?)(d?d.d+),([NS]),")     // latitude
             .number("(d*?)(d?d.d+),([EW])?,")    // longitude

--- a/src/org/traccar/protocol/XexunProtocolDecoder.java
+++ b/src/org/traccar/protocol/XexunProtocolDecoder.java
@@ -37,7 +37,7 @@ public class XexunProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN_BASIC = new PatternBuilder()
             .expression("G[PN]RMC,")
-            .number("(?:(dd)(dd)(dd))?.(ddd),")   // time (hhmmss.sss)
+            .number("(?:(dd)(dd)(dd))?.?d*,")    // time (hhmmss.sss)
             .expression("([AV]),")               // validity
             .number("(d*?)(d?d.d+),([NS]),")     // latitude
             .number("(d*?)(d?d.d+),([EW])?,")    // longitude
@@ -104,7 +104,7 @@ public class XexunProtocolDecoder extends BaseProtocolDecoder {
         }
 
         DateBuilder dateBuilder = new DateBuilder()
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt(), parser.nextInt());
+                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
 
         position.setValid(parser.next().equals("A"));
         position.setLatitude(parser.nextCoordinate());

--- a/src/org/traccar/protocol/XexunProtocolDecoder.java
+++ b/src/org/traccar/protocol/XexunProtocolDecoder.java
@@ -37,7 +37,7 @@ public class XexunProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN_BASIC = new PatternBuilder()
             .expression("G[PN]RMC,")
-            .number("(?:(dd)(dd)(dd))?.(d+),")   // time (hhmmss.ms)
+            .number("(?:(dd)(dd)(dd))?.(ddd),")   // time (hhmmss.sss)
             .expression("([AV]),")               // validity
             .number("(d*?)(d?d.d+),([NS]),")     // latitude
             .number("(d*?)(d?d.d+),([EW])?,")    // longitude

--- a/src/org/traccar/protocol/XexunProtocolDecoder.java
+++ b/src/org/traccar/protocol/XexunProtocolDecoder.java
@@ -37,13 +37,13 @@ public class XexunProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN_BASIC = new PatternBuilder()
             .expression("G[PN]RMC,")
-            .number("(?:(dd)(dd)(dd))?.(d+),")   // time
+            .number("(?:(dd)(dd)(dd))?.(d+),")   // time (hhmmss.ms)
             .expression("([AV]),")               // validity
             .number("(d*?)(d?d.d+),([NS]),")     // latitude
             .number("(d*?)(d?d.d+),([EW])?,")    // longitude
             .number("(d+.?d*),")                 // speed
             .number("(d+.?d*)?,")                // course
-            .number("(?:(dd)(dd)(dd))?,")        // date
+            .number("(?:(dd)(dd)(dd))?,")        // date (ddmmyy)
             .expression("[^*]*").text("*")
             .number("xx")                        // checksum
             .expression("\\r\\n").optional()

--- a/src/org/traccar/protocol/XirgoProtocolDecoder.java
+++ b/src/org/traccar/protocol/XirgoProtocolDecoder.java
@@ -38,8 +38,8 @@ public class XirgoProtocolDecoder extends BaseProtocolDecoder {
             .text("$$")
             .number("(d+),")                     // imei
             .number("(d+),")                     // event
-            .number("(dddd)/(dd)/(dd),")         // date
-            .number("(dd):(dd):(dd),")           // time
+            .number("(dddd)/(dd)/(dd),")         // date (yyyy/mm/dd)
+            .number("(dd):(dd):(dd),")           // time (hh:mm:ss)
             .number("(-?d+.?d*),")               // latitude
             .number("(-?d+.?d*),")               // longitude
             .number("(-?d+.?d*),")               // altitude

--- a/src/org/traccar/protocol/XirgoProtocolDecoder.java
+++ b/src/org/traccar/protocol/XirgoProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
@@ -59,8 +58,8 @@ public class XirgoProtocolDecoder extends BaseProtocolDecoder {
             .text("$$")
             .number("(d+),")                     // imei
             .number("(d+),")                     // event
-            .number("(dddd)/(dd)/(dd),")         // date
-            .number("(dd):(dd):(dd),")           // time
+            .number("(dddd)/(dd)/(dd),")         // date (yyyy/mm/dd)
+            .number("(dd):(dd):(dd),")           // time (hh:mm:ss)
             .number("(-?d+.?d*),")               // latitude
             .number("(-?d+.?d*),")               // longitude
             .number("(-?d+.?d*),")               // altitude
@@ -120,10 +119,7 @@ public class XirgoProtocolDecoder extends BaseProtocolDecoder {
 
         position.set(Position.KEY_EVENT, parser.next());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime());
 
         position.setLatitude(parser.nextDouble());
         position.setLongitude(parser.nextDouble());

--- a/src/org/traccar/protocol/Xt013ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Xt013ProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.helper.UnitsConverter;
@@ -38,7 +37,7 @@ public class Xt013ProtocolDecoder extends BaseProtocolDecoder {
             .text("TK,")
             .number("(d+),")                     // imei
             .number("(dd)(dd)(dd)")              // date (yymmdd)
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .number("([+-]d+.d+),")              // latitude
             .number("([+-]d+.d+),")              // longitude
             .number("(d+),")                     // speed
@@ -75,10 +74,7 @@ public class Xt013ProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(deviceSession.getDeviceId());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
 
         position.setLatitude(parser.nextDouble());
         position.setLongitude(parser.nextDouble());

--- a/src/org/traccar/protocol/Xt013ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Xt013ProtocolDecoder.java
@@ -74,7 +74,7 @@ public class Xt013ProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(deviceSession.getDeviceId());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
+        position.setTime(parser.nextDateTime());
 
         position.setLatitude(parser.nextDouble());
         position.setLongitude(parser.nextDouble());

--- a/src/org/traccar/protocol/YwtProtocolDecoder.java
+++ b/src/org/traccar/protocol/YwtProtocolDecoder.java
@@ -18,7 +18,6 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.Position;
@@ -37,7 +36,7 @@ public class YwtProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+):")                     // unit identifier
             .number("d+,")                       // subtype
             .number("(dd)(dd)(dd)")              // date (yymmdd)
-            .number("(dd)(dd)(dd),")             // time
+            .number("(dd)(dd)(dd),")             // time (hhmmss)
             .expression("([EW])")
             .number("(ddd.d{6}),")               // longitude
             .expression("([NS])")
@@ -88,10 +87,7 @@ public class YwtProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(deviceSession.getDeviceId());
 
-        DateBuilder dateBuilder = new DateBuilder()
-                .setDate(parser.nextInt(), parser.nextInt(), parser.nextInt())
-                .setTime(parser.nextInt(), parser.nextInt(), parser.nextInt());
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
 
         position.setLongitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG));
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG));

--- a/src/org/traccar/protocol/YwtProtocolDecoder.java
+++ b/src/org/traccar/protocol/YwtProtocolDecoder.java
@@ -87,7 +87,7 @@ public class YwtProtocolDecoder extends BaseProtocolDecoder {
         }
         position.setDeviceId(deviceSession.getDeviceId());
 
-        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.Y2MD_HMS));
+        position.setTime(parser.nextDateTime());
 
         position.setLongitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG));
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG));


### PR DESCRIPTION
I introduced a new function in the Parser class, nextDateTime(). This allowed me to eliminate duplicative code in many protocols. I also found some discrepancies in the comments for dates and time which I cleared up. I still have some anomalies that I am chasing and will raise issues to determine if these need to be fixed.

I merged the four and two digit year enum values to reduce the complexity of the function, as requested.  I find this to be a better compromise than using multiple flags as parameters.  I also removed millisecond information from three protocols as per discussion in Issue #2995.

I reverted the StarLink protocol changes to resolve the merge conflict.  This was a better option than what I did in my aborted pull request #2994.