### PR TITLE
MaxError despite Valid mark

### DIFF
--- a/src/org/traccar/CoordinatesHandler.java
+++ b/src/org/traccar/CoordinatesHandler.java
@@ -43,7 +43,7 @@ public class CoordinatesHandler extends BaseDataHandler {
             double distance = DistanceCalculator.distance(
                     position.getLatitude(), position.getLongitude(), last.getLatitude(), last.getLongitude());
             boolean satisfiesMin = coordinatesMinError == 0 || distance > coordinatesMinError;
-            boolean satisfiesMax = coordinatesMaxError == 0 || distance < coordinatesMaxError || position.getValid();
+            boolean satisfiesMax = coordinatesMaxError == 0 || distance < coordinatesMaxError;
             if (!satisfiesMin || !satisfiesMax) {
                 position.setLatitude(last.getLatitude());
                 position.setLongitude(last.getLongitude());

--- a/src/org/traccar/protocol/WondexProtocolDecoder.java
+++ b/src/org/traccar/protocol/WondexProtocolDecoder.java
@@ -107,7 +107,12 @@ public class WondexProtocolDecoder extends BaseProtocolDecoder {
             position.setAltitude(parser.nextDouble(0));
 
             int satellites = parser.nextInt(0);
-            position.setValid(satellites >= 3);
+            
+            if (satellites <3 || latitude > 90 || longitude > 180) {
+                 position.setValid(false);
+            }
+            position.setValid(satellites >=3 && latitude < 91 && longitude < 181);
+            
             position.set(Position.KEY_SATELLITES, satellites);
 
             position.set(Position.KEY_EVENT, parser.next());


### PR DESCRIPTION
I get every day jumps over 4000km because the tracker sends valid mark despite it sends useless coordinates, I already set coordinatesMaxError, but now  I see this only works when the position is not valid, isn't it? So I think it would be better to have another way to see if its a tracker error or a tracker flown in a plane or so!? What do you think?