### PR TITLE
Detect Trips and Stops by gaps in data

### DIFF
--- a/src/org/traccar/reports/ReportUtils.java
+++ b/src/org/traccar/reports/ReportUtils.java
@@ -133,7 +133,7 @@ public final class ReportUtils {
                 Context.getConfig().getLong("report.trip.minimalTripDistance", 500),
                 Context.getConfig().getLong("report.trip.minimalParkingDuration", 300) * 1000,
                 Context.getConfig().getBoolean("report.trip.greedyParking"),
-                Context.getConfig().getLong("report.trip.minimalNoDataDuration", 0) * 1000);
+                Context.getConfig().getLong("report.trip.minimalNoDataDuration", 3600) * 1000);
     }
 
     private static TripReport calculateTrip(

--- a/src/org/traccar/reports/ReportUtils.java
+++ b/src/org/traccar/reports/ReportUtils.java
@@ -132,7 +132,8 @@ public final class ReportUtils {
                 Context.getConfig().getLong("report.trip.minimalTripDuration", 300) * 1000,
                 Context.getConfig().getLong("report.trip.minimalTripDistance", 500),
                 Context.getConfig().getLong("report.trip.minimalParkingDuration", 300) * 1000,
-                Context.getConfig().getBoolean("report.trip.greedyParking"));
+                Context.getConfig().getBoolean("report.trip.greedyParking"),
+                Context.getConfig().getLong("report.trip.minimalNoDataDuration", 0) * 1000);
     }
 
     private static TripReport calculateTrip(
@@ -212,6 +213,16 @@ public final class ReportUtils {
 
     }
 
+    private static boolean isMoving(ArrayList<Position> positions, int index,
+            TripsConfig tripsConfig, double speedThreshold) {
+        if (tripsConfig.getMinimalNoDataDuration() > 0 && index < positions.size() - 1
+                && positions.get(index + 1).getFixTime().getTime() - positions.get(index).getFixTime().getTime()
+                >= tripsConfig.getMinimalNoDataDuration()) {
+            return false;
+        }
+        return positions.get(index).getSpeed() > speedThreshold;
+    }
+
     public static Collection<BaseReport> detectTripsAndStops(TripsConfig tripsConfig, boolean ignoreOdometer,
             double speedThreshold, Collection<Position> positionCollection, boolean trips) {
 
@@ -230,7 +241,7 @@ public final class ReportUtils {
             boolean tripFiltered = false;
 
             for (int i = 0; i < positions.size(); i++) {
-                isMoving = positions.get(i).getSpeed() > speedThreshold;
+                isMoving = isMoving(positions, i, tripsConfig, speedThreshold);
                 isLast = i == positions.size() - 1;
 
                 if ((isMoving || isLast) && startParkingIndex != -1) {

--- a/src/org/traccar/reports/model/TripsConfig.java
+++ b/src/org/traccar/reports/model/TripsConfig.java
@@ -22,11 +22,12 @@ public class TripsConfig {
     }
 
     public TripsConfig(double minimalTripDistance, long minimalTripDuration,
-            long minimalParkingDuration, boolean greedyParking) {
+            long minimalParkingDuration, boolean greedyParking, long minimalNoDataDuration) {
         this.minimalTripDistance = minimalTripDistance;
         this.minimalTripDuration = minimalTripDuration;
         this.minimalParkingDuration = minimalParkingDuration;
         this.greedyParking = greedyParking;
+        this.minimalNoDataDuration = minimalNoDataDuration;
     }
 
     private double minimalTripDistance;
@@ -68,4 +69,15 @@ public class TripsConfig {
     public void setGreedyParking(boolean greedyParking) {
         this.greedyParking = greedyParking;
     }
+
+    private long minimalNoDataDuration;
+
+    public long getMinimalNoDataDuration() {
+        return minimalNoDataDuration;
+    }
+
+    public void setMinimalNoDataDuration(long minimalNoDataDuration) {
+        this.minimalNoDataDuration = minimalNoDataDuration;
+    }
+
 }

--- a/test/org/traccar/reports/ReportUtilsTest.java
+++ b/test/org/traccar/reports/ReportUtilsTest.java
@@ -79,7 +79,7 @@ public class ReportUtilsTest extends BaseTest {
                 position("2016-01-01 00:06:00.000", 0, 3000),
                 position("2016-01-01 00:07:00.000", 0, 3000));
 
-        TripsConfig tripsConfig = new TripsConfig(500, 300000, 180000, false);
+        TripsConfig tripsConfig = new TripsConfig(500, 300000, 180000, false, 900000);
 
         Collection<? extends BaseReport> result = ReportUtils.detectTripsAndStops(tripsConfig, false, 0.01, data, true);
 
@@ -119,7 +119,7 @@ public class ReportUtilsTest extends BaseTest {
                 position("2016-01-01 00:04:00.000", 1, 0),
                 position("2016-01-01 00:05:00.000", 0, 0));
 
-        TripsConfig tripsConfig = new TripsConfig(500, 300000, 200000, false);
+        TripsConfig tripsConfig = new TripsConfig(500, 300000, 200000, false, 900000);
 
         Collection<? extends BaseReport> result = ReportUtils.detectTripsAndStops(tripsConfig, false, 0.01, data, false);
 
@@ -145,7 +145,7 @@ public class ReportUtilsTest extends BaseTest {
                 position("2016-01-01 00:04:00.000", 1, 0),
                 position("2016-01-01 00:05:00.000", 2, 0));
 
-        TripsConfig tripsConfig = new TripsConfig(500, 300000, 200000, false);
+        TripsConfig tripsConfig = new TripsConfig(500, 300000, 200000, false, 900000);
 
         Collection<? extends BaseReport> result = ReportUtils.detectTripsAndStops(tripsConfig, false, 0.01, data, false);
 
@@ -184,7 +184,7 @@ public class ReportUtilsTest extends BaseTest {
                 position("2016-01-01 00:04:00.000", 0, 0),
                 position("2016-01-01 00:05:00.000", 0, 0));
 
-        TripsConfig tripsConfig = new TripsConfig(500, 300000, 200000, false);
+        TripsConfig tripsConfig = new TripsConfig(500, 300000, 200000, false, 900000);
 
         Collection<? extends BaseReport> result = ReportUtils.detectTripsAndStops(tripsConfig, false, 0.01, data, false);
 
@@ -210,13 +210,54 @@ public class ReportUtilsTest extends BaseTest {
                 position("2016-01-01 00:04:00.000", 5, 0),
                 position("2016-01-01 00:05:00.000", 5, 0));
 
-        TripsConfig tripsConfig = new TripsConfig(500, 300000, 200000, false);
+        TripsConfig tripsConfig = new TripsConfig(500, 300000, 200000, false, 900000);
 
         Collection<? extends BaseReport> result = ReportUtils.detectTripsAndStops(tripsConfig, false, 0.01, data, false);
 
         assertNotNull(result);
         assertTrue(result.isEmpty());
 
+    }
+
+    @Test
+    public void testDetectTripAndStopByGap() throws ParseException {
+
+        Collection<Position> data = Arrays.asList(
+                position("2016-01-01 00:00:00.000", 7, 100),
+                position("2016-01-01 00:01:00.000", 7, 300),
+                position("2016-01-01 00:02:00.000", 5, 500),
+                position("2016-01-01 00:03:00.000", 5, 600),
+                position("2016-01-01 00:04:00.000", 3, 700),
+                position("2016-01-01 00:23:00.000", 2, 700),
+                position("2016-01-01 00:24:00.000", 5, 800),
+                position("2016-01-01 00:25:00.000", 5, 900));
+
+        TripsConfig tripsConfig = new TripsConfig(500, 200000, 200000, false, 900000);
+
+        Collection<? extends BaseReport> result = ReportUtils.detectTripsAndStops(tripsConfig, false, 0.01, data, true);
+
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+
+        TripReport itemTrip = (TripReport) result.iterator().next();
+
+        assertEquals(date("2016-01-01 00:00:00.000"), itemTrip.getStartTime());
+        assertEquals(date("2016-01-01 00:04:00.000"), itemTrip.getEndTime());
+        assertEquals(240000, itemTrip.getDuration());
+        assertEquals(6.75, itemTrip.getAverageSpeed(), 0.01);
+        assertEquals(7, itemTrip.getMaxSpeed(), 0.01);
+        assertEquals(600, itemTrip.getDistance(), 0.01);
+
+        result = ReportUtils.detectTripsAndStops(tripsConfig, false, 0.01, data, false);
+
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+
+        StopReport itemStop = (StopReport) result.iterator().next();
+
+        assertEquals(date("2016-01-01 00:04:00.000"), itemStop.getStartTime());
+        assertEquals(date("2016-01-01 00:23:00.000"), itemStop.getEndTime());
+        assertEquals(1140000, itemStop.getDuration());
     }
 
 }


### PR DESCRIPTION
Introduced `report.trip.minimalNoDataDuration` config parameter. It is 0 (disabled) by default.

Check time between current and "next" position if gap is more than config, then this is start of parking period.