### PR TITLE
Osmand: Store 'batt' parameter as 'batteryLevel'

### DIFF
--- a/src/org/traccar/protocol/OsmAndProtocolDecoder.java
+++ b/src/org/traccar/protocol/OsmAndProtocolDecoder.java
@@ -126,7 +126,7 @@ public class OsmAndProtocolDecoder extends BaseProtocolDecoder {
                     position.set(Position.KEY_HDOP, Double.parseDouble(value));
                     break;
                 case "batt":
-                    position.set(Position.KEY_BATTERY, Double.parseDouble(value));
+                    position.set(Position.KEY_BATTERY_LEVEL, Double.parseDouble(value));
                     break;
                 default:
                     try {


### PR DESCRIPTION
fix #3274 