### PR TITLE
Unwrap position fields and attributes to computedAttribute context

### DIFF
--- a/src/org/traccar/processing/ComputedAttributesHandler.java
+++ b/src/org/traccar/processing/ComputedAttributesHandler.java
@@ -18,8 +18,11 @@ package org.traccar.processing;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.jexl2.JexlEngine;
 import org.apache.commons.jexl2.JexlException;
@@ -41,11 +44,11 @@ public class ComputedAttributesHandler extends BaseDataHandler {
 
     private MapContext prepareContext(Position position) {
         MapContext result = new MapContext();
-        Method[] methods = position.getClass().getMethods();
+        Set<Method> methods = new HashSet<>(Arrays.asList(position.getClass().getMethods()));
+        methods.removeAll(Arrays.asList(Object.class.getMethods()));
         for (Method method : methods) {
-            if (method.getName().startsWith("get") && method.getParameterTypes().length == 0
-                    && !method.getName().equals("getClass")) {
-                String name = method.getName().substring(3, 4).toLowerCase() + method.getName().substring(4);
+            if (method.getName().startsWith("get") && method.getParameterTypes().length == 0) {
+                String name = Character.toLowerCase(method.getName().charAt(3)) + method.getName().substring(4);
 
                 try {
                     if (!method.getReturnType().equals(Map.class)) {

--- a/src/org/traccar/processing/ComputedAttributesHandler.java
+++ b/src/org/traccar/processing/ComputedAttributesHandler.java
@@ -16,7 +16,10 @@
  */
 package org.traccar.processing;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Collection;
+import java.util.Map;
 
 import org.apache.commons.jexl2.JexlEngine;
 import org.apache.commons.jexl2.JexlException;
@@ -36,10 +39,32 @@ public class ComputedAttributesHandler extends BaseDataHandler {
         engine.setStrict(true);
     }
 
+    private MapContext prepareContext(Position position) {
+        MapContext result = new MapContext();
+        Method[] methods = position.getClass().getMethods();
+        for (Method method : methods) {
+            if (method.getName().startsWith("get") && method.getParameterTypes().length == 0
+                    && !method.getName().equals("getClass")) {
+                String name = method.getName().substring(3, 4).toLowerCase() + method.getName().substring(4);
+
+                try {
+                    if (!method.getReturnType().equals(Map.class)) {
+                        result.set(name, method.invoke(position));
+                    } else {
+                        for (Object key : ((Map) method.invoke(position)).keySet()) {
+                            result.set((String) key, ((Map) method.invoke(position)).get(key));
+                        }
+                    }
+                } catch (IllegalAccessException | InvocationTargetException error) {
+                    Log.warning(error);
+                }
+            }
+        }
+        return result;
+    }
+
     public Object computeAttribute(Attribute attribute, Position position) throws JexlException {
-        MapContext expressionContext = new MapContext();
-        expressionContext.set("position", position);
-        return engine.createExpression(attribute.getExpression()).evaluate(expressionContext);
+        return engine.createExpression(attribute.getExpression()).evaluate(prepareContext(position));
     }
 
     @Override

--- a/test/org/traccar/processing/ComputedAttributesTest.java
+++ b/test/org/traccar/processing/ComputedAttributesTest.java
@@ -1,5 +1,7 @@
 package org.traccar.processing;
 
+import java.util.Date;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.traccar.model.Attribute;
@@ -11,27 +13,52 @@ public class ComputedAttributesTest {
     public void testComputedAttributes() {
         Position position = new Position();
         ComputedAttributesHandler computedAttributesHandler = new ComputedAttributesHandler();
+        Date date = new Date();
+        position.setTime(date);
+        position.setSpeed(42);
+        position.setValid(false);
         position.set("adc1", 128);
         position.set("booleanFlag", true);
         position.set("adc2", 100);
         position.set("bitFlag", 7);
         position.set("event", 42);
+        position.set("result", "success");
         Attribute attribute = new Attribute();
 
-        attribute.setExpression("position.getInteger(\"adc1\")");
+        attribute.setExpression("adc1");
         Assert.assertEquals(128, computedAttributesHandler.computeAttribute(attribute, position));
 
-        attribute.setExpression("!position.getBoolean(\"booleanFlag\")");
+        attribute.setExpression("!booleanFlag");
         Assert.assertEquals(false, computedAttributesHandler.computeAttribute(attribute, position));
 
-        attribute.setExpression("position.getInteger(\"adc2\") * 2 + 50");
+        attribute.setExpression("adc2 * 2 + 50");
         Assert.assertEquals(250, computedAttributesHandler.computeAttribute(attribute, position));
 
-        attribute.setExpression("(position.getLong(\"bitFlag\") & 4) != 0");
+        attribute.setExpression("(bitFlag & 4) != 0");
         Assert.assertEquals(true, computedAttributesHandler.computeAttribute(attribute, position));
 
-        attribute.setExpression("if (position.getLong(\"event\") == 42) \"lowBattery\"");
+        attribute.setExpression("if (event == 42) \"lowBattery\"");
         Assert.assertEquals("lowBattery", computedAttributesHandler.computeAttribute(attribute, position));
+        
+        attribute.setExpression("speed > 5 && valid");
+        Assert.assertEquals(false, computedAttributesHandler.computeAttribute(attribute, position));
+        
+        attribute.setExpression("fixTime");
+        Assert.assertEquals(date, computedAttributesHandler.computeAttribute(attribute, position));
+        
+        // modification tests
+        attribute.setExpression("adc1 = 256");
+        computedAttributesHandler.computeAttribute(attribute, position);
+        Assert.assertEquals(128, position.getInteger("adc1"));
+        
+        attribute.setExpression("result = \"fail\"");
+        computedAttributesHandler.computeAttribute(attribute, position);
+        Assert.assertEquals("success", position.getString("result"));
+        
+        attribute.setExpression("fixTime = \"2017-10-18 10:00:01\"");
+        computedAttributesHandler.computeAttribute(attribute, position);
+        Assert.assertEquals(date, position.getFixTime());
+        
     }
 
 }


### PR DESCRIPTION
Map all position fields and attributes to jexl context with help of reflection.

Expressions look more simple now.

Did not notice any changes in performance.

Added some tests to check if scripts can influence on the original position.

