### PR TITLE
Handle incoming SMS from devices as Event

### DIFF
--- a/src/org/traccar/database/DeviceManager.java
+++ b/src/org/traccar/database/DeviceManager.java
@@ -19,6 +19,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -133,19 +134,19 @@ public class DeviceManager implements IdentityManager {
                     device.setStatus(Device.STATUS_OFFLINE);
                 }
             }
-            for (Long cachedDeviceId : devicesById.keySet()) {
-                if (!databaseDevicesIds.contains(cachedDeviceId)) {
-                    devicesById.remove(cachedDeviceId);
+            for (Iterator<Long> iterator = devicesById.keySet().iterator(); iterator.hasNext();) {
+                if (!databaseDevicesIds.contains(iterator.next())) {
+                    iterator.remove();
                 }
             }
-            for (String cachedDeviceUniqueId : devicesByUniqueId.keySet()) {
-                if (!databaseDevicesUniqueIds.contains(cachedDeviceUniqueId)) {
-                    devicesByUniqueId.remove(cachedDeviceUniqueId);
+            for (Iterator<String> iterator = devicesByUniqueId.keySet().iterator(); iterator.hasNext();) {
+                if (!databaseDevicesUniqueIds.contains(iterator.next())) {
+                    iterator.remove();
                 }
             }
-            for (String cachedDevicePhone : devicesByPhone.keySet()) {
-                if (!databaseDevicesPhones.contains(cachedDevicePhone)) {
-                    devicesByPhone.remove(cachedDevicePhone);
+            for (Iterator<String> iterator = devicesByPhone.keySet().iterator(); iterator.hasNext();) {
+                if (!databaseDevicesPhones.contains(iterator.next())) {
+                    iterator.remove();
                 }
             }
         }

--- a/src/org/traccar/database/DeviceManager.java
+++ b/src/org/traccar/database/DeviceManager.java
@@ -34,7 +34,6 @@ import org.traccar.model.Command;
 import org.traccar.model.CommandType;
 import org.traccar.model.Device;
 import org.traccar.model.DeviceTotalDistance;
-import org.traccar.model.Event;
 import org.traccar.model.Group;
 import org.traccar.model.Position;
 import org.traccar.model.Server;
@@ -139,9 +138,9 @@ public class DeviceManager implements IdentityManager {
                     devicesById.remove(cachedDeviceId);
                 }
             }
-            for (String cachedDeviceUniqId : devicesByUniqueId.keySet()) {
-                if (!databaseDevicesUniqueIds.contains(cachedDeviceUniqId)) {
-                    devicesByUniqueId.remove(cachedDeviceUniqId);
+            for (String cachedDeviceUniqueId : devicesByUniqueId.keySet()) {
+                if (!databaseDevicesUniqueIds.contains(cachedDeviceUniqueId)) {
+                    devicesByUniqueId.remove(cachedDeviceUniqueId);
                 }
             }
             for (String cachedDevicePhone : devicesByPhone.keySet()) {
@@ -149,9 +148,6 @@ public class DeviceManager implements IdentityManager {
                     devicesByPhone.remove(cachedDevicePhone);
                 }
             }
-            databaseDevicesIds.clear();
-            databaseDevicesUniqueIds.clear();
-            databaseDevicesPhones.clear();
         }
     }
 
@@ -506,14 +502,5 @@ public class DeviceManager implements IdentityManager {
             result.add(new CommandType(Command.TYPE_CUSTOM));
         }
         return result;
-    }
-
-    public void handleTextMessage(String phone, String message) {
-        Device device = devicesByPhone.get(phone);
-        if (device != null && Context.getNotificationManager() != null) {
-            Event event = new Event(Event.TYPE_TEXT_MESSAGE, device.getId());
-            event.set("message", message);
-            Context.getNotificationManager().updateEvent(event, null);
-        }
     }
 }

--- a/src/org/traccar/events/TextMessageEventHandler.java
+++ b/src/org/traccar/events/TextMessageEventHandler.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.events;
+
+import org.traccar.Context;
+import org.traccar.model.Device;
+import org.traccar.model.Event;
+
+public final class TextMessageEventHandler {
+
+    private TextMessageEventHandler() {
+    }
+
+    public static void handleTextMessage(String phone, String message) {
+        Device device = Context.getDeviceManager().getDeviceByPhone(phone);
+        if (device != null && Context.getNotificationManager() != null) {
+            Event event = new Event(Event.TYPE_TEXT_MESSAGE, device.getId());
+            event.set("message", message);
+            Context.getNotificationManager().updateEvent(event, null);
+        }
+    }
+
+}

--- a/src/org/traccar/model/Event.java
+++ b/src/org/traccar/model/Event.java
@@ -58,6 +58,8 @@ public class Event extends Message {
 
     public static final String TYPE_MAINTENANCE = "maintenance";
 
+    public static final String TYPE_TEXT_MESSAGE = "textMessage";
+
     private Date serverTime;
 
     public Date getServerTime() {

--- a/src/org/traccar/smpp/ClientSmppSessionHandler.java
+++ b/src/org/traccar/smpp/ClientSmppSessionHandler.java
@@ -16,7 +16,7 @@
  */
 package org.traccar.smpp;
 
-import org.traccar.Context;
+import org.traccar.events.TextMessageEventHandler;
 import org.traccar.helper.Log;
 
 import com.cloudhopper.commons.charset.CharsetUtil;
@@ -54,7 +54,7 @@ public class ClientSmppSessionHandler extends DefaultSmppSessionHandler {
                     String message = CharsetUtil.decode(((DeliverSm) request).getShortMessage(),
                             smppClient.mapDataCodingToCharset(((DeliverSm) request).getDataCoding()));
                     Log.debug("SMS Message Received: " + message.trim() + ", Source Address: " + sourceAddress);
-                    Context.getDeviceManager().handleTextMessage(sourceAddress, message);
+                    TextMessageEventHandler.handleTextMessage(sourceAddress, message);
                 }
             }
             response = request.createResponse();

--- a/src/org/traccar/smpp/ClientSmppSessionHandler.java
+++ b/src/org/traccar/smpp/ClientSmppSessionHandler.java
@@ -16,6 +16,7 @@
  */
 package org.traccar.smpp;
 
+import org.traccar.Context;
 import org.traccar.helper.Log;
 
 import com.cloudhopper.commons.charset.CharsetUtil;
@@ -49,11 +50,11 @@ public class ClientSmppSessionHandler extends DefaultSmppSessionHandler {
                             + ", State: "
                             + request.getOptionalParameter(SmppConstants.TAG_MSG_STATE).getValueAsByte());
                 } else {
-                    Log.debug("SMS Message Received: "
-                            + CharsetUtil.decode(((DeliverSm) request).getShortMessage(),
-                            smppClient.mapDataCodingToCharset(((DeliverSm) request).getDataCoding())).trim()
-                            + ", Source Address: "
-                            + ((DeliverSm) request).getSourceAddress().getAddress());
+                    String sourceAddress = ((DeliverSm) request).getSourceAddress().getAddress();
+                    String message = CharsetUtil.decode(((DeliverSm) request).getShortMessage(),
+                            smppClient.mapDataCodingToCharset(((DeliverSm) request).getDataCoding()));
+                    Log.debug("SMS Message Received: " + message.trim() + ", Source Address: " + sourceAddress);
+                    Context.getDeviceManager().handleTextMessage(sourceAddress, message);
                 }
             }
             response = request.createResponse();

--- a/templates/mail/textMessage.vm
+++ b/templates/mail/textMessage.vm
@@ -1,0 +1,9 @@
+#set($subject = "$device.name: text message received")
+<!DOCTYPE html>
+<html>
+<body>
+Device: $device.name<br>
+Message:  $event.getString("message")<br>
+Time: $dateTool.format("YYYY-MM-dd HH:mm:ss", $event.serverTime, $locale, $timezone)<br>
+</body>
+</html>  

--- a/templates/sms/textMessage.vm
+++ b/templates/sms/textMessage.vm
@@ -1,0 +1,1 @@
+Text message received from $device.name at $dateTool.format("YYYY-MM-dd HH:mm:ss", $event.serverTime, $locale, $timezone)


### PR DESCRIPTION
Key changes:

- Schema changes applies to "non-mssql" DB engines only. It "nulls" all "phone" duplicates and add unique constraint
- Added map phone -> devices
- Added new type of Event - `textMessage`

If DB is MS then behavior will be next: In case phone has duplicates last added device will be mapped.

Frankly, I do not like the changes very much, especially null phone if it is `""` in `addDevice` and  `updateDevice` methods. Only multiple nulls are possible with unique constraint and it comes as `""` from web-client by default.
But I do not have other more beautiful solution may be you have another idea... 
