### PR TITLE
Set status to offline for new device

### DIFF
--- a/src/org/traccar/database/DeviceManager.java
+++ b/src/org/traccar/database/DeviceManager.java
@@ -131,7 +131,6 @@ public class DeviceManager implements IdentityManager {
                             device.setGeofenceIds(geofenceManager.getCurrentDeviceGeofences(lastPosition));
                         }
                     }
-                    device.setStatus(Device.STATUS_OFFLINE);
                 }
             }
             for (Iterator<Long> iterator = devicesById.keySet().iterator(); iterator.hasNext();) {

--- a/src/org/traccar/database/DeviceManager.java
+++ b/src/org/traccar/database/DeviceManager.java
@@ -202,6 +202,7 @@ public class DeviceManager implements IdentityManager {
     public void addDevice(Device device) throws SQLException {
         dataManager.addDevice(device);
 
+        device.setStatus(Device.STATUS_OFFLINE);
         devicesById.put(device.getId(), device);
         devicesByUniqueId.put(device.getUniqueId(), device);
         if (device.getPhone() != null  && !device.getPhone().isEmpty()) {

--- a/src/org/traccar/database/DeviceManager.java
+++ b/src/org/traccar/database/DeviceManager.java
@@ -202,7 +202,6 @@ public class DeviceManager implements IdentityManager {
     public void addDevice(Device device) throws SQLException {
         dataManager.addDevice(device);
 
-        device.setStatus(Device.STATUS_OFFLINE);
         devicesById.put(device.getId(), device);
         devicesByUniqueId.put(device.getUniqueId(), device);
         if (device.getPhone() != null  && !device.getPhone().isEmpty()) {

--- a/src/org/traccar/model/Device.java
+++ b/src/org/traccar/model/Device.java
@@ -47,15 +47,11 @@ public class Device extends Extensible {
     private String status;
 
     public String getStatus() {
-        return status;
+        return status != null ? status : STATUS_OFFLINE;
     }
 
     public void setStatus(String status) {
-        if (STATUS_ONLINE.equals(status) || STATUS_UNKNOWN.equals(status)) {
-            this.status = status;
-        } else {
-            this.status = STATUS_OFFLINE;
-        }
+        this.status = status;
     }
 
     private Date lastUpdate;

--- a/src/org/traccar/model/Device.java
+++ b/src/org/traccar/model/Device.java
@@ -51,7 +51,11 @@ public class Device extends Extensible {
     }
 
     public void setStatus(String status) {
-        this.status = status;
+        if (STATUS_ONLINE.equals(status) || STATUS_UNKNOWN.equals(status)) {
+            this.status = status;
+        } else {
+            this.status = STATUS_OFFLINE;
+        }
     }
 
     private Date lastUpdate;


### PR DESCRIPTION
I'm working on filtering in web-part discussed in #3025 

By default new device will have `""` as status and handle fourth value (empty string) is very very inconvenient and break logic.