### PR TITLE
Organize KEY_POWER and KEY_CHARGE

### DIFF
--- a/src/org/traccar/protocol/AquilaProtocolDecoder.java
+++ b/src/org/traccar/protocol/AquilaProtocolDecoder.java
@@ -161,7 +161,7 @@ public class AquilaProtocolDecoder extends BaseProtocolDecoder {
 
             position.set(Position.KEY_FUEL_LEVEL, parser.nextInt());
             position.set(Position.PREFIX_IN + 1, parser.next());
-            position.set(Position.KEY_CHARGE, parser.next());
+            position.set(Position.KEY_CHARGE, parser.next().equals("1"));
             position.set(Position.PREFIX_IN + 2, parser.next());
 
             position.set(Position.KEY_IGNITION, parser.nextInt(0) == 1);
@@ -176,7 +176,7 @@ public class AquilaProtocolDecoder extends BaseProtocolDecoder {
 
             position.setCourse(parser.nextInt(0));
 
-            position.set(Position.KEY_CHARGE, parser.next());
+            position.set(Position.KEY_CHARGE, parser.next().equals("1"));
             position.set(Position.KEY_IGNITION, parser.nextInt(0) == 1);
             position.set(Position.KEY_POWER, parser.nextInt(0));
             position.set(Position.KEY_BATTERY, parser.nextInt(0));
@@ -195,7 +195,7 @@ public class AquilaProtocolDecoder extends BaseProtocolDecoder {
             position.set(Position.KEY_HDOP, parser.nextDouble(0));
             position.set(Position.PREFIX_ADC + 1, parser.nextInt(0));
             position.set(Position.PREFIX_IN + 1, parser.nextInt(0));
-            position.set(Position.KEY_CHARGE, parser.next());
+            position.set(Position.KEY_CHARGE, parser.next().equals("1"));
             position.set(Position.PREFIX_IN + 2, parser.nextInt(0));
             position.set(Position.KEY_IGNITION, parser.nextInt(0) == 1);
             position.set(Position.KEY_POWER, parser.nextInt(0));

--- a/src/org/traccar/protocol/BlackKiteProtocolDecoder.java
+++ b/src/org/traccar/protocol/BlackKiteProtocolDecoder.java
@@ -125,7 +125,7 @@ public class BlackKiteProtocolDecoder extends BaseProtocolDecoder {
                     if (BitUtil.check(status, 15)) {
                         position.set(Position.KEY_ALARM, Position.ALARM_GENERAL);
                     }
-                    position.set(Position.KEY_POWER, BitUtil.check(status, 2));
+                    position.set(Position.KEY_CHARGE, BitUtil.check(status, 2));
                     break;
 
                 case TAG_DIGITAL_INPUTS:

--- a/src/org/traccar/protocol/GoSafeProtocolDecoder.java
+++ b/src/org/traccar/protocol/GoSafeProtocolDecoder.java
@@ -164,7 +164,7 @@ public class GoSafeProtocolDecoder extends BaseProtocolDecoder {
         if (parser.hasNext()) {
             position.set(Position.KEY_ODOMETER, parser.nextInt(0));
         }
-        position.set(Position.KEY_POWER, parser.nextDouble(0));
+        position.set(Position.KEY_POWER, parser.nextDouble());
         position.set(Position.KEY_BATTERY, parser.nextDouble());
 
         if (parser.hasNext(6)) {

--- a/src/org/traccar/protocol/IntellitracProtocolDecoder.java
+++ b/src/org/traccar/protocol/IntellitracProtocolDecoder.java
@@ -107,7 +107,7 @@ public class IntellitracProtocolDecoder extends BaseProtocolDecoder {
         position.set(Position.KEY_FUEL_LEVEL, parser.nextInt(0));
         position.set(Position.KEY_FUEL_CONSUMPTION, parser.nextInt(0));
         position.set(Position.PREFIX_TEMP + 1, parser.nextInt(0));
-        position.set(Position.KEY_CHARGE, parser.nextInt(0));
+        position.set("chargerPressure", parser.nextInt(0));
         position.set("tpl", parser.nextInt(0));
         position.set("axle", parser.nextInt(0));
         position.set(Position.KEY_OBD_ODOMETER, parser.nextInt(0));

--- a/src/org/traccar/protocol/TrakMateProtocolDecoder.java
+++ b/src/org/traccar/protocol/TrakMateProtocolDecoder.java
@@ -189,7 +189,7 @@ public class TrakMateProtocolDecoder extends BaseProtocolDecoder {
         position.set("dop2", parser.next());
         position.set(Position.KEY_INPUT, parser.next());
         position.set(Position.KEY_BATTERY, parser.nextDouble(0));
-        position.set(Position.KEY_POWER, parser.next());
+        position.set(Position.KEY_POWER, parser.nextDouble());
         position.set(Position.KEY_ODOMETER, parser.nextDouble(0));
         position.set("pulseOdometer", parser.next());
         position.set(Position.KEY_STATUS, parser.nextInt(0));

--- a/src/org/traccar/protocol/VisiontekProtocolDecoder.java
+++ b/src/org/traccar/protocol/VisiontekProtocolDecoder.java
@@ -114,7 +114,7 @@ public class VisiontekProtocolDecoder extends BaseProtocolDecoder {
             position.set(Position.PREFIX_IO + 1, parser.next());
             position.set(Position.PREFIX_IO + 2, parser.next());
             position.set("immobilizer", parser.next());
-            position.set(Position.KEY_POWER, parser.next());
+            position.set(Position.KEY_CHARGE, parser.next().equals("1"));
             position.set(Position.KEY_RSSI, parser.next());
         }
 

--- a/test/org/traccar/ProtocolTest.java
+++ b/test/org/traccar/ProtocolTest.java
@@ -192,6 +192,10 @@ public class ProtocolTest extends BaseTest {
             Assert.assertTrue(attributes.get(Position.KEY_FUEL_LEVEL) instanceof Number);
         }
 
+        if (attributes.containsKey(Position.KEY_POWER)) {
+            Assert.assertTrue(attributes.get(Position.KEY_POWER) instanceof Number);
+        }
+
         if (attributes.containsKey(Position.KEY_BATTERY)) {
             Assert.assertTrue(attributes.get(Position.KEY_BATTERY) instanceof Number);
         }
@@ -199,6 +203,10 @@ public class ProtocolTest extends BaseTest {
         if (attributes.containsKey(Position.KEY_BATTERY_LEVEL)) {
             int batteryLevel = ((Number) attributes.get(Position.KEY_BATTERY_LEVEL)).intValue();
             Assert.assertTrue(batteryLevel <= 100 && batteryLevel >= 0);
+        }
+
+        if (attributes.containsKey(Position.KEY_CHARGE)) {
+            Assert.assertTrue(attributes.get(Position.KEY_CHARGE) instanceof Boolean);
         }
 
         if (position.getNetwork() != null && position.getNetwork().getCellTowers() != null) {


### PR DESCRIPTION
Organized `KEY_POWER` and `KEY_CHARGE` using in few places

- Sorry, reverted `KEY_POWER` without default value in GoSafe (from last PR)
- "chargerPressure" has nothing to `KEY_CHARGE` in Intellitrac, it is about turbine or compressor or something
- I'm not sure in BlackKite, there is no documentation and any description, but it looks like `KEY_CHARGE`
- And I'm pretty sure that it is `KEY_CHARGE` in Visiontek