### PR TITLE
OwnTracks velocity is in km/h not cps

### DIFF
--- a/src/org/traccar/protocol/OwnTracksProtocolDecoder.java
+++ b/src/org/traccar/protocol/OwnTracksProtocolDecoder.java
@@ -71,7 +71,7 @@ public class OwnTracksProtocolDecoder extends BaseProtocolDecoder {
         position.setLongitude(root.getJsonNumber("lon").doubleValue());
 
         if (root.containsKey("vel")) {
-            position.setSpeed(UnitsConverter.knotsFromCps(root.getInt("vel")));
+            position.setSpeed(UnitsConverter.knotsFromKph(root.getInt("vel")));
         }
         if (root.containsKey("alt")) {
             position.setAltitude(root.getInt("alt"));


### PR DESCRIPTION
This pull request corrects an embarassing error. 