### PR TITLE
Change GT06 command result to result key from command key.

### DIFF
--- a/src/org/traccar/protocol/Gt06ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gt06ProtocolDecoder.java
@@ -305,7 +305,7 @@ public class Gt06ProtocolDecoder extends BaseProtocolDecoder {
 
                 if (commandLength > 0) {
                     buf.readUnsignedByte(); // server flag (reserved)
-                    position.set(Position.KEY_COMMAND,
+                    position.set(Position.KEY_RESULT,
                             buf.readBytes(commandLength - 1).toString(StandardCharsets.US_ASCII));
                 }
 


### PR DESCRIPTION
Hi Anton 

Currently GT06 command response is not creating CommandResult event as it is been treated as command and not result. 
This change will help to handle custom command results as events.

Thanks