### PR TITLE
Environment variables

### DIFF
--- a/setup/docker/build.sh
+++ b/setup/docker/build.sh
@@ -5,9 +5,10 @@ which awk &> /dev/null  || { echo >&2 "Awk package cant be found on path. Aborti
 which docker &> /dev/null  || { echo >&2 "Docker package cant be found on path. Aborting."; exit 1; }
 mvn package || { echo >&2 "Maven package has failed. Aborting."; exit 1; }
 
-export company="tananaev"
-export software="traccar"
-export version=$(head -n 10 ./pom.xml |grep version|cut -d ">" -f2|cut -d"<" -f1)
+export company=${1:-"tananaev"}
+export software=${2:-"traccar"}
+export _version=$(head -n 10 ./pom.xml |grep version|cut -d ">" -f2|cut -d"<" -f1)
+export version=${3:-_version}
 
 tmp="./setup/docker/tmp"
 

--- a/src/org/traccar/Config.java
+++ b/src/org/traccar/Config.java
@@ -15,8 +15,6 @@
  */
 package org.traccar;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -56,7 +54,7 @@ public class Config {
     public String getString(String key) {
         String envName = key.toUpperCase().replaceAll("\\.", "_");
         String envValue = System.getenv(envName);
-        if (StringUtils.isNotBlank(envValue)) {
+        if (envValue != null && !envValue.isEmpty()) {
             return envValue;
         }
         return properties.getProperty(key);

--- a/src/org/traccar/Config.java
+++ b/src/org/traccar/Config.java
@@ -18,44 +18,50 @@ package org.traccar;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Enumeration;
 import java.util.Properties;
 
 public class Config {
 
     private final Properties properties = new Properties();
 
-    void load(String file) throws IOException {
-        try (InputStream inputStream = new FileInputStream(file)) {
-            properties.loadFromXML(inputStream);
-        }
+    private boolean useEnvVars = false;
 
+    void load(String file) throws IOException {
+        // First we load default config (if any)
         String defaultConfigFile = properties.getProperty("config.default");
         if (defaultConfigFile != null) {
             try (InputStream inputStream = new FileInputStream(defaultConfigFile)) {
-                Properties defaultProperties = new Properties();
-                defaultProperties.loadFromXML(inputStream);
-
-                Enumeration props = defaultProperties.propertyNames();
-                while (props.hasMoreElements()) {
-                    String key = (String) props.nextElement();
-                    if (!properties.containsKey(key)) {
-                        properties.setProperty(key, defaultProperties.getProperty(key));
-                    }
-                }
+                properties.loadFromXML(inputStream);
             }
+        }
+        // Then we override by loading <code>file</code>
+        try (InputStream inputStream = new FileInputStream(file)) {
+            Properties props = new Properties();
+            props.loadFromXML(inputStream);
+            properties.putAll(props);
+        }
+        // Environment variables interpolation support
+        if ("true".equals(System.getenv("CONFIG_USE_ENV"))) {
+            useEnvVars = true;
+        } else {
+            useEnvVars = properties.getProperty("config.useEnv", "false").equalsIgnoreCase("true");
         }
     }
 
+
     public boolean hasKey(String key) {
+        if (useEnvVars && System.getenv().containsKey(getEnvVarName(key))) {
+            return true;
+        }
         return properties.containsKey(key);
     }
 
     public String getString(String key) {
-        String envName = key.toUpperCase().replaceAll("\\.", "_");
-        String envValue = System.getenv(envName);
-        if (envValue != null && !envValue.isEmpty()) {
-            return envValue;
+        if (useEnvVars) {
+            String envValue = System.getenv(getEnvVarName(key));
+            if (envValue != null && !envValue.isEmpty()) {
+                return envValue;
+            }
         }
         return properties.getProperty(key);
     }
@@ -90,6 +96,10 @@ public class Config {
 
     public double getDouble(String key, double defaultValue) {
         return hasKey(key) ? Double.parseDouble(getString(key)) : defaultValue;
+    }
+
+    public static String getEnvVarName(String key) {
+        return key.replaceAll("\\.", "_").replaceAll("(.)(\\p{Lu})", "$1_$2").toUpperCase();
     }
 
 }

--- a/test/org/traccar/config/EnvVarTest.java
+++ b/test/org/traccar/config/EnvVarTest.java
@@ -1,0 +1,18 @@
+package org.traccar.config;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import org.traccar.Config;
+
+public class EnvVarTest {
+
+    @Test
+    public void testFormat() {
+        assertEquals("DATABASE_URL", Config.getEnvVarName("database.url"));
+        assertEquals("DATABASE_CHECK_CONNECTION", Config.getEnvVarName("database.checkConnection"));
+        assertEquals("DATABASE_MAX_POOL_SIZE", Config.getEnvVarName("database.maxPoolSize"));
+        assertEquals("DEVICE_MANAGER_LOOKUP_GROUPS_ATTRIBUTE", Config.getEnvVarName("deviceManager.lookupGroupsAttribute"));
+        assertEquals("COMMAND_FALLBACK_TO_SMS", Config.getEnvVarName("command.fallbackToSms"));
+        assertEquals("STATUS_TIMEOUT", Config.getEnvVarName("status.timeout"));
+    }
+}


### PR DESCRIPTION
When working with Docker, passing environment variables is more practical than using a configuration file.
This PR changed the `Config` class to look for an environment variable before checking the pre-configured configuration files.
There is an UPPERCASE_SNAKE rule applied to properties names.
Ex:
forward.url --> FORWARD_URL
database.driver --> DATABASE_DRIVER