### PR TITLE
New protocol decoder for OwnTracks

### DIFF
--- a/setup/default.xml
+++ b/setup/default.xml
@@ -575,5 +575,6 @@
     <entry key='gps056.port'>5141</entry>
     <entry key='flexcomm.port'>5142</entry>
     <entry key='vt200.port'>5143</entry>
+    <entry key='owntracks.port'>5144</entry>
 
 </properties>

--- a/src/org/traccar/protocol/OwnTracksProtocol.java
+++ b/src/org/traccar/protocol/OwnTracksProtocol.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Jan-Piet Mens (jpmens@gmail.com)
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.protocol;
+
+import org.jboss.netty.bootstrap.ServerBootstrap;
+import org.jboss.netty.channel.ChannelPipeline;
+import org.jboss.netty.handler.codec.http.HttpRequestDecoder;
+import org.jboss.netty.handler.codec.http.HttpResponseEncoder;
+import org.traccar.BaseProtocol;
+import org.traccar.TrackerServer;
+
+import java.util.List;
+
+public class OwnTracksProtocol extends BaseProtocol {
+
+    public OwnTracksProtocol() {
+        super("owntracks");
+    }
+
+    @Override
+    public void initTrackerServers(List<TrackerServer> serverList) {
+        serverList.add(new TrackerServer(new ServerBootstrap(), getName()) {
+            @Override
+            protected void addSpecificHandlers(ChannelPipeline pipeline) {
+                pipeline.addLast("httpEncoder", new HttpResponseEncoder());
+                pipeline.addLast("httpDecoder", new HttpRequestDecoder());
+                pipeline.addLast("objectDecoder", new OwnTracksProtocolDecoder(OwnTracksProtocol.this));
+            }
+        });
+    }
+
+}

--- a/src/org/traccar/protocol/OwnTracksProtocolDecoder.java
+++ b/src/org/traccar/protocol/OwnTracksProtocolDecoder.java
@@ -56,7 +56,7 @@ public class OwnTracksProtocolDecoder extends BaseProtocolDecoder {
 
         HttpRequest request = (HttpRequest) msg;
         JsonObject root = Json.createReader(
-                          new StringReader(request.getContent().toString(StandardCharsets.US_ASCII))).readObject();
+                new StringReader(request.getContent().toString(StandardCharsets.US_ASCII))).readObject();
 
         Position position = new Position();
         position.setProtocol(getProtocolName());

--- a/src/org/traccar/protocol/OwnTracksProtocolDecoder.java
+++ b/src/org/traccar/protocol/OwnTracksProtocolDecoder.java
@@ -83,6 +83,9 @@ public class OwnTracksProtocolDecoder extends BaseProtocolDecoder {
         if (root.containsKey("batt")) {
             position.set(Position.KEY_BATTERY, root.getInt("batt"));
         }
+        if (root.containsKey("topic")) {
+            position.set("topic", root.getString("topic"));
+        }
 
         long timestamp = root.getJsonNumber("tst").longValue();
         if (timestamp < Integer.MAX_VALUE) {

--- a/src/org/traccar/protocol/OwnTracksProtocolDecoder.java
+++ b/src/org/traccar/protocol/OwnTracksProtocolDecoder.java
@@ -56,7 +56,7 @@ public class OwnTracksProtocolDecoder extends BaseProtocolDecoder {
 
         HttpRequest request = (HttpRequest) msg;
         JsonObject root = Json.createReader(
-            new StringReader(request.getContent().toString(StandardCharsets.US_ASCII))).readObject();
+                          new StringReader(request.getContent().toString(StandardCharsets.US_ASCII))).readObject();
 
         Position position = new Position();
         position.setProtocol(getProtocolName());
@@ -66,22 +66,22 @@ public class OwnTracksProtocolDecoder extends BaseProtocolDecoder {
         position.setLongitude(root.getJsonNumber("lon").doubleValue());
 
         if (root.containsKey("vel")) {
-                position.setSpeed(UnitsConverter.knotsFromCps(root.getInt("vel")));
+            position.setSpeed(UnitsConverter.knotsFromCps(root.getInt("vel")));
         }
         if (root.containsKey("alt")) {
-                position.setAltitude(root.getInt("alt"));
+            position.setAltitude(root.getInt("alt"));
         }
         if (root.containsKey("cog")) {
-                position.setCourse(root.getInt("cog"));
+            position.setCourse(root.getInt("cog"));
         }
         if (root.containsKey("acc")) {
-                position.setAccuracy(root.getInt("acc"));
+            position.setAccuracy(root.getInt("acc"));
         }
         if (root.containsKey("t")) {
-                position.set("t", root.getString("t"));
+            position.set("t", root.getString("t"));
         }
         if (root.containsKey("batt")) {
-                position.set(Position.KEY_BATTERY, root.getInt("batt"));
+            position.set(Position.KEY_BATTERY, root.getInt("batt"));
         }
 
         long timestamp = root.getJsonNumber("tst").longValue();
@@ -92,8 +92,8 @@ public class OwnTracksProtocolDecoder extends BaseProtocolDecoder {
 
         DeviceSession deviceSession = getDeviceSession(channel, remoteAddress, root.getString("tid"));
         if (deviceSession == null) {
-                sendResponse(channel, HttpResponseStatus.BAD_REQUEST);
-                return null;
+            sendResponse(channel, HttpResponseStatus.BAD_REQUEST);
+            return null;
         }
         position.setDeviceId(deviceSession.getDeviceId());
 

--- a/src/org/traccar/protocol/OwnTracksProtocolDecoder.java
+++ b/src/org/traccar/protocol/OwnTracksProtocolDecoder.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017 Jan-Piet Mens (jpmens@gmail.com)
+ * Copyright 2013 - 2017 Anton Tananaev (anton@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.protocol;
+
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
+import org.jboss.netty.handler.codec.http.HttpHeaders;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponse;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.jboss.netty.handler.codec.http.HttpVersion;
+import org.traccar.BaseProtocolDecoder;
+import org.traccar.DeviceSession;
+import org.traccar.model.Position;
+import org.traccar.helper.UnitsConverter;
+
+import java.net.SocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import java.io.StringReader;
+import javax.json.Json;
+import javax.json.JsonObject;
+
+public class OwnTracksProtocolDecoder extends BaseProtocolDecoder {
+
+    public OwnTracksProtocolDecoder(OwnTracksProtocol protocol) {
+        super(protocol);
+    }
+
+    private void sendResponse(Channel channel, HttpResponseStatus status) {
+        if (channel != null) {
+            HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
+            response.headers().add(HttpHeaders.Names.CONTENT_LENGTH, 0);
+            channel.write(response);
+        }
+    }
+
+    @Override
+    protected Object decode(
+            Channel channel, SocketAddress remoteAddress, Object msg) throws Exception {
+
+        HttpRequest request = (HttpRequest) msg;
+        JsonObject root = Json.createReader(
+            new StringReader(request.getContent().toString(StandardCharsets.US_ASCII))).readObject();
+
+        Position position = new Position();
+        position.setProtocol(getProtocolName());
+        position.setValid(true);
+
+        position.setLatitude(root.getJsonNumber("lat").doubleValue());
+        position.setLongitude(root.getJsonNumber("lon").doubleValue());
+
+        if (root.containsKey("vel")) {
+                position.setSpeed(UnitsConverter.knotsFromCps(root.getInt("vel")));
+        }
+        if (root.containsKey("alt")) {
+                position.setAltitude(root.getInt("alt"));
+        }
+        if (root.containsKey("cog")) {
+                position.setCourse(root.getInt("cog"));
+        }
+        if (root.containsKey("acc")) {
+                position.setAccuracy(root.getInt("acc"));
+        }
+        if (root.containsKey("t")) {
+                position.set("t", root.getString("t"));
+        }
+        if (root.containsKey("batt")) {
+                position.set(Position.KEY_BATTERY, root.getInt("batt"));
+        }
+
+        long timestamp = root.getJsonNumber("tst").longValue();
+        if (timestamp < Integer.MAX_VALUE) {
+            timestamp *= 1000;
+        }
+        position.setTime(new Date(timestamp));
+
+        DeviceSession deviceSession = getDeviceSession(channel, remoteAddress, root.getString("tid"));
+        if (deviceSession == null) {
+                sendResponse(channel, HttpResponseStatus.BAD_REQUEST);
+                return null;
+        }
+        position.setDeviceId(deviceSession.getDeviceId());
+
+        sendResponse(channel, HttpResponseStatus.OK);
+        return position;
+    }
+}

--- a/test/org/traccar/protocol/OwnTracksProtocolDecoderTest.java
+++ b/test/org/traccar/protocol/OwnTracksProtocolDecoderTest.java
@@ -1,5 +1,6 @@
 package org.traccar.protocol;
 
+import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.junit.Test;
 import org.traccar.ProtocolTest;
 
@@ -10,16 +11,11 @@ public class OwnTracksProtocolDecoderTest extends ProtocolTest {
 
         OwnTracksProtocolDecoder decoder = new OwnTracksProtocolDecoder(new OwnTracksProtocol());
 
-/*
- * I don'w know how to get JSON into that ...
- *
-        verifyNull(decoder, request(
-                "{ \"id\" : \"hello\" }"));
+	verifyPosition(decoder, request(HttpMethod.POST, "/",
+	                buffer(text("{\"lon\":2.29513,\"lat\":48.85833,\"tst\":1497349316,\"_type\":\"location\",\"tid\":\"JJ\"}"))));
 
-        verifyPosition(decoder, request(
-                "{\"cog\":271,\"lon\":2.29513,\"acc\":5,\"vel\":61,\"vac\":21,\"lat\":48.85833,\"tst\":1497349316,\"alt\":167,\"_type\":\"location\",\"tid\":\"JJ\"}"));
-
-*/
+	verifyPosition(decoder, request(HttpMethod.POST, "/",
+	                buffer(text("{\"cog\":271,\"lon\":2.29513,\"acc\":5,\"vel\":61,\"vac\":21,\"lat\":48.85833,\"tst\":1497349316,\"alt\":167,\"_type\":\"location\",\"tid\":\"JJ\",\"t\":\"u\",\"batt\":67}"))));
 
     }
 

--- a/test/org/traccar/protocol/OwnTracksProtocolDecoderTest.java
+++ b/test/org/traccar/protocol/OwnTracksProtocolDecoderTest.java
@@ -1,0 +1,26 @@
+package org.traccar.protocol;
+
+import org.junit.Test;
+import org.traccar.ProtocolTest;
+
+public class OwnTracksProtocolDecoderTest extends ProtocolTest {
+
+    @Test
+    public void testDecode() throws Exception {
+
+        OwnTracksProtocolDecoder decoder = new OwnTracksProtocolDecoder(new OwnTracksProtocol());
+
+/*
+ * I don'w know how to get JSON into that ...
+ *
+        verifyNull(decoder, request(
+                "{ \"id\" : \"hello\" }"));
+
+        verifyPosition(decoder, request(
+                "{\"cog\":271,\"lon\":2.29513,\"acc\":5,\"vel\":61,\"vac\":21,\"lat\":48.85833,\"tst\":1497349316,\"alt\":167,\"_type\":\"location\",\"tid\":\"JJ\"}"));
+
+*/
+
+    }
+
+}

--- a/test/org/traccar/protocol/OwnTracksProtocolDecoderTest.java
+++ b/test/org/traccar/protocol/OwnTracksProtocolDecoderTest.java
@@ -11,11 +11,11 @@ public class OwnTracksProtocolDecoderTest extends ProtocolTest {
 
         OwnTracksProtocolDecoder decoder = new OwnTracksProtocolDecoder(new OwnTracksProtocol());
 
-	verifyPosition(decoder, request(HttpMethod.POST, "/",
-	                buffer(text("{\"lon\":2.29513,\"lat\":48.85833,\"tst\":1497349316,\"_type\":\"location\",\"tid\":\"JJ\"}"))));
+        verifyPosition(decoder, request(HttpMethod.POST, "/",
+                buffer(text("{\"lon\":2.29513,\"lat\":48.85833,\"tst\":1497349316,\"_type\":\"location\",\"tid\":\"JJ\"}"))));
 
-	verifyPosition(decoder, request(HttpMethod.POST, "/",
-	                buffer(text("{\"cog\":271,\"lon\":2.29513,\"acc\":5,\"vel\":61,\"vac\":21,\"lat\":48.85833,\"tst\":1497349316,\"alt\":167,\"_type\":\"location\",\"tid\":\"JJ\",\"t\":\"u\",\"batt\":67}"))));
+        verifyPosition(decoder, request(HttpMethod.POST, "/",
+                buffer(text("{\"cog\":271,\"lon\":2.29513,\"acc\":5,\"vel\":61,\"vac\":21,\"lat\":48.85833,\"tst\":1497349316,\"alt\":167,\"_type\":\"location\",\"tid\":\"JJ\",\"t\":\"u\",\"batt\":67}"))));
 
     }
 


### PR DESCRIPTION
This pull request implements a new protocol called `owntracks` which decodes JSON publishes by the [OwnTracks](http://owntracks.org) apps running on iOS or Android. These open source apps originally did MQTT (and still do of course), but a while ago we added HTTP POST which posts JSON payloads such as

```json
{"cog":271,"lon":2.29513,"acc":5,"vel":61,"vac":21,"lat":48.85833,"tst":1497350249,"alt":167,"_type":"location","tid":"JJ"}
```

Traccar's deviceId is gleaned from OwnTracks' `tid` (tracker ID) which is a 2-character code. The other elements ought to be self-explanatory and are all mapped onto appropriate Traccar parameters.

We (i.e. the OwnTracks team) hope this is a valuable contribution to the excellent Traccar project and would like to see this in Traccar to enhance interoperability.