### PR TITLE
Wondex upgrade and fix for a little missing thing

### DIFF
--- a/src/org/traccar/model/Command.java
+++ b/src/org/traccar/model/Command.java
@@ -47,8 +47,8 @@ public class Command extends Message {
     public static final String TYPE_FIRMWARE_UPDATE = "firmwareUpdate";
     public static final String TYPE_SET_CONNECTION = "setConnection";
     public static final String TYPE_SET_ODOMETER = "setOdometer";
-    public static final String TYPE_GET_GSMSTATUS = "getGsmstatus";
-    public static final String TYPE_GET_DEVICESTATUS = "getDevicestatus";
+    public static final String TYPE_GET_MODEM_STATUS = "getModemstatus";
+    public static final String TYPE_GET_DEVICE_STATUS = "getDevicestatus";
 
     public static final String TYPE_MODE_POWER_SAVING = "modePowerSaving";
     public static final String TYPE_MODE_DEEP_SLEEP = "modeDeepSleep";

--- a/src/org/traccar/model/Command.java
+++ b/src/org/traccar/model/Command.java
@@ -47,6 +47,8 @@ public class Command extends Message {
     public static final String TYPE_FIRMWARE_UPDATE = "firmwareUpdate";
     public static final String TYPE_SET_CONNECTION = "setConnection";
     public static final String TYPE_SET_ODOMETER = "setOdometer";
+    public static final String TYPE_GET_GSMSTATUS = "getGsmstatus";
+    public static final String TYPE_GET_DEVICESTATUS = "getDevicestatus";
 
     public static final String TYPE_MODE_POWER_SAVING = "modePowerSaving";
     public static final String TYPE_MODE_DEEP_SLEEP = "modeDeepSleep";

--- a/src/org/traccar/model/Command.java
+++ b/src/org/traccar/model/Command.java
@@ -47,8 +47,8 @@ public class Command extends Message {
     public static final String TYPE_FIRMWARE_UPDATE = "firmwareUpdate";
     public static final String TYPE_SET_CONNECTION = "setConnection";
     public static final String TYPE_SET_ODOMETER = "setOdometer";
-    public static final String TYPE_GET_MODEM_STATUS = "getModemstatus";
-    public static final String TYPE_GET_DEVICE_STATUS = "getDevicestatus";
+    public static final String TYPE_GET_MODEM_STATUS = "getModemStatus";
+    public static final String TYPE_GET_DEVICE_STATUS = "getDeviceStatus";
 
     public static final String TYPE_MODE_POWER_SAVING = "modePowerSaving";
     public static final String TYPE_MODE_DEEP_SLEEP = "modeDeepSleep";

--- a/src/org/traccar/protocol/WondexProtocol.java
+++ b/src/org/traccar/protocol/WondexProtocol.java
@@ -31,8 +31,8 @@ public class WondexProtocol extends BaseProtocol {
         super("wondex");
         setTextCommandEncoder(new WondexProtocolEncoder());
         setSupportedCommands(
-                Command.TYPE_GET_DEVICESTATUS,
-                Command.TYPE_GET_GSMSTATUS,
+                Command.TYPE_GET_DEVICE_STATUS,
+                Command.TYPE_GET_MODEM_STATUS,
                 Command.TYPE_REBOOT_DEVICE,
                 Command.TYPE_POSITION_SINGLE,
                 Command.TYPE_GET_VERSION,

--- a/src/org/traccar/protocol/WondexProtocol.java
+++ b/src/org/traccar/protocol/WondexProtocol.java
@@ -31,8 +31,11 @@ public class WondexProtocol extends BaseProtocol {
         super("wondex");
         setTextCommandEncoder(new WondexProtocolEncoder());
         setSupportedCommands(
+                Command.TYPE_GET_DEVICESTATUS,
+                Command.TYPE_GET_GSMSTATUS,
                 Command.TYPE_REBOOT_DEVICE,
                 Command.TYPE_POSITION_SINGLE,
+                Command.TYPE_GET_VERSION,
                 Command.TYPE_IDENTIFICATION);
     }
 

--- a/src/org/traccar/protocol/WondexProtocolDecoder.java
+++ b/src/org/traccar/protocol/WondexProtocolDecoder.java
@@ -69,7 +69,8 @@ public class WondexProtocolDecoder extends BaseProtocolDecoder {
 
             return null;
         } else if (buf.toString(StandardCharsets.US_ASCII).startsWith("$OK:")
-                || buf.toString(StandardCharsets.US_ASCII).startsWith("$ERR:")) {
+                || buf.toString(StandardCharsets.US_ASCII).startsWith("$ERR:")
+                  || buf.toString(StandardCharsets.US_ASCII).startsWith("$MSG:")) {
 
             DeviceSession deviceSession = getDeviceSession(channel, remoteAddress);
 

--- a/src/org/traccar/protocol/WondexProtocolEncoder.java
+++ b/src/org/traccar/protocol/WondexProtocolEncoder.java
@@ -28,9 +28,9 @@ public class WondexProtocolEncoder extends StringProtocolEncoder {
         switch (command.getType()) {
             case Command.TYPE_REBOOT_DEVICE:
                 return formatCommand(command, "$WP+REBOOT={%s}", Command.KEY_DEVICE_PASSWORD);
-            case Command.TYPE_GET_DEVICESTATUS:
+            case Command.TYPE_GET_DEVICE_STATUS:
                 return formatCommand(command, "$WP+TEST={%s}", Command.KEY_DEVICE_PASSWORD);
-            case Command.TYPE_GET_GSMSTATUS:
+            case Command.TYPE_GET_MODEM_STATUS:
                 return formatCommand(command, "$WP+GSMINFO={%s}", Command.KEY_DEVICE_PASSWORD);
             case Command.TYPE_IDENTIFICATION:
                 return formatCommand(command, "$WP+IMEI={%s}", Command.KEY_DEVICE_PASSWORD);

--- a/src/org/traccar/protocol/WondexProtocolEncoder.java
+++ b/src/org/traccar/protocol/WondexProtocolEncoder.java
@@ -28,9 +28,15 @@ public class WondexProtocolEncoder extends StringProtocolEncoder {
         switch (command.getType()) {
             case Command.TYPE_REBOOT_DEVICE:
                 return formatCommand(command, "$WP+REBOOT={%s}", Command.KEY_DEVICE_PASSWORD);
+            case Command.TYPE_GET_DEVICESTATUS:
+                return formatCommand(command, "$WP+TEST={%s}", Command.KEY_DEVICE_PASSWORD);
+            case Command.TYPE_GET_GSMSTATUS:
+                return formatCommand(command, "$WP+GSMINFO={%s}", Command.KEY_DEVICE_PASSWORD);
+            case Command.TYPE_IDENTIFICATION:
+                return formatCommand(command, "$WP+IMEI={%s}", Command.KEY_DEVICE_PASSWORD);
             case Command.TYPE_POSITION_SINGLE:
                 return formatCommand(command, "$WP+GETLOCATION={%s}", Command.KEY_DEVICE_PASSWORD);
-            case Command.TYPE_IDENTIFICATION:
+            case Command.TYPE_GET_VERSION:
                 return formatCommand(command, "$WP+VER={%s}", Command.KEY_DEVICE_PASSWORD);
             default:
                 Log.warning(new UnsupportedOperationException(command.getType()));


### PR DESCRIPTION
Didn't show $MSG messages from the tracker, example hex:
2017-06-02 21:43:43 DEBUG: [BEEC07FB: 5032 < 2.247.253.121] HEX: 244d53473a47534d494e464f3d6e65747a636c75622b2c33302c312c300d0a
-> $MSG:GSMINFO=netzclub+,30,1,0[13][10]

Identifaction was wrong, result from the Tracker was the Version; Version added and Identification corrected, added Battery Status and GSM Status, as also added in the command.java and wondexprotocol.java and in the webfile

Added gsmstatus and devicestatus commands for wondexprotocol