### PR TITLE
Map Device attributes to Computed Attributes

### DIFF
--- a/src/org/traccar/processing/ComputedAttributesHandler.java
+++ b/src/org/traccar/processing/ComputedAttributesHandler.java
@@ -31,19 +31,34 @@ import org.traccar.BaseDataHandler;
 import org.traccar.Context;
 import org.traccar.helper.Log;
 import org.traccar.model.Attribute;
+import org.traccar.model.Device;
 import org.traccar.model.Position;
 
 public class ComputedAttributesHandler extends BaseDataHandler {
 
     private JexlEngine engine;
 
+    private boolean mapDeviceAttributes;
+
     public ComputedAttributesHandler() {
         engine = new JexlEngine();
         engine.setStrict(true);
+        if (Context.getConfig() != null) {
+            mapDeviceAttributes = Context.getConfig().getBoolean(
+                    "processing.computedAttributes.mapDeviceAttributes.enable");
+        }
     }
 
     private MapContext prepareContext(Position position) {
         MapContext result = new MapContext();
+        if (mapDeviceAttributes) {
+            Device device = Context.getIdentityManager().getDeviceById(position.getDeviceId());
+            if (device != null) {
+                for (Object key : device.getAttributes().keySet()) {
+                    result.set((String) key, device.getAttributes().get(key));
+                }
+            }
+        }
         Set<Method> methods = new HashSet<>(Arrays.asList(position.getClass().getMethods()));
         methods.removeAll(Arrays.asList(Object.class.getMethods()));
         for (Method method : methods) {

--- a/src/org/traccar/processing/ComputedAttributesHandler.java
+++ b/src/org/traccar/processing/ComputedAttributesHandler.java
@@ -44,8 +44,7 @@ public class ComputedAttributesHandler extends BaseDataHandler {
         engine = new JexlEngine();
         engine.setStrict(true);
         if (Context.getConfig() != null) {
-            mapDeviceAttributes = Context.getConfig().getBoolean(
-                    "processing.computedAttributes.mapDeviceAttributes.enable");
+            mapDeviceAttributes = Context.getConfig().getBoolean("processing.computedAttributes.deviceAttributes");
         }
     }
 


### PR DESCRIPTION
Mapped attributes only and as is. If position has attributes with same names, they will replace device attributes.

fix #3347 
fix #3333 