### PR TITLE
Format speed in notification templates

### DIFF
--- a/src/org/traccar/notification/NotificationFormatter.java
+++ b/src/org/traccar/notification/NotificationFormatter.java
@@ -24,6 +24,7 @@ import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.exception.ResourceNotFoundException;
 import org.apache.velocity.tools.generic.DateTool;
+import org.apache.velocity.tools.generic.NumberTool;
 import org.traccar.Context;
 import org.traccar.helper.Log;
 import org.traccar.model.Device;
@@ -51,6 +52,7 @@ public final class NotificationFormatter {
         }
         velocityContext.put("webUrl", Context.getVelocityEngine().getProperty("web.url"));
         velocityContext.put("dateTool", new DateTool());
+        velocityContext.put("numberTool", new NumberTool());
         velocityContext.put("timezone", ReportUtils.getTimezone(userId));
         velocityContext.put("locale", Locale.getDefault());
         return velocityContext;

--- a/src/org/traccar/reports/ReportUtils.java
+++ b/src/org/traccar/reports/ReportUtils.java
@@ -17,6 +17,7 @@
 package org.traccar.reports;
 
 import org.apache.velocity.tools.generic.DateTool;
+import org.apache.velocity.tools.generic.NumberTool;
 import org.jxls.area.Area;
 import org.jxls.builder.xls.XlsCommentAreaBuilder;
 import org.jxls.common.CellRef;
@@ -115,6 +116,7 @@ public final class ReportUtils {
         jxlsContext.putVar("speedUnit", getSpeedUnit(userId));
         jxlsContext.putVar("webUrl", Context.getVelocityEngine().getProperty("web.url"));
         jxlsContext.putVar("dateTool", new DateTool());
+        jxlsContext.putVar("numberTool", new NumberTool());
         jxlsContext.putVar("timezone", getTimezone(userId));
         jxlsContext.putVar("locale", Locale.getDefault());
         jxlsContext.putVar("bracketsRegex", "[\\{\\}\"]");

--- a/templates/mail/deviceOverspeed.vm
+++ b/templates/mail/deviceOverspeed.vm
@@ -1,10 +1,12 @@
 #set($subject = "$device.name: exceeds the speed")
 #if($speedUnits == 'kmh')
-#set($speedString = $position.speed * 1.852 + ' km/h')
+#set($speedValue = $position.speed * 1.852)
+#set($speedString = $numberTool.format("0.0 km/h", $speedValue))
 #elseif($speedUnits == 'mph')
-#set($speedString = $position.speed * 1.15078 + ' mph')
+#set($speedValue = $position.speed * 1.15078)
+#set($speedString = $numberTool.format("0.0 mph", $speedValue))
 #else
-#set($speedString = "$position.speed kn")
+#set($speedString = $numberTool.format("0.0 kn", $position.speed))
 #end
 <!DOCTYPE html>
 <html>

--- a/templates/sms/deviceOverspeed.vm
+++ b/templates/sms/deviceOverspeed.vm
@@ -1,8 +1,10 @@
 #if($speedUnits == 'kmh')
-#set($speedString = $position.speed * 1.852 + ' km/h')
+#set($speedValue = $position.speed * 1.852)
+#set($speedString = $numberTool.format("0.0 km/h", $speedValue))
 #elseif($speedUnits == 'mph')
-#set($speedString = $position.speed * 1.15078 + ' mph')
+#set($speedValue = $position.speed * 1.15078)
+#set($speedString = $numberTool.format("0.0 mph", $speedValue))
 #else
-#set($speedString = "$position.speed kn")
+#set($speedString = $numberTool.format("0.0 kn", $position.speed))
 #end
 $device.name exceeds the speed $speedString at $dateTool.format("YYYY-MM-dd HH:mm:ss", $event.serverTime, $locale, $timezone)


### PR DESCRIPTION
Pass `NumberTool` object to templates (also to reports for consistence and case if somebody wants use decimal format)

Also adjusted notification templates to format one digit after point. Used intermediate variable `$speedValue`, because we can not use math everywhere, just in `#set`.
Did not change report templates, because it is already formatted with help of `String.format()`

fix #3049 