### PR TITLE
Added EnforaEncoder tested on 2818

### DIFF
--- a/src/org/traccar/protocol/EnforaProtocol.java
+++ b/src/org/traccar/protocol/EnforaProtocol.java
@@ -20,6 +20,7 @@ import org.jboss.netty.channel.ChannelPipeline;
 import org.jboss.netty.handler.codec.frame.LengthFieldBasedFrameDecoder;
 import org.traccar.BaseProtocol;
 import org.traccar.TrackerServer;
+import org.traccar.model.Command;
 
 import java.util.List;
 
@@ -27,6 +28,10 @@ public class EnforaProtocol extends BaseProtocol {
 
     public EnforaProtocol() {
         super("enfora");
+        setSupportedDataCommands(
+                Command.TYPE_CUSTOM,
+                Command.TYPE_ENGINE_STOP,
+                Command.TYPE_ENGINE_RESUME);
     }
 
     @Override
@@ -35,6 +40,7 @@ public class EnforaProtocol extends BaseProtocol {
             @Override
             protected void addSpecificHandlers(ChannelPipeline pipeline) {
                 pipeline.addLast("frameDecoder", new LengthFieldBasedFrameDecoder(1024, 0, 2, -2, 2));
+                pipeline.addLast("objectEncoder", new EnforaProtocolEncoder());
                 pipeline.addLast("objectDecoder", new EnforaProtocolDecoder(EnforaProtocol.this));
             }
         });

--- a/src/org/traccar/protocol/EnforaProtocolEncoder.java
+++ b/src/org/traccar/protocol/EnforaProtocolEncoder.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 Anton Tananaev (anton@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.protocol;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.ChannelBuffers;
+import org.traccar.StringProtocolEncoder;
+import org.traccar.helper.Log;
+import org.traccar.model.Command;
+
+import java.nio.charset.StandardCharsets;
+
+public class EnforaProtocolEncoder extends StringProtocolEncoder {
+
+    private ChannelBuffer encodeContent(String content) {
+
+        ChannelBuffer buf = ChannelBuffers.dynamicBuffer();
+
+        byte[] contentBytes = content.getBytes();
+
+        buf.writeByte(0x00); // Byte 0 Length
+        buf.writeByte(contentBytes.length + 6); // Byte 1 Length
+        buf.writeByte(0x00); // Byte 2 Api Number Sequence
+        buf.writeByte(0x00); // Byte 3 Api Number Sequence
+        buf.writeByte(0x04); // Byte 4 Command Type 4 AT Command
+        buf.writeByte(0x00); // Byte 5 API Optional Header
+        // Byte 6+m AT Command
+        buf.writeBytes(content.getBytes(StandardCharsets.UTF_8));
+
+        return buf;
+    }
+
+    @Override
+    protected Object encodeCommand(Command command) {
+
+        initDevicePassword(command, "");
+
+        switch (command.getType()) {
+            case Command.TYPE_CUSTOM:
+                return encodeContent(command.getString(Command.KEY_DATA));
+            case Command.TYPE_ENGINE_STOP:
+                return encodeContent("AT$IOGP3=1");
+            case Command.TYPE_ENGINE_RESUME:
+                return encodeContent("AT$IOGP3=0");
+            default:
+                Log.warning(new UnsupportedOperationException(command.getType()));
+                break;
+        }
+
+        return null;
+    }
+
+}

--- a/src/org/traccar/protocol/EnforaProtocolEncoder.java
+++ b/src/org/traccar/protocol/EnforaProtocolEncoder.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
+ *                Jose Castellanos
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +32,7 @@ public class EnforaProtocolEncoder extends StringProtocolEncoder {
 
         byte[] contentBytes = content.getBytes();
 
-        buf.writeByte(0x00); // Byte 0 Length
-        buf.writeByte(contentBytes.length + 6); // Byte 1 Length
+        buf.writeShort(contentBytes.length + 6); // Byte 0 Byte 1 Length
         buf.writeByte(0x00); // Byte 2 Api Number Sequence
         buf.writeByte(0x00); // Byte 3 Api Number Sequence
         buf.writeByte(0x04); // Byte 4 Command Type 4 AT Command
@@ -45,9 +45,6 @@ public class EnforaProtocolEncoder extends StringProtocolEncoder {
 
     @Override
     protected Object encodeCommand(Command command) {
-
-        initDevicePassword(command, "");
-
         switch (command.getType()) {
             case Command.TYPE_CUSTOM:
                 return encodeContent(command.getString(Command.KEY_DATA));


### PR DESCRIPTION
Hi

wanted to share with you this implementation of the EnforeEncoder, tested and working on 2818.

It was implemented following documentation on http://documentation.nvtl.com/board/download/file.php?id=221, on TCP protocol

Hope you find it useful for others.

