### PR TITLE
Adjust battery and batteryLevel type

### DIFF
--- a/src/org/traccar/model/Position.java
+++ b/src/org/traccar/model/Position.java
@@ -41,7 +41,8 @@ public class Position extends Message {
     // The units for the below four KEYs currently vary.
     // The preferred units of measure are specified in the comment for each.
     public static final String KEY_POWER = "power"; // volts
-    public static final String KEY_BATTERY = "battery"; // volts (or percentage appending %)
+    public static final String KEY_BATTERY = "battery"; // volts
+    public static final String KEY_BATTERY_LEVEL = "batteryLevel"; // percentage
     public static final String KEY_FUEL_LEVEL = "fuel"; // liters
     public static final String KEY_FUEL_CONSUMPTION = "fuelConsumption"; // liters/hour
 

--- a/src/org/traccar/protocol/Ardi01ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Ardi01ProtocolDecoder.java
@@ -78,7 +78,7 @@ public class Ardi01ProtocolDecoder extends BaseProtocolDecoder {
         position.set(Position.KEY_SATELLITES, satellites);
 
         position.set(Position.KEY_EVENT, parser.next());
-        position.set(Position.KEY_BATTERY, parser.next());
+        position.set(Position.KEY_BATTERY_LEVEL, parser.nextInt(0));
         position.set(Position.PREFIX_TEMP + 1, parser.next());
 
         return position;

--- a/src/org/traccar/protocol/CguardProtocolDecoder.java
+++ b/src/org/traccar/protocol/CguardProtocolDecoder.java
@@ -102,7 +102,7 @@ public class CguardProtocolDecoder extends BaseProtocolDecoder {
                     position.set(Position.KEY_SATELLITES, Integer.parseInt(value));
                     break;
                 case "BAT1":
-                    position.set(Position.KEY_BATTERY, Integer.parseInt(value) + "%");
+                    position.set(Position.KEY_BATTERY_LEVEL, Integer.parseInt(value));
                     break;
                 case "PWR1":
                     position.set(Position.KEY_POWER, Double.parseDouble(value));

--- a/src/org/traccar/protocol/DishaProtocolDecoder.java
+++ b/src/org/traccar/protocol/DishaProtocolDecoder.java
@@ -88,7 +88,7 @@ public class DishaProtocolDecoder extends BaseProtocolDecoder {
         position.set(Position.KEY_HDOP, parser.next());
         position.set(Position.KEY_RSSI, parser.next());
         position.set(Position.KEY_CHARGE, parser.nextInt(0) == 2);
-        position.set(Position.KEY_BATTERY, parser.next());
+        position.set(Position.KEY_BATTERY_LEVEL, parser.nextInt(0));
 
         position.set(Position.PREFIX_ADC + 1, parser.nextInt(0));
         position.set(Position.PREFIX_ADC + 2, parser.nextInt(0));

--- a/src/org/traccar/protocol/Gl200ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gl200ProtocolDecoder.java
@@ -399,9 +399,7 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
         position.set(Position.KEY_BATTERY, parser.nextDouble(0));
         position.set(Position.KEY_CHARGE, parser.nextInt(0) == 1);
 
-        if (parser.hasNext()) {
-            position.set(Position.KEY_BATTERY_LEVEL, parser.nextInt(0));
-        }
+        position.set(Position.KEY_BATTERY_LEVEL, parser.nextInt());
 
         position.set(Position.PREFIX_TEMP + 1, parser.next());
 
@@ -546,13 +544,13 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
         }
 
         position.set(Position.KEY_ODOMETER, parser.nextDouble(0) * 1000);
-        position.set(Position.KEY_BATTERY_LEVEL, parser.nextInt(0));
+        position.set(Position.KEY_BATTERY_LEVEL, parser.nextInt());
 
         position.set(Position.KEY_ODOMETER, parser.nextDouble(0) * 1000);
         position.set(Position.KEY_HOURS, parser.next());
         position.set(Position.PREFIX_ADC + 1, parser.next());
         position.set(Position.PREFIX_ADC + 2, parser.next());
-        position.set(Position.KEY_BATTERY_LEVEL, parser.nextInt(0));
+        position.set(Position.KEY_BATTERY_LEVEL, parser.nextInt());
 
         decodeStatus(position, parser);
 
@@ -599,7 +597,7 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
         position.set(Position.KEY_HOURS, parser.next());
         position.set(Position.PREFIX_ADC + 1, parser.next());
         position.set(Position.PREFIX_ADC + 2, parser.next());
-        position.set(Position.KEY_BATTERY_LEVEL, parser.nextInt(0));
+        position.set(Position.KEY_BATTERY_LEVEL, parser.nextInt());
 
         decodeStatus(position, parser);
 

--- a/src/org/traccar/protocol/Gl200ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gl200ProtocolDecoder.java
@@ -400,7 +400,7 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
         position.set(Position.KEY_CHARGE, parser.nextInt(0) == 1);
 
         if (parser.hasNext()) {
-            position.set(Position.KEY_BATTERY, parser.next() + "%");
+            position.set(Position.KEY_BATTERY_LEVEL, parser.nextInt(0));
         }
 
         position.set(Position.PREFIX_TEMP + 1, parser.next());
@@ -546,13 +546,13 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
         }
 
         position.set(Position.KEY_ODOMETER, parser.nextDouble(0) * 1000);
-        position.set(Position.KEY_BATTERY, parser.next());
+        position.set(Position.KEY_BATTERY_LEVEL, parser.nextInt(0));
 
         position.set(Position.KEY_ODOMETER, parser.nextDouble(0) * 1000);
         position.set(Position.KEY_HOURS, parser.next());
         position.set(Position.PREFIX_ADC + 1, parser.next());
         position.set(Position.PREFIX_ADC + 2, parser.next());
-        position.set(Position.KEY_BATTERY, parser.next());
+        position.set(Position.KEY_BATTERY_LEVEL, parser.nextInt(0));
 
         decodeStatus(position, parser);
 
@@ -599,7 +599,7 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
         position.set(Position.KEY_HOURS, parser.next());
         position.set(Position.PREFIX_ADC + 1, parser.next());
         position.set(Position.PREFIX_ADC + 2, parser.next());
-        position.set(Position.KEY_BATTERY, parser.next());
+        position.set(Position.KEY_BATTERY_LEVEL, parser.nextInt(0));
 
         decodeStatus(position, parser);
 
@@ -664,7 +664,7 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
 
         position.setNetwork(network);
 
-        position.set(Position.KEY_BATTERY, parser.nextInt(0));
+        position.set(Position.KEY_BATTERY_LEVEL, parser.nextInt(0));
 
         return position;
     }
@@ -712,7 +712,7 @@ public class Gl200ProtocolDecoder extends BaseProtocolDecoder {
         decodeLocation(position, parser);
 
         position.set(Position.KEY_ODOMETER, parser.nextDouble(0) * 1000);
-        position.set(Position.KEY_BATTERY, parser.next());
+        position.set(Position.KEY_BATTERY_LEVEL, parser.nextInt(0));
 
         position.set(Position.KEY_ODOMETER, parser.nextDouble(0) * 1000);
 

--- a/src/org/traccar/protocol/GlobalSatProtocolDecoder.java
+++ b/src/org/traccar/protocol/GlobalSatProtocolDecoder.java
@@ -165,7 +165,12 @@ public class GlobalSatProtocolDecoder extends BaseProtocolDecoder {
                     position.setCourse(Double.parseDouble(value));
                     break;
                 case 'N':
-                    position.set(Position.KEY_BATTERY, value);
+                    if (value.endsWith("mV")) {
+                        position.set(Position.KEY_BATTERY,
+                                Integer.parseInt(value.substring(0, value.length() - 2)) / 1000.0);
+                    } else {
+                        position.set(Position.KEY_BATTERY_LEVEL, Integer.parseInt(value));
+                    }
                     break;
                 default:
                     // Unsupported

--- a/src/org/traccar/protocol/GoSafeProtocolDecoder.java
+++ b/src/org/traccar/protocol/GoSafeProtocolDecoder.java
@@ -164,8 +164,8 @@ public class GoSafeProtocolDecoder extends BaseProtocolDecoder {
         if (parser.hasNext()) {
             position.set(Position.KEY_ODOMETER, parser.nextInt(0));
         }
-        position.set(Position.KEY_POWER, parser.next());
-        position.set(Position.KEY_BATTERY, parser.next());
+        position.set(Position.KEY_POWER, parser.nextDouble(0));
+        position.set(Position.KEY_BATTERY, parser.nextDouble(0));
 
         if (parser.hasNext(6)) {
             long status = parser.nextLong(16, 0);

--- a/src/org/traccar/protocol/GoSafeProtocolDecoder.java
+++ b/src/org/traccar/protocol/GoSafeProtocolDecoder.java
@@ -165,7 +165,7 @@ public class GoSafeProtocolDecoder extends BaseProtocolDecoder {
             position.set(Position.KEY_ODOMETER, parser.nextInt(0));
         }
         position.set(Position.KEY_POWER, parser.nextDouble(0));
-        position.set(Position.KEY_BATTERY, parser.nextDouble(0));
+        position.set(Position.KEY_BATTERY, parser.nextDouble());
 
         if (parser.hasNext(6)) {
             long status = parser.nextLong(16, 0);

--- a/src/org/traccar/protocol/GpsMarkerProtocolDecoder.java
+++ b/src/org/traccar/protocol/GpsMarkerProtocolDecoder.java
@@ -79,7 +79,7 @@ public class GpsMarkerProtocolDecoder extends BaseProtocolDecoder {
         position.setCourse(parser.nextDouble(0));
 
         position.set(Position.KEY_SATELLITES, parser.nextHexInt(0));
-        position.set(Position.KEY_BATTERY, parser.next());
+        position.set(Position.KEY_BATTERY_LEVEL, parser.nextInt(0));
         position.set(Position.KEY_INPUT, parser.next());
         position.set(Position.KEY_OUTPUT, parser.next());
         position.set(Position.PREFIX_TEMP + 1, parser.next());

--- a/src/org/traccar/protocol/H02ProtocolDecoder.java
+++ b/src/org/traccar/protocol/H02ProtocolDecoder.java
@@ -82,18 +82,18 @@ public class H02ProtocolDecoder extends BaseProtocolDecoder {
 
     }
 
-    private String decodeBattery(int value) {
+    private Integer decodeBattery(int value) {
         switch (value) {
             case 6:
-                return "100%";
+                return 100;
             case 5:
-                return "80%";
+                return 80;
             case 4:
-                return "60%";
+                return 60;
             case 3:
-                return "20%";
+                return 20;
             case 2:
-                return "10%";
+                return 10;
             default:
                 return null;
         }
@@ -123,7 +123,7 @@ public class H02ProtocolDecoder extends BaseProtocolDecoder {
         position.setTime(dateBuilder.getDate());
 
         double latitude = readCoordinate(buf, false);
-        position.set(Position.KEY_BATTERY, decodeBattery(buf.readUnsignedByte()));
+        position.set(Position.KEY_BATTERY_LEVEL, decodeBattery(buf.readUnsignedByte()));
         double longitude = readCoordinate(buf, true);
 
         int flags = buf.readUnsignedByte() & 0x0f;

--- a/src/org/traccar/protocol/Jt600ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Jt600ProtocolDecoder.java
@@ -107,7 +107,7 @@ public class Jt600ProtocolDecoder extends BaseProtocolDecoder {
             if (battery == 0xff) {
                 position.set(Position.KEY_CHARGE, true);
             } else {
-                position.set(Position.KEY_BATTERY, battery + "%");
+                position.set(Position.KEY_BATTERY_LEVEL, battery);
             }
 
             CellTower cellTower = CellTower.fromCidLac(buf.readUnsignedShort(), buf.readUnsignedShort());
@@ -218,7 +218,7 @@ public class Jt600ProtocolDecoder extends BaseProtocolDecoder {
             .number("(d+.?d*),")                 // speed
             .number("(d+),")                     // course
             .number("(d+),")                     // satellites
-            .number("(d+%),")                    // battery
+            .number("(d+)%,")                    // battery
             .expression("([01]+),")              // status
             .number("(d+),")                     // cid
             .number("(d+),")                     // lac
@@ -257,7 +257,7 @@ public class Jt600ProtocolDecoder extends BaseProtocolDecoder {
         position.setCourse(parser.nextDouble(0));
 
         position.set(Position.KEY_SATELLITES, parser.nextInt(0));
-        position.set(Position.KEY_BATTERY, parser.next());
+        position.set(Position.KEY_BATTERY_LEVEL, parser.nextInt(0));
         position.set(Position.KEY_STATUS, parser.nextBinInt(0));
 
         CellTower cellTower = CellTower.fromCidLac(parser.nextInt(0), parser.nextInt(0));

--- a/src/org/traccar/protocol/OsmAndProtocolDecoder.java
+++ b/src/org/traccar/protocol/OsmAndProtocolDecoder.java
@@ -126,7 +126,7 @@ public class OsmAndProtocolDecoder extends BaseProtocolDecoder {
                     position.set(Position.KEY_HDOP, Double.parseDouble(value));
                     break;
                 case "batt":
-                    position.set(Position.KEY_BATTERY, value);
+                    position.set(Position.KEY_BATTERY, Double.parseDouble(value));
                     break;
                 default:
                     try {

--- a/src/org/traccar/protocol/T55ProtocolDecoder.java
+++ b/src/org/traccar/protocol/T55ProtocolDecoder.java
@@ -219,7 +219,7 @@ public class T55ProtocolDecoder extends BaseProtocolDecoder {
         position.setCourse(parser.nextDouble(0));
         position.setAltitude(parser.nextDouble(0));
 
-        position.set(Position.KEY_BATTERY, parser.next());
+        position.set(Position.KEY_BATTERY, parser.nextDouble(0));
 
         return position;
     }

--- a/src/org/traccar/protocol/T55ProtocolDecoder.java
+++ b/src/org/traccar/protocol/T55ProtocolDecoder.java
@@ -137,7 +137,7 @@ public class T55ProtocolDecoder extends BaseProtocolDecoder {
 
             position.set(Position.KEY_IGNITION, parser.hasNext() && parser.next().equals("1"));
             position.set(Position.KEY_FUEL_LEVEL, parser.nextInt(0));
-            position.set(Position.KEY_BATTERY, parser.nextInt(0));
+            position.set(Position.KEY_BATTERY, parser.nextInt());
         }
 
         if (parser.hasNext()) {

--- a/src/org/traccar/protocol/TaipProtocolDecoder.java
+++ b/src/org/traccar/protocol/TaipProtocolDecoder.java
@@ -175,7 +175,7 @@ public class TaipProtocolDecoder extends BaseProtocolDecoder {
                             break;
 
                         case "bl":
-                            position.set(Position.KEY_BATTERY, value);
+                            position.set(Position.KEY_BATTERY, Integer.parseInt(value));
                             break;
 
                         case "vo":

--- a/src/org/traccar/protocol/TotemProtocolDecoder.java
+++ b/src/org/traccar/protocol/TotemProtocolDecoder.java
@@ -252,7 +252,11 @@ public class TotemProtocolDecoder extends BaseProtocolDecoder {
             }
 
             position.set(Position.PREFIX_IO + 1, parser.next());
-            position.set(Position.KEY_BATTERY, parser.next());
+            if (pattern == PATTERN1) {
+                position.set(Position.KEY_BATTERY, parser.nextDouble(0) * 0.01);
+            } else {
+                position.set(Position.KEY_BATTERY, parser.nextDouble(0) * 0.1);
+            }
             position.set(Position.KEY_POWER, parser.nextDouble(0));
             position.set(Position.PREFIX_ADC + 1, parser.next());
 

--- a/src/org/traccar/protocol/WatchProtocolDecoder.java
+++ b/src/org/traccar/protocol/WatchProtocolDecoder.java
@@ -160,7 +160,7 @@ public class WatchProtocolDecoder extends BaseProtocolDecoder {
 
                     getLastLocation(position, null);
 
-                    position.set(Position.KEY_BATTERY, values[3]);
+                    position.set(Position.KEY_BATTERY_LEVEL, Integer.parseInt(values[3]));
 
                     return position;
                 }
@@ -193,7 +193,7 @@ public class WatchProtocolDecoder extends BaseProtocolDecoder {
 
             position.set(Position.KEY_SATELLITES, parser.nextInt(0));
             position.set(Position.KEY_RSSI, parser.nextInt(0));
-            position.set(Position.KEY_BATTERY, parser.nextInt(0));
+            position.set(Position.KEY_BATTERY_LEVEL, parser.nextInt(0));
 
             position.set("steps", parser.nextInt(0));
 

--- a/src/org/traccar/protocol/WondexProtocolDecoder.java
+++ b/src/org/traccar/protocol/WondexProtocolDecoder.java
@@ -110,7 +110,7 @@ public class WondexProtocolDecoder extends BaseProtocolDecoder {
             position.set(Position.KEY_SATELLITES, satellites);
 
             position.set(Position.KEY_EVENT, parser.next());
-            position.set(Position.KEY_BATTERY, parser.nextDouble(0));
+            position.set(Position.KEY_BATTERY, parser.nextDouble());
             if (parser.hasNext()) {
                 position.set(Position.KEY_ODOMETER, parser.nextDouble(0) * 1000);
             }

--- a/src/org/traccar/protocol/WondexProtocolDecoder.java
+++ b/src/org/traccar/protocol/WondexProtocolDecoder.java
@@ -110,7 +110,7 @@ public class WondexProtocolDecoder extends BaseProtocolDecoder {
             position.set(Position.KEY_SATELLITES, satellites);
 
             position.set(Position.KEY_EVENT, parser.next());
-            position.set(Position.KEY_BATTERY, parser.next());
+            position.set(Position.KEY_BATTERY, parser.nextDouble(0));
             if (parser.hasNext()) {
                 position.set(Position.KEY_ODOMETER, parser.nextDouble(0) * 1000);
             }

--- a/src/org/traccar/protocol/XirgoProtocolDecoder.java
+++ b/src/org/traccar/protocol/XirgoProtocolDecoder.java
@@ -152,7 +152,7 @@ public class XirgoProtocolDecoder extends BaseProtocolDecoder {
             position.set(Position.KEY_FUEL_CONSUMPTION, parser.next());
         }
 
-        position.set(Position.KEY_BATTERY, parser.next());
+        position.set(Position.KEY_BATTERY, parser.nextDouble(0));
         position.set(Position.KEY_RSSI, parser.next());
 
         if (!newFormat) {

--- a/src/org/traccar/protocol/Xt013ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Xt013ProtocolDecoder.java
@@ -85,8 +85,8 @@ public class Xt013ProtocolDecoder extends BaseProtocolDecoder {
 
         position.set(Position.KEY_GPS, parser.next());
         position.set(Position.KEY_RSSI, parser.next());
-        position.set(Position.KEY_BATTERY, parser.next());
-        position.set(Position.KEY_CHARGE, parser.next());
+        position.set(Position.KEY_BATTERY, parser.nextDouble(0));
+        position.set(Position.KEY_CHARGE, parser.next().equals("1"));
 
         return position;
     }

--- a/test/org/traccar/ProtocolTest.java
+++ b/test/org/traccar/ProtocolTest.java
@@ -197,9 +197,8 @@ public class ProtocolTest extends BaseTest {
         }
 
         if (attributes.containsKey(Position.KEY_BATTERY_LEVEL)) {
-            Object batteryLevel = attributes.get(Position.KEY_BATTERY_LEVEL);
-            Assert.assertTrue(batteryLevel instanceof Number);
-            Assert.assertTrue(((Number) batteryLevel).intValue() <=100 && ((Number) batteryLevel).intValue() >= 0);
+            int batteryLevel = ((Number) attributes.get(Position.KEY_BATTERY_LEVEL)).intValue();
+            Assert.assertTrue(batteryLevel <= 100 && batteryLevel >= 0);
         }
 
         if (position.getNetwork() != null && position.getNetwork().getCellTowers() != null) {

--- a/test/org/traccar/ProtocolTest.java
+++ b/test/org/traccar/ProtocolTest.java
@@ -192,6 +192,16 @@ public class ProtocolTest extends BaseTest {
             Assert.assertTrue(attributes.get(Position.KEY_FUEL_LEVEL) instanceof Number);
         }
 
+        if (attributes.containsKey(Position.KEY_BATTERY)) {
+            Assert.assertTrue(attributes.get(Position.KEY_BATTERY) instanceof Number);
+        }
+
+        if (attributes.containsKey(Position.KEY_BATTERY_LEVEL)) {
+            Object batteryLevel = attributes.get(Position.KEY_BATTERY_LEVEL);
+            Assert.assertTrue(batteryLevel instanceof Number);
+            Assert.assertTrue(((Number) batteryLevel).intValue() <=100 && ((Number) batteryLevel).intValue() >= 0);
+        }
+
         if (position.getNetwork() != null && position.getNetwork().getCellTowers() != null) {
             for (CellTower cellTower : position.getNetwork().getCellTowers()) {
                 checkInteger(cellTower.getMobileCountryCode(), 0, 999);


### PR DESCRIPTION
Here is part of big common position attributes improvement.
`KEY_BATTERY` and `KEY_BATTERY_LEVEL` today

Added test for number and percents.

One half changed according to documentation, second half according to intuition and logic.
I supposed that `(d+.d+)` usually voltage and `(dd)` usually percents.

The only protocol I do not know how interpret is `taip`, there are only three values in tests: `229`, `4416` and `4190` and no documentation. I have no idea how handle it. Just converted to integer to not fail tests.