### PR TITLE
Adding and correcting event codes for Meitrack

### DIFF
--- a/src/org/traccar/model/Position.java
+++ b/src/org/traccar/model/Position.java
@@ -106,6 +106,7 @@ public class Position extends Message {
     public static final String ALARM_BREAKING = "hardBreaking";
     public static final String ALARM_FATIGUE_DRIVING = "fatigueDriving";
     public static final String ALARM_POWER_CUT = "powerCut";
+    public static final String ALARM_POWER_RESTORED = "powerRestored";
     public static final String ALARM_JAMMING = "jamming";
     public static final String ALARM_TEMPERATURE = "temperature";
     public static final String ALARM_PARKING = "parking";

--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -83,7 +83,6 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
             .number("xx")
             .text("\r\n").optional()
             .compile();
-
     private String decodeAlarm(int event) {
         switch (event) {
             case 1:
@@ -91,13 +90,17 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
             case 17:
                 return Position.ALARM_LOW_BATTERY;
             case 18:
-                return Position.ALARM_POWER_CUT;
+                return Position.ALARM_LOW_POWER;
             case 19:
                 return Position.ALARM_OVERSPEED;
             case 20:
                 return Position.ALARM_GEOFENCE_ENTER;
             case 21:
                 return Position.ALARM_GEOFENCE_EXIT;
+            case 22:
+                return Position.ALARM_POWER_RESTORED;
+            case 23:
+                return Position.ALARM_POWER_CUT;
             case 36:
                 return Position.ALARM_TOW;
             default:


### PR DESCRIPTION
Adding new Events:
- External power restored (reported by device, event code 22) - ALARM_POWER_RESTORED
- External power cut (reported by device, event code 23) - ALARM_POWER_CUT

Modifing Events:
- Event code 18 reports ALARM_LOW_POWER (instead of ALARM_POWER_CUT)