### PR TITLE
Update MeitrackProtocolDecoder.java

### DIFF
--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -155,7 +155,7 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
                 position.set(Position.PREFIX_ADC + i, parser.nextHexInt(0));
             }
         }
-        if (!Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel()equals("")) {
+        if (!Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel().equals("")) {
             switch (Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel()) {
                 case "MVT340":
                     position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.0 * 2.0 / 1024.0);

--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -155,7 +155,7 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
                 position.set(Position.PREFIX_ADC + i, parser.nextHexInt(0));
             }
         }
-        if (Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel()) {
+        if (Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel() <> "") {
             switch (Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel()) {
                 case "MVT340":
                     position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.0 * 2.0 / 1024.0);

--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -155,7 +155,7 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
                 position.set(Position.PREFIX_ADC + i, parser.nextHexInt(0));
             }
         }
-        if (Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel()) == "TC68S") {
+        if (Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel() == "TC68S") {
             position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
             position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
         } else {

--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -156,8 +156,8 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
             }
         }
 
-        String Model = Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel();
-        if (Model != null && Model.length() > 0) {
+        String deviceModel = Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel();
+        if (deviceModel != null && deviceModel.length() > 0) {
             switch (Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel().toUpperCase()) {
                 case "MVT340":
                     position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.0 * 2.0 / 1024.0);

--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -155,7 +155,8 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
                 position.set(Position.PREFIX_ADC + i, parser.nextHexInt(0));
             }
         }
-        if (!Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel().equals("")) {
+
+        if (Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel() != null && Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel().length() > 0) {
             switch (Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel()) {
                 case "MVT340":
                     position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.0 * 2.0 / 1024.0);

--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -155,64 +155,70 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
                 position.set(Position.PREFIX_ADC + i, parser.nextHexInt(0));
             }
         }
-        switch (Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel()) {
-            case "MVT340":
-                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.0 * 2.0 / 1024.0);
-                position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.0 * 16.0 / 1024.0);
-                break;
-            case "MVT380":
-                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.0 * 2.0 / 1024.0);
-                position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.0 * 16.0 / 1024.0);
-                break;
-            case "MT90":
-                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
-                position.set(Position.KEY_POWER, parser.nextHexInt(0));
-                break;
-            case "T1":
-                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
-                position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
-                break;
-            case "T3":
-                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
-                position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
-                break;
-            case "MVT100":
-                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
-                position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
-                break;
-            case "MVT600":
-                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
-                position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
-                break;
-            case "MVT800":
-                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
-                position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
-                break;
-            case "TC68":
-                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
-                position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
-                break;
-            case "TC68S":
-                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
-                position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
-                break;
-            case "T311":
-                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) / 100.0);
-                position.set(Position.KEY_POWER, parser.nextHexInt(0) / 100.0);
-                break;
-            case "T322X":
-                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) / 100.0);
-                position.set(Position.KEY_POWER, parser.nextHexInt(0) / 100.0);
-                break;
-            case "T333":
-                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) / 100.0);
-                position.set(Position.KEY_POWER, parser.nextHexInt(0) / 100.0);
-                break;
-            case "T355":
-                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) / 100.0);
-                position.set(Position.KEY_POWER, parser.nextHexInt(0) / 100.0);
-                break;
-            default:
+        if (Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel()) {
+            switch (Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel()) {
+                case "MVT340":
+                    position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.0 * 2.0 / 1024.0);
+                    position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.0 * 16.0 / 1024.0);
+                    break;
+                case "MVT380":
+                    position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.0 * 2.0 / 1024.0);
+                    position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.0 * 16.0 / 1024.0);
+                    break;
+                case "MT90":
+                    position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
+                    position.set(Position.KEY_POWER, parser.nextHexInt(0));
+                    break;
+                case "T1":
+                    position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
+                    position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
+                    break;
+                case "T3":
+                    position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
+                    position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
+                    break;
+                case "MVT100":
+                    position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
+                    position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
+                    break;
+                case "MVT600":
+                    position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
+                    position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
+                    break;
+                case "MVT800":
+                    position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
+                    position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
+                    break;
+                case "TC68":
+                    position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
+                    position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
+                    break;
+                case "TC68S":
+                    position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
+                    position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
+                    break;
+                case "T311":
+                    position.set(Position.KEY_BATTERY, parser.nextHexInt(0) / 100.0);
+                    position.set(Position.KEY_POWER, parser.nextHexInt(0) / 100.0);
+                    break;
+                case "T322X":
+                    position.set(Position.KEY_BATTERY, parser.nextHexInt(0) / 100.0);
+                    position.set(Position.KEY_POWER, parser.nextHexInt(0) / 100.0);
+                    break;
+                case "T333":
+                    position.set(Position.KEY_BATTERY, parser.nextHexInt(0) / 100.0);
+                    position.set(Position.KEY_POWER, parser.nextHexInt(0) / 100.0);
+                    break;
+                case "T355":
+                    position.set(Position.KEY_BATTERY, parser.nextHexInt(0) / 100.0);
+                    position.set(Position.KEY_POWER, parser.nextHexInt(0) / 100.0);
+                    break;
+                default:
+                    position.set(Position.KEY_BATTERY, parser.nextHexInt(0));
+                    position.set(Position.KEY_POWER, parser.nextHexInt(0));
+            }
+        }
+        else {
                 position.set(Position.KEY_BATTERY, parser.nextHexInt(0));
                 position.set(Position.KEY_POWER, parser.nextHexInt(0));
         }

--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -217,8 +217,7 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
                     position.set(Position.KEY_BATTERY, parser.nextHexInt(0));
                     position.set(Position.KEY_POWER, parser.nextHexInt(0));
             }
-        }
-        else {
+        } else {
                 position.set(Position.KEY_BATTERY, parser.nextHexInt(0));
                 position.set(Position.KEY_POWER, parser.nextHexInt(0));
         }

--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -215,7 +215,6 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
             default:
                 position.set(Position.KEY_BATTERY, parser.nextHexInt(0));
                 position.set(Position.KEY_POWER, parser.nextHexInt(0));
-                break;
         }
 
         String eventData = parser.next();

--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -155,8 +155,7 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
                 position.set(Position.PREFIX_ADC + i, parser.nextHexInt(0));
             }
         }
-        switch (Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel())
-        {
+        switch (Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel()) {
             case MVT340:
                 position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.0 * 2.0 / 1024.0);
                 position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.0 * 16.0 / 1024.0);

--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -155,9 +155,14 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
                 position.set(Position.PREFIX_ADC + i, parser.nextHexInt(0));
             }
         }
-
-        position.set(Position.KEY_BATTERY, parser.nextHexInt(0));
-        position.set(Position.KEY_POWER, parser.nextHexInt(0));
+        
+        if (Context.getConfig().hasKey(getProtocolName() + ".devicetype") == "tc68s") {
+            position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
+            position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
+        } else {
+            position.set(Position.KEY_BATTERY, parser.nextHexInt(0));
+            position.set(Position.KEY_POWER, parser.nextHexInt(0));
+        }
 
         String eventData = parser.next();
         if (eventData != null && !eventData.isEmpty()) {

--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -155,7 +155,6 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
                 position.set(Position.PREFIX_ADC + i, parser.nextHexInt(0));
             }
         }
-        
         if (Context.getConfig().hasKey(getProtocolName() + ".devicetype") == "tc68s") {
             position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
             position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);

--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -211,7 +211,7 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
             case T355:
                 position.set(Position.KEY_BATTERY, parser.nextHexInt(0) / 100.0);
                 position.set(Position.KEY_POWER, parser.nextHexInt(0) / 100.0);
-                break;        
+                break;
             default:
                 position.set(Position.KEY_BATTERY, parser.nextHexInt(0));
                 position.set(Position.KEY_POWER, parser.nextHexInt(0));

--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -155,7 +155,7 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
                 position.set(Position.PREFIX_ADC + i, parser.nextHexInt(0));
             }
         }
-        if (Context.getConfig().hasKey(getProtocolName() + ".devicetype") == "tc68s") {
+        if (Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel()) == "TC68S") {
             position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
             position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
         } else {

--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -156,59 +156,59 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
             }
         }
         switch (Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel()) {
-            case MVT340:
+            case "MVT340":
                 position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.0 * 2.0 / 1024.0);
                 position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.0 * 16.0 / 1024.0);
                 break;
-            case MVT380:
+            case "MVT380":
                 position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.0 * 2.0 / 1024.0);
                 position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.0 * 16.0 / 1024.0);
                 break;
-            case MT90:
+            case "MT90":
                 position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
                 position.set(Position.KEY_POWER, parser.nextHexInt(0));
                 break;
-            case T1:
+            case "T1":
                 position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
                 position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
                 break;
-            case T3:
+            case "T3":
                 position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
                 position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
                 break;
-            case MVT100:
+            case "MVT100":
                 position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
                 position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
                 break;
-            case MVT600:
+            case "MVT600":
                 position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
                 position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
                 break;
-            case MVT800:
+            case "MVT800":
                 position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
                 position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
                 break;
-            case TC68:
+            case "TC68":
                 position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
                 position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
                 break;
-            case TC68S:
+            case "TC68S":
                 position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
                 position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
                 break;
-            case T311:
+            case "T311":
                 position.set(Position.KEY_BATTERY, parser.nextHexInt(0) / 100.0);
                 position.set(Position.KEY_POWER, parser.nextHexInt(0) / 100.0);
                 break;
-            case T322X:
+            case "T322X":
                 position.set(Position.KEY_BATTERY, parser.nextHexInt(0) / 100.0);
                 position.set(Position.KEY_POWER, parser.nextHexInt(0) / 100.0);
                 break;
-            case T333:
+            case "T333":
                 position.set(Position.KEY_BATTERY, parser.nextHexInt(0) / 100.0);
                 position.set(Position.KEY_POWER, parser.nextHexInt(0) / 100.0);
                 break;
-            case T355:
+            case "T355":
                 position.set(Position.KEY_BATTERY, parser.nextHexInt(0) / 100.0);
                 position.set(Position.KEY_POWER, parser.nextHexInt(0) / 100.0);
                 break;

--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -155,7 +155,7 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
                 position.set(Position.PREFIX_ADC + i, parser.nextHexInt(0));
             }
         }
-        if (Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel() <> "") {
+        if (!Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel()equals("")) {
             switch (Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel()) {
                 case "MVT340":
                     position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.0 * 2.0 / 1024.0);

--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -156,8 +156,9 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
             }
         }
 
-        if (Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel() != null && Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel().length() > 0) {
-            switch (Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel()) {
+        String Model = Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel();
+        if (Model != null && Model.length() > 0) {
+            switch (Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel().toUpperCase()) {
                 case "MVT340":
                     position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.0 * 2.0 / 1024.0);
                     position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.0 * 16.0 / 1024.0);

--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -155,12 +155,68 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
                 position.set(Position.PREFIX_ADC + i, parser.nextHexInt(0));
             }
         }
-        if (Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel() == "TC68S") {
-            position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
-            position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
-        } else {
-            position.set(Position.KEY_BATTERY, parser.nextHexInt(0));
-            position.set(Position.KEY_POWER, parser.nextHexInt(0));
+        switch (Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel())
+        {
+            case MVT340:
+                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.0 * 2.0 / 1024.0);
+                position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.0 * 16.0 / 1024.0);
+                break;
+            case MVT380:
+                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.0 * 2.0 / 1024.0);
+                position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.0 * 16.0 / 1024.0);
+                break;
+            case MT90:
+                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
+                position.set(Position.KEY_POWER, parser.nextHexInt(0));
+                break;
+            case T1:
+                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
+                position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
+                break;
+            case T3:
+                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
+                position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
+                break;
+            case MVT100:
+                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
+                position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
+                break;
+            case MVT600:
+                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
+                position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
+                break;
+            case MVT800:
+                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
+                position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
+                break;
+            case TC68:
+                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
+                position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
+                break;
+            case TC68S:
+                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) * 3.3 * 2.0 / 4096.0);
+                position.set(Position.KEY_POWER, parser.nextHexInt(0) * 3.3 * 16.0 / 4096.0);
+                break;
+            case T311:
+                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) / 100.0);
+                position.set(Position.KEY_POWER, parser.nextHexInt(0) / 100.0);
+                break;
+            case T322X:
+                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) / 100.0);
+                position.set(Position.KEY_POWER, parser.nextHexInt(0) / 100.0);
+                break;
+            case T333:
+                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) / 100.0);
+                position.set(Position.KEY_POWER, parser.nextHexInt(0) / 100.0);
+                break;
+            case T355:
+                position.set(Position.KEY_BATTERY, parser.nextHexInt(0) / 100.0);
+                position.set(Position.KEY_POWER, parser.nextHexInt(0) / 100.0);
+                break;        
+            default:
+                position.set(Position.KEY_BATTERY, parser.nextHexInt(0));
+                position.set(Position.KEY_POWER, parser.nextHexInt(0));
+                break;
         }
 
         String eventData = parser.next();


### PR DESCRIPTION
To show correct values for Battery and Power in case of device TC68S it needs some changes in code.
If parameter "meitrack.devicetype" with value "tc68s" exists in global configuration, values are calculated in another way according to official GPRS protocol.