### PR TITLE
Solidify OwnTracks protocol decoder

### DIFF
--- a/src/org/traccar/protocol/OwnTracksProtocolDecoder.java
+++ b/src/org/traccar/protocol/OwnTracksProtocolDecoder.java
@@ -94,15 +94,17 @@ public class OwnTracksProtocolDecoder extends BaseProtocolDecoder {
 
         position.setTime(new Date(root.getJsonNumber("tst").longValue() * 1000));
 
-        String uniqueId = "";
-        if (root.containsKey("tid")) {
-            uniqueId = root.getString("tid");
-        }
-        if (root.containsKey("topic")) {
+        Boolean haveTopic = root.containsKey("topic");
+        Boolean haveTid = root.containsKey("tid");
+        String uniqueId = null;
+
+        if (haveTopic) {
             uniqueId = root.getString("topic");
-            if (root.containsKey("tid")) {
+            if (haveTid) {
                 position.set("tid", root.getString("tid"));
             }
+        } else {
+            uniqueId = root.getString("tid");
         }
 
         DeviceSession deviceSession = getDeviceSession(channel, remoteAddress, uniqueId);
@@ -115,5 +117,4 @@ public class OwnTracksProtocolDecoder extends BaseProtocolDecoder {
         sendResponse(channel, HttpResponseStatus.OK);
         return position;
     }
-
 }

--- a/src/org/traccar/protocol/OwnTracksProtocolDecoder.java
+++ b/src/org/traccar/protocol/OwnTracksProtocolDecoder.java
@@ -58,6 +58,13 @@ public class OwnTracksProtocolDecoder extends BaseProtocolDecoder {
         JsonObject root = Json.createReader(
                 new StringReader(request.getContent().toString(StandardCharsets.US_ASCII))).readObject();
 
+        if (!root.containsKey("_type") || !root.getString("_type").equals("location")) {
+            sendResponse(channel, HttpResponseStatus.BAD_REQUEST);
+            return null;
+        }
+
+        long timestamp;
+        String deviceId = new String();
         Position position = new Position();
         position.setProtocol(getProtocolName());
         position.setValid(true);
@@ -80,16 +87,34 @@ public class OwnTracksProtocolDecoder extends BaseProtocolDecoder {
         if (root.containsKey("t")) {
             position.set("t", root.getString("t"));
         }
+        if (root.containsKey("p")) {
+            position.set("pb", root.getInt("p"));
+        }
         if (root.containsKey("batt")) {
             position.set(Position.KEY_BATTERY, root.getInt("batt"));
         }
+
+        if (root.containsKey("tst")) {
+            timestamp = root.getJsonNumber("tst").longValue();
+            if (timestamp < Integer.MAX_VALUE) {
+                timestamp *= 1000;
+            }
+        } else {
+            timestamp = new Date().getTime();
+        }
+        position.setTime(new Date(timestamp));
+
+        if (root.containsKey("tid")) {
+            deviceId = root.getString("tid");
+        }
         if (root.containsKey("topic")) {
-            position.set("topic", root.getString("topic"));
+            deviceId = root.getString("topic");
+            if (root.containsKey("tid")) {
+                position.set("tid", root.getString("tid"));
+            }
         }
 
-        position.setTime(new Date(root.getJsonNumber("tst").longValue() * 1000));
-
-        DeviceSession deviceSession = getDeviceSession(channel, remoteAddress, root.getString("tid"));
+        DeviceSession deviceSession = getDeviceSession(channel, remoteAddress, deviceId);
         if (deviceSession == null) {
             sendResponse(channel, HttpResponseStatus.BAD_REQUEST);
             return null;

--- a/src/org/traccar/protocol/OwnTracksProtocolDecoder.java
+++ b/src/org/traccar/protocol/OwnTracksProtocolDecoder.java
@@ -63,8 +63,6 @@ public class OwnTracksProtocolDecoder extends BaseProtocolDecoder {
             return null;
         }
 
-        long timestamp;
-        String deviceId = new String();
         Position position = new Position();
         position.setProtocol(getProtocolName());
         position.setValid(true);
@@ -94,27 +92,20 @@ public class OwnTracksProtocolDecoder extends BaseProtocolDecoder {
             position.set(Position.KEY_BATTERY, root.getInt("batt"));
         }
 
-        if (root.containsKey("tst")) {
-            timestamp = root.getJsonNumber("tst").longValue();
-            if (timestamp < Integer.MAX_VALUE) {
-                timestamp *= 1000;
-            }
-        } else {
-            timestamp = new Date().getTime();
-        }
-        position.setTime(new Date(timestamp));
+        position.setTime(new Date(root.getJsonNumber("tst").longValue() * 1000));
 
+        String uniqueId = "";
         if (root.containsKey("tid")) {
-            deviceId = root.getString("tid");
+            uniqueId = root.getString("tid");
         }
         if (root.containsKey("topic")) {
-            deviceId = root.getString("topic");
+            uniqueId = root.getString("topic");
             if (root.containsKey("tid")) {
                 position.set("tid", root.getString("tid"));
             }
         }
 
-        DeviceSession deviceSession = getDeviceSession(channel, remoteAddress, deviceId);
+        DeviceSession deviceSession = getDeviceSession(channel, remoteAddress, uniqueId);
         if (deviceSession == null) {
             sendResponse(channel, HttpResponseStatus.BAD_REQUEST);
             return null;

--- a/src/org/traccar/protocol/OwnTracksProtocolDecoder.java
+++ b/src/org/traccar/protocol/OwnTracksProtocolDecoder.java
@@ -91,13 +91,11 @@ public class OwnTracksProtocolDecoder extends BaseProtocolDecoder {
 
         position.setTime(new Date(root.getJsonNumber("tst").longValue() * 1000));
 
-        boolean haveTopic = root.containsKey("topic");
-        boolean haveTid = root.containsKey("tid");
         String uniqueId;
 
-        if (haveTopic) {
+        if (root.containsKey("topic")) {
             uniqueId = root.getString("topic");
-            if (haveTid) {
+            if (root.containsKey("tid")) {
                 position.set("tid", root.getString("tid"));
             }
         } else {

--- a/src/org/traccar/protocol/OwnTracksProtocolDecoder.java
+++ b/src/org/traccar/protocol/OwnTracksProtocolDecoder.java
@@ -85,18 +85,15 @@ public class OwnTracksProtocolDecoder extends BaseProtocolDecoder {
         if (root.containsKey("t")) {
             position.set("t", root.getString("t"));
         }
-        if (root.containsKey("p")) {
-            position.set("pb", root.getInt("p"));
-        }
         if (root.containsKey("batt")) {
             position.set(Position.KEY_BATTERY, root.getInt("batt"));
         }
 
         position.setTime(new Date(root.getJsonNumber("tst").longValue() * 1000));
 
-        Boolean haveTopic = root.containsKey("topic");
-        Boolean haveTid = root.containsKey("tid");
-        String uniqueId = null;
+        boolean haveTopic = root.containsKey("topic");
+        boolean haveTid = root.containsKey("tid");
+        String uniqueId;
 
         if (haveTopic) {
             uniqueId = root.getString("topic");

--- a/test/org/traccar/protocol/OwnTracksProtocolDecoderTest.java
+++ b/test/org/traccar/protocol/OwnTracksProtocolDecoderTest.java
@@ -18,7 +18,7 @@ public class OwnTracksProtocolDecoderTest extends ProtocolTest {
                 buffer("{\"cog\":271,\"lon\":2.29513,\"acc\":5,\"vel\":61,\"vac\":21,\"lat\":48.85833,\"tst\":1497349316,\"alt\":167,\"_type\":\"location\",\"tid\":\"JJ\",\"t\":\"u\",\"batt\":67}")));
 
         verifyPosition(decoder, request(HttpMethod.POST, "/",
-                buffer(text("{\"lat\":48.85,\"lon\":2.295,\"_type\":\"location\",\"tid\":\"JJ\"}"))));
+                buffer("{\"lat\":48.85,\"lon\":2.295,\"_type\":\"location\",\"tid\":\"JJ\",\"tst\":1497476456}")));
     }
 
 }

--- a/test/org/traccar/protocol/OwnTracksProtocolDecoderTest.java
+++ b/test/org/traccar/protocol/OwnTracksProtocolDecoderTest.java
@@ -17,6 +17,8 @@ public class OwnTracksProtocolDecoderTest extends ProtocolTest {
         verifyPosition(decoder, request(HttpMethod.POST, "/",
                 buffer("{\"cog\":271,\"lon\":2.29513,\"acc\":5,\"vel\":61,\"vac\":21,\"lat\":48.85833,\"tst\":1497349316,\"alt\":167,\"_type\":\"location\",\"tid\":\"JJ\",\"t\":\"u\",\"batt\":67}")));
 
+        verifyPosition(decoder, request(HttpMethod.POST, "/",
+                buffer(text("{\"lat\":48.85,\"lon\":2.295,\"_type\":\"location\",\"tid\":\"JJ\"}"))));
     }
 
 }


### PR DESCRIPTION
You kindly merged, the new [OwnTracks Protocol Decoder](https://github.com/tananaev/traccar/pull/3242), and this pull request attempts to address some things I omitted the first time around. In particular:

1. Ensures most attributes in [OwnTracks JSON](http://owntracks.org/booklet/tech/json/#_typelocation) are optional: only `lat`, `lon`, and `_type` are mandatory.
2. Checks for payloads of `"_type" : "location"` and uses only those. (OwnTracks has other payload types, e.g. "transition" which probably shouldn't be used in Traccar.)
3. Addresses an originally too simplistic method of creating a Traccar _deviceId_ using our _tracking ID_ (`tid`). Starting now, if the payload contains our `topic` (e.g. `owntracks/jpmens/iphone5s`) that will be used in preference to avoid collisions.
4. Adds another unit test.

I hope this is OK.


We're updating our documentation to [include Traccar](http://owntracks.org/booklet/features/traccar/), and that could be the landing for "device type OwnTracks" on your [https://www.traccar.org/devices/](https://www.traccar.org/devices/) page, for example. Just a thought.