### PR TITLE
Organize satellites and RSSI values

### DIFF
--- a/src/org/traccar/protocol/CityeasyProtocolDecoder.java
+++ b/src/org/traccar/protocol/CityeasyProtocolDecoder.java
@@ -100,7 +100,7 @@ public class CityeasyProtocolDecoder extends BaseProtocolDecoder {
                 position.setTime(parser.nextDateTime());
 
                 position.setValid(parser.next().equals("A"));
-                position.set(Position.KEY_SATELLITES, parser.next());
+                position.set(Position.KEY_SATELLITES, parser.nextInt());
 
                 position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG));
                 position.setLongitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG));

--- a/src/org/traccar/protocol/CradlepointProtocolDecoder.java
+++ b/src/org/traccar/protocol/CradlepointProtocolDecoder.java
@@ -77,7 +77,7 @@ public class CradlepointProtocolDecoder extends BaseProtocolDecoder {
 
         parser.skip(4);
 
-        position.set(Position.KEY_RSSI, parser.next());
+        position.set(Position.KEY_RSSI, parser.nextDouble());
 
         return position;
     }

--- a/src/org/traccar/protocol/DishaProtocolDecoder.java
+++ b/src/org/traccar/protocol/DishaProtocolDecoder.java
@@ -84,9 +84,9 @@ public class DishaProtocolDecoder extends BaseProtocolDecoder {
         position.setSpeed(parser.nextDouble(0));
         position.setCourse(parser.nextDouble(0));
 
-        position.set(Position.KEY_SATELLITES, parser.next());
+        position.set(Position.KEY_SATELLITES, parser.nextInt());
         position.set(Position.KEY_HDOP, parser.nextDouble());
-        position.set(Position.KEY_RSSI, parser.next());
+        position.set(Position.KEY_RSSI, parser.nextDouble());
         position.set(Position.KEY_CHARGE, parser.nextInt(0) == 2);
         position.set(Position.KEY_BATTERY_LEVEL, parser.nextInt(0));
 

--- a/src/org/traccar/protocol/GoSafeProtocolDecoder.java
+++ b/src/org/traccar/protocol/GoSafeProtocolDecoder.java
@@ -146,7 +146,7 @@ public class GoSafeProtocolDecoder extends BaseProtocolDecoder {
         position.set(Position.KEY_EVENT, parser.next());
 
         position.setValid(parser.next().equals("A"));
-        position.set(Position.KEY_SATELLITES, parser.next());
+        position.set(Position.KEY_SATELLITES, parser.nextInt());
 
         position.setLatitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG));
         position.setLongitude(parser.nextCoordinate(Parser.CoordinateFormat.HEM_DEG));

--- a/src/org/traccar/protocol/HaicomProtocolDecoder.java
+++ b/src/org/traccar/protocol/HaicomProtocolDecoder.java
@@ -97,8 +97,8 @@ public class HaicomProtocolDecoder extends BaseProtocolDecoder {
         position.setCourse(parser.nextDouble(0) / 10);
 
         position.set(Position.KEY_STATUS, parser.next());
-        position.set(Position.KEY_RSSI, parser.next());
-        position.set(Position.KEY_GPS, parser.next());
+        position.set("gprsCount", parser.next());
+        position.set("powersaveCountdown", parser.next());
         position.set(Position.KEY_INPUT, parser.next());
         position.set(Position.KEY_OUTPUT, parser.next());
         position.set(Position.KEY_BATTERY, parser.nextDouble(0) * 0.1);

--- a/src/org/traccar/protocol/MegastekProtocolDecoder.java
+++ b/src/org/traccar/protocol/MegastekProtocolDecoder.java
@@ -166,11 +166,17 @@ public class MegastekProtocolDecoder extends BaseProtocolDecoder {
                 }
                 position.setDeviceId(deviceSession.getDeviceId());
 
-                position.set(Position.KEY_SATELLITES, parser.next());
+                String sat = parser.next();
+                if (sat.contains("/")) {
+                    position.set(Position.KEY_SATELLITES, Integer.parseInt(sat.split("/")[0]));
+                    position.set(Position.KEY_SATELLITES_VISIBLE, Integer.parseInt(sat.split("/")[1]));
+                } else {
+                    position.set(Position.KEY_SATELLITES, Integer.parseInt(sat));
+                }
 
                 position.setAltitude(parser.nextDouble(0));
 
-                position.set(Position.KEY_POWER, parser.nextDouble(0));
+                position.set(Position.KEY_BATTERY_LEVEL, parser.nextDouble(0));
 
                 String charger = parser.next();
                 if (charger != null) {
@@ -206,7 +212,7 @@ public class MegastekProtocolDecoder extends BaseProtocolDecoder {
                 position.setNetwork(new Network(CellTower.from(parser.nextInt(0), parser.nextInt(0),
                         parser.nextHexInt(0), parser.nextHexInt(0), parser.nextInt(0))));
 
-                position.set(Position.KEY_BATTERY, Double.parseDouble(parser.next()));
+                position.set(Position.KEY_BATTERY_LEVEL, parser.nextDouble());
 
                 position.set(Position.KEY_FLAGS, parser.next());
                 position.set(Position.KEY_INPUT, parser.next());

--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -136,7 +136,7 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
 
         position.setValid(parser.next().equals("A"));
 
-        position.set(Position.KEY_SATELLITES, parser.next());
+        position.set(Position.KEY_SATELLITES, parser.nextInt());
         int rssi = parser.nextInt(0);
 
         position.setSpeed(UnitsConverter.knotsFromKph(parser.nextDouble(0)));

--- a/src/org/traccar/protocol/T55ProtocolDecoder.java
+++ b/src/org/traccar/protocol/T55ProtocolDecoder.java
@@ -127,7 +127,7 @@ public class T55ProtocolDecoder extends BaseProtocolDecoder {
         position.setTime(dateBuilder.getDate());
 
         if (parser.hasNext(5)) {
-            position.set(Position.KEY_SATELLITES, parser.next());
+            position.set(Position.KEY_SATELLITES, parser.nextInt());
 
             deviceSession = getDeviceSession(channel, remoteAddress, parser.next());
             if (deviceSession == null) {

--- a/src/org/traccar/protocol/TaipProtocolDecoder.java
+++ b/src/org/traccar/protocol/TaipProtocolDecoder.java
@@ -171,7 +171,7 @@ public class TaipProtocolDecoder extends BaseProtocolDecoder {
                             break;
 
                         case "sv":
-                            position.set(Position.KEY_SATELLITES, value);
+                            position.set(Position.KEY_SATELLITES, Integer.parseInt(value));
                             break;
 
                         case "bl":

--- a/src/org/traccar/protocol/TotemProtocolDecoder.java
+++ b/src/org/traccar/protocol/TotemProtocolDecoder.java
@@ -288,7 +288,7 @@ public class TotemProtocolDecoder extends BaseProtocolDecoder {
                     CellTower.fromLacCid(parser.nextHexInt(0), parser.nextHexInt(0))));
 
             position.setValid(parser.next().equals("A"));
-            position.set(Position.KEY_SATELLITES, parser.next());
+            position.set(Position.KEY_SATELLITES, parser.nextInt());
             position.setCourse(parser.nextDouble(0));
             position.setSpeed(parser.nextDouble(0));
             position.set(Position.KEY_PDOP, parser.nextDouble());

--- a/src/org/traccar/protocol/Tr900ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Tr900ProtocolDecoder.java
@@ -81,7 +81,7 @@ public class Tr900ProtocolDecoder extends BaseProtocolDecoder {
         position.setSpeed(parser.nextDouble(0));
         position.setCourse(parser.nextDouble(0));
 
-        position.set(Position.KEY_RSSI, parser.next());
+        position.set(Position.KEY_RSSI, parser.nextDouble());
         position.set(Position.KEY_EVENT, parser.nextInt(0));
         position.set(Position.PREFIX_ADC + 1, parser.nextInt(0));
         position.set(Position.KEY_BATTERY, parser.nextInt(0));

--- a/src/org/traccar/protocol/TrackboxProtocolDecoder.java
+++ b/src/org/traccar/protocol/TrackboxProtocolDecoder.java
@@ -101,7 +101,7 @@ public class TrackboxProtocolDecoder extends BaseProtocolDecoder {
         dateBuilder.setDateReverse(parser.nextInt(0), parser.nextInt(0), parser.nextInt(0));
         position.setTime(dateBuilder.getDate());
 
-        position.set(Position.KEY_SATELLITES, parser.next());
+        position.set(Position.KEY_SATELLITES, parser.nextInt());
 
         return position;
     }

--- a/src/org/traccar/protocol/V680ProtocolDecoder.java
+++ b/src/org/traccar/protocol/V680ProtocolDecoder.java
@@ -89,7 +89,7 @@ public class V680ProtocolDecoder extends BaseProtocolDecoder {
             position.set("password", parser.next());
             position.set(Position.KEY_EVENT, parser.next());
             position.set("packet", parser.next());
-            position.set(Position.KEY_RSSI, parser.next());
+            position.set("lbsData", parser.next());
 
             double lon = parser.nextDouble(0);
             boolean west = parser.next().equals("W");

--- a/src/org/traccar/protocol/VisiontekProtocolDecoder.java
+++ b/src/org/traccar/protocol/VisiontekProtocolDecoder.java
@@ -108,14 +108,14 @@ public class VisiontekProtocolDecoder extends BaseProtocolDecoder {
 
         if (parser.hasNext(9)) {
             position.setAltitude(parser.nextDouble(0));
-            position.set(Position.KEY_SATELLITES, parser.next());
+            position.set(Position.KEY_SATELLITES, parser.nextInt());
             position.set(Position.KEY_ODOMETER, parser.nextInt(0) * 1000);
             position.set(Position.KEY_IGNITION, parser.next().equals("1"));
             position.set(Position.PREFIX_IO + 1, parser.next());
             position.set(Position.PREFIX_IO + 2, parser.next());
             position.set("immobilizer", parser.next());
             position.set(Position.KEY_CHARGE, parser.next().equals("1"));
-            position.set(Position.KEY_RSSI, parser.next());
+            position.set(Position.KEY_RSSI, parser.nextDouble());
         }
 
         if (parser.hasNext(7)) {

--- a/src/org/traccar/protocol/XexunProtocolDecoder.java
+++ b/src/org/traccar/protocol/XexunProtocolDecoder.java
@@ -136,7 +136,7 @@ public class XexunProtocolDecoder extends BaseProtocolDecoder {
         position.setDeviceId(deviceSession.getDeviceId());
 
         if (full) {
-            position.set(Position.KEY_SATELLITES, parser.next().replaceFirst("^0*(?![\\.$])", ""));
+            position.set(Position.KEY_SATELLITES, parser.nextInt());
 
             position.setAltitude(parser.nextDouble(0));
 

--- a/src/org/traccar/protocol/XirgoProtocolDecoder.java
+++ b/src/org/traccar/protocol/XirgoProtocolDecoder.java
@@ -144,7 +144,7 @@ public class XirgoProtocolDecoder extends BaseProtocolDecoder {
         position.setSpeed(UnitsConverter.knotsFromMph(parser.nextDouble(0)));
         position.setCourse(parser.nextDouble(0));
 
-        position.set(Position.KEY_SATELLITES, parser.next());
+        position.set(Position.KEY_SATELLITES, parser.nextInt());
         position.set(Position.KEY_HDOP, parser.nextDouble());
 
         if (newFormat) {
@@ -153,7 +153,7 @@ public class XirgoProtocolDecoder extends BaseProtocolDecoder {
         }
 
         position.set(Position.KEY_BATTERY, parser.nextDouble(0));
-        position.set(Position.KEY_RSSI, parser.next());
+        position.set(Position.KEY_RSSI, parser.nextDouble());
 
         if (!newFormat) {
             position.set(Position.KEY_ODOMETER, UnitsConverter.metersFromMiles(parser.nextDouble(0)));

--- a/src/org/traccar/protocol/Xt013ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Xt013ProtocolDecoder.java
@@ -83,8 +83,8 @@ public class Xt013ProtocolDecoder extends BaseProtocolDecoder {
         position.setAltitude(parser.nextDouble(0));
         position.setValid(parser.next().equals("F"));
 
-        position.set(Position.KEY_GPS, parser.next());
-        position.set(Position.KEY_RSSI, parser.next());
+        position.set(Position.KEY_SATELLITES, parser.nextInt());
+        position.set(Position.KEY_RSSI, parser.nextDouble());
         position.set(Position.KEY_BATTERY, parser.nextDouble(0));
         position.set(Position.KEY_CHARGE, parser.next().equals("1"));
 

--- a/test/org/traccar/ProtocolTest.java
+++ b/test/org/traccar/ProtocolTest.java
@@ -196,6 +196,18 @@ public class ProtocolTest extends BaseTest {
             Assert.assertTrue(attributes.get(Position.KEY_PDOP) instanceof Number);
         }
 
+        if (attributes.containsKey(Position.KEY_SATELLITES)) {
+            Assert.assertTrue(attributes.get(Position.KEY_SATELLITES) instanceof Number);
+        }
+
+        if (attributes.containsKey(Position.KEY_SATELLITES_VISIBLE)) {
+            Assert.assertTrue(attributes.get(Position.KEY_SATELLITES_VISIBLE) instanceof Number);
+        }
+
+        if (attributes.containsKey(Position.KEY_RSSI)) {
+            Assert.assertTrue(attributes.get(Position.KEY_RSSI) instanceof Number);
+        }
+
         if (attributes.containsKey(Position.KEY_ODOMETER)) {
             Assert.assertTrue(attributes.get(Position.KEY_ODOMETER) instanceof Number);
         }


### PR DESCRIPTION
Next portion...

Satellites was most easier.
Supposed that RSSI is float dBm value or 0..31 signal strength.

V680 is not RSSI at all, it can contain lbs data

As for Megastek... checked again documentation and fixed battery and power. Also according to documentation satellites can be only number, but some test cases has "0/3" or "0/8" values, I believe that it is used and visible number of satellites.

I checked `KEY_GPS` using for next changes and become upset. It used for very different data.
Frankly, it is very thankless work, organize attributes without documentation. I'm going to make a pause.
