### PR TITLE
Change type of 'spentFuel' to double

### DIFF
--- a/src/org/traccar/reports/ReportUtils.java
+++ b/src/org/traccar/reports/ReportUtils.java
@@ -89,16 +89,16 @@ public final class ReportUtils {
         return distance;
     }
 
-    public static String calculateFuel(Position firstPosition, Position lastPosition) {
+    public static double calculateFuel(Position firstPosition, Position lastPosition) {
 
         if (firstPosition.getAttributes().get(Position.KEY_FUEL_LEVEL) != null
                 && lastPosition.getAttributes().get(Position.KEY_FUEL_LEVEL) != null) {
 
             BigDecimal value = new BigDecimal(firstPosition.getDouble(Position.KEY_FUEL_LEVEL)
                     - lastPosition.getDouble(Position.KEY_FUEL_LEVEL));
-            return value.setScale(1, RoundingMode.HALF_EVEN).toString();
+            return value.setScale(1, RoundingMode.HALF_EVEN).doubleValue();
         }
-        return null;
+        return 0;
     }
 
     public static org.jxls.common.Context initializeContext(long userId) {

--- a/src/org/traccar/reports/model/BaseReport.java
+++ b/src/org/traccar/reports/model/BaseReport.java
@@ -74,13 +74,13 @@ public class BaseReport {
         }
     }
 
-    private String spentFuel;
+    private double spentFuel;
 
-    public String getSpentFuel() {
+    public double getSpentFuel() {
         return spentFuel;
     }
 
-    public void setSpentFuel(String spentFuel) {
+    public void setSpentFuel(double spentFuel) {
         this.spentFuel = spentFuel;
     }
 

--- a/test/org/traccar/reports/ReportUtilsTest.java
+++ b/test/org/traccar/reports/ReportUtilsTest.java
@@ -60,10 +60,10 @@ public class ReportUtilsTest extends BaseTest {
     public void testCalculateSpentFuel() {
         Position startPosition = new Position();
         Position endPosition = new Position();
-        Assert.assertNull(ReportUtils.calculateFuel(startPosition, endPosition));
+        Assert.assertEquals(ReportUtils.calculateFuel(startPosition, endPosition), 0.0, 0.01);
         startPosition.set(Position.KEY_FUEL_LEVEL, 0.7);
         endPosition.set(Position.KEY_FUEL_LEVEL, 0.5);
-        Assert.assertEquals(ReportUtils.calculateFuel(startPosition, endPosition), "0.2");
+        Assert.assertEquals(ReportUtils.calculateFuel(startPosition, endPosition), 0.2, 0.01);
     }
 
     @Test


### PR DESCRIPTION
If I'm not mistaken when reports was implemented we do not have standardized `KEY_FUEL_LEVEL` type and used string for reports. I thing it is time to make it correct.

Moreover there is warnings in logs when export reports for device without `KEY_FUEL_LEVEL` attribute.
````
INFO|27168/0|Service traccar|17-06-20 16:42:18|[qtp30275617-44] WARN org.apache.commons.jexl2.JexlEngine - org.jxls.expression.JexlExpressionEvaluator.evaluate@61![0,14]: 'trip.spentFuel;' inaccessible or unknown property trip
INFO|27168/0|Service traccar|17-06-20 16:42:18|[qtp30275617-44] WARN org.apache.commons.jexl2.JexlEngine - org.jxls.expression.JexlExpressionEvaluator.evaluate@61![0,14]: 'trip.spentFuel;' inaccessible or unknown property trip
INFO|27168/0|Service traccar|17-06-20 16:42:18|[qtp30275617-44] WARN org.apache.commons.jexl2.JexlEngine - org.jxls.expression.JexlExpressionEvaluator.evaluate@61![0,14]: 'trip.spentFuel;' inaccessible or unknown property trip
INFO|27168/0|Service traccar|17-06-20 16:42:18|[qtp30275617-44] WARN org.apache.commons.jexl2.JexlEngine - org.jxls.expression.JexlExpressionEvaluator.evaluate@61![0,14]: 'trip.spentFuel;' inaccessible or unknown property trip
INFO|27168/0|Service traccar|17-06-20 16:42:18|[qtp30275617-44] WARN org.apache.commons.jexl2.JexlEngine - org.jxls.expression.JexlExpressionEvaluator.evaluate@61![0,14]: 'trip.spentFuel;' inaccessible or unknown property trip
````