### PR TITLE
[NEW] add GET with list of uniqueId to API

### DIFF
--- a/src/org/traccar/api/resource/DeviceResource.java
+++ b/src/org/traccar/api/resource/DeviceResource.java
@@ -45,30 +45,39 @@ public class DeviceResource extends BaseResource {
     @GET
     public Collection<Device> get(
             @QueryParam("all") boolean all, @QueryParam("userId") long userId,
+            @QueryParam("uniqueId") List<String> uniqueIds,
             @QueryParam("id") List<Long> deviceIds) throws SQLException {
-        if (deviceIds.isEmpty()) {
-            if (all) {
-                if (Context.getPermissionsManager().isAdmin(getUserId())) {
-                    return Context.getDeviceManager().getAllDevices();
-                } else {
-                    Context.getPermissionsManager().checkManager(getUserId());
-                    return Context.getDeviceManager().getManagedDevices(getUserId());
-                }
+        if (all) {
+            if (Context.getPermissionsManager().isAdmin(getUserId())) {
+                return Context.getDeviceManager().getAllDevices();
             } else {
-                if (userId == 0) {
-                    userId = getUserId();
-                }
-                Context.getPermissionsManager().checkUser(getUserId(), userId);
-                return Context.getDeviceManager().getDevices(userId);
+                Context.getPermissionsManager().checkManager(getUserId());
+                return Context.getDeviceManager().getManagedDevices(getUserId());
             }
-        } else {
-            ArrayList<Device> devices = new ArrayList<>();
+        }
+        if (uniqueIds.isEmpty() && deviceIds.isEmpty()) {
+            if (userId == 0) {
+                userId = getUserId();
+            }
+            Context.getPermissionsManager().checkUser(getUserId(), userId);
+            return Context.getDeviceManager().getDevices(userId);
+        }
+
+        ArrayList<Device> devices = new ArrayList<>();
+        if (!uniqueIds.isEmpty()) {
+            for (String uniqueId : uniqueIds) {
+                Device device = Context.getDeviceManager().getDeviceByUniqueId(uniqueId);
+                Context.getPermissionsManager().checkDevice(getUserId(), device.getId());
+                devices.add(device);
+            }
+        }
+        if (!deviceIds.isEmpty()) {
             for (Long deviceId : deviceIds) {
                 Context.getPermissionsManager().checkDevice(getUserId(), deviceId);
                 devices.add(Context.getDeviceManager().getDeviceById(deviceId));
             }
-            return devices;
         }
+        return devices;
     }
 
     @POST

--- a/src/org/traccar/api/resource/DeviceResource.java
+++ b/src/org/traccar/api/resource/DeviceResource.java
@@ -64,18 +64,15 @@ public class DeviceResource extends BaseResource {
         }
 
         ArrayList<Device> devices = new ArrayList<>();
-        if (!uniqueIds.isEmpty()) {
-            for (String uniqueId : uniqueIds) {
-                Device device = Context.getDeviceManager().getDeviceByUniqueId(uniqueId);
-                Context.getPermissionsManager().checkDevice(getUserId(), device.getId());
-                devices.add(device);
-            }
+
+        for (String uniqueId : uniqueIds) {
+            Device device = Context.getDeviceManager().getDeviceByUniqueId(uniqueId);
+            Context.getPermissionsManager().checkDevice(getUserId(), device.getId());
+            devices.add(device);
         }
-        if (!deviceIds.isEmpty()) {
-            for (Long deviceId : deviceIds) {
-                Context.getPermissionsManager().checkDevice(getUserId(), deviceId);
-                devices.add(Context.getDeviceManager().getDeviceById(deviceId));
-            }
+        for (Long deviceId : deviceIds) {
+            Context.getPermissionsManager().checkDevice(getUserId(), deviceId);
+            devices.add(Context.getDeviceManager().getDeviceById(deviceId));
         }
         return devices;
     }

--- a/swagger.json
+++ b/swagger.json
@@ -65,6 +65,14 @@
                         "required" : false,
                         "type" : "integer",
                         "collectionFormat" : "multi"
+                    },
+                    {
+                        "name" : "uniqueId",
+                        "in" : "query",
+                        "description" : "To fetch one or more devices. Multiple params can be passed like `uniqueId=333331&uniqieId=44442`",
+                        "required" : false,
+                        "type" : "string",
+                        "collectionFormat" : "multi"
                     }
                 ],
                 "responses": {


### PR DESCRIPTION
This pull request adds the possibility to GET a device with its `uniqueId`. Modelled after `Id`, we also accept a list of `uniqueId`. Basically, if `all` is false, we collect devices by `Id` and `uniqueId` and return those.

Hence, the following GET request is possible:

```
http://127.0.0.1:8082/api/devices?uniqueId=9876543210987654&id=11
```