### PR TITLE
Correctly ignore OwnTracks publishes of type != location

### DIFF
--- a/src/org/traccar/protocol/OwnTracksProtocolDecoder.java
+++ b/src/org/traccar/protocol/OwnTracksProtocolDecoder.java
@@ -59,7 +59,7 @@ public class OwnTracksProtocolDecoder extends BaseProtocolDecoder {
                 new StringReader(request.getContent().toString(StandardCharsets.US_ASCII))).readObject();
 
         if (!root.containsKey("_type") || !root.getString("_type").equals("location")) {
-            sendResponse(channel, HttpResponseStatus.BAD_REQUEST);
+            sendResponse(channel, HttpResponseStatus.OK);
             return null;
         }
 


### PR DESCRIPTION
OwnTracks apps can publish payloads with distinct `_type`s in the JSON payload, but Traccar should process only `_type: location`. However, if the apps publish, say, a `_type: transition` and Traccar returns 400, the app will continue to attempt delivery for ever.

This PR fixes that by having Traccar return HTTP status 200 to the apps, indicating "ok" but otherwise i gnoring that particular data.