### PR TITLE
Adding and correcting event numbers - Update MeitrackProtocolDecoder.java

### DIFF
--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -91,13 +91,17 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
             case 17:
                 return Position.ALARM_LOW_BATTERY;
             case 18:
-                return Position.ALARM_POWER_CUT;
+                return Position.ALARM_LOW_POWER;
             case 19:
                 return Position.ALARM_OVERSPEED;
             case 20:
                 return Position.ALARM_GEOFENCE_ENTER;
             case 21:
                 return Position.ALARM_GEOFENCE_EXIT;
+            case 22:
+                return Position.ALARM_POWER_RESTORED;
+            case 23:
+                return Position.ALARM_POWER_CUT;
             case 36:
                 return Position.ALARM_TOW;
             default:


### PR DESCRIPTION
Adding and correcting event numbers reported by device:

17 - ALARM_LOW_BATTERY: when device's internal battery is low
18 - ALARM_LOW_POWER: when external power measure by the device is under limit (limit configured in device)
22 - ALARM_POWER_CUT: when external power disconnected
23 - ALARM_POWER_RESTORED: when external power reconnected (this alarm needed to be created in other files)