### PR TITLE
Fix managed devices enumerating

### DIFF
--- a/src/org/traccar/database/DeviceManager.java
+++ b/src/org/traccar/database/DeviceManager.java
@@ -190,7 +190,7 @@ public class DeviceManager implements IdentityManager {
     }
 
     public Collection<Device> getManagedDevices(long userId) throws SQLException {
-        Collection<Device> devices = new ArrayList<>();
+        Collection<Device> devices = new HashSet<>();
         devices.addAll(getDevices(userId));
         for (long managedUserId : Context.getPermissionsManager().getUserPermissions(userId)) {
             devices.addAll(getDevices(managedUserId));


### PR DESCRIPTION
Enumerate managed devices as `Set` to exclude duplicates

fix #3238 