### PR TITLE
Few managers optimizations

### DIFF
--- a/src/org/traccar/database/AttributesManager.java
+++ b/src/org/traccar/database/AttributesManager.java
@@ -16,8 +16,6 @@
  */
 package org.traccar.database;
 
-import java.sql.SQLException;
-
 import org.traccar.model.Attribute;
 import org.traccar.model.BaseModel;
 
@@ -25,14 +23,11 @@ public class AttributesManager extends ExtendedObjectManager {
 
     public AttributesManager(DataManager dataManager) {
         super(dataManager, Attribute.class);
-        refreshItems();
-        refreshExtendedPermissions();
     }
 
     @Override
-    public void updateItem(BaseModel item) throws SQLException {
+    public void updateCachedItem(BaseModel item) {
         Attribute attribute = (Attribute) item;
-        getDataManager().updateObject(attribute);
         Attribute cachedAttribute = (Attribute) getById(item.getId());
         cachedAttribute.setDescription(attribute.getDescription());
         cachedAttribute.setAttribute(attribute.getAttribute());

--- a/src/org/traccar/database/CalendarManager.java
+++ b/src/org/traccar/database/CalendarManager.java
@@ -22,7 +22,6 @@ public class CalendarManager extends SimpleObjectManager {
 
     public CalendarManager(DataManager dataManager) {
         super(dataManager, Calendar.class);
-        refreshItems();
     }
 
 }

--- a/src/org/traccar/database/DataManager.java
+++ b/src/org/traccar/database/DataManager.java
@@ -23,7 +23,6 @@ import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Date;
-import java.util.Map;
 
 import javax.naming.InitialContext;
 import javax.sql.DataSource;
@@ -41,6 +40,7 @@ import org.traccar.helper.Log;
 import org.traccar.model.AttributeAlias;
 import org.traccar.model.Device;
 import org.traccar.model.Event;
+import org.traccar.model.Permission;
 import org.traccar.model.BaseModel;
 import org.traccar.model.Position;
 import org.traccar.model.Server;
@@ -293,10 +293,10 @@ public class DataManager {
         return QueryBuilder.create(dataSource, getQuery(query)).executeQuery(clazz);
     }
 
-    public Collection<Map<String, Long>> getPermissions(Class<? extends BaseModel> owner,
-            Class<? extends BaseModel> property) throws SQLException {
+    public Collection<Permission> getPermissions(Class<? extends BaseModel> owner,
+            Class<? extends BaseModel> property) throws SQLException, ClassNotFoundException {
         String query = "database.select" + owner.getSimpleName() + property.getSimpleName() + "s";
-        return QueryBuilder.create(dataSource, getQuery(query)).executeMapQuery(Long.class);
+        return QueryBuilder.create(dataSource, getQuery(query)).executePermissionsQuery();
     }
 
     public void addObject(BaseModel entity) throws SQLException {

--- a/src/org/traccar/database/DeviceManager.java
+++ b/src/org/traccar/database/DeviceManager.java
@@ -306,7 +306,7 @@ public class DeviceManager implements IdentityManager {
             }
             for (Long cachedGroupId : groupsById.keySet()) {
                 if (!databaseGroupsIds.contains(cachedGroupId)) {
-                    devicesById.remove(cachedGroupId);
+                    groupsById.remove(cachedGroupId);
                 }
             }
             databaseGroupsIds.clear();

--- a/src/org/traccar/database/DriversManager.java
+++ b/src/org/traccar/database/DriversManager.java
@@ -54,7 +54,7 @@ public class DriversManager extends ExtendedObjectManager {
         Driver cachedDriver = (Driver) getById(driverId);
         if (cachedDriver != null) {
             String driverUniqueId = cachedDriver.getUniqueId();
-            removeCachedItem(driverId);
+            super.removeCachedItem(driverId);
             driversByUniqueId.remove(driverUniqueId);
         }
     }

--- a/src/org/traccar/database/DriversManager.java
+++ b/src/org/traccar/database/DriversManager.java
@@ -24,16 +24,23 @@ import org.traccar.model.BaseModel;
 
 public class DriversManager extends ExtendedObjectManager {
 
-    private final Map<String, Driver> driversByUniqueId = new ConcurrentHashMap<>();
+    private Map<String, Driver> driversByUniqueId;
 
     public DriversManager(DataManager dataManager) {
         super(dataManager, Driver.class);
     }
 
+    private void putUniqueDriverId(Driver driver) {
+        if (driversByUniqueId == null) {
+            driversByUniqueId = new ConcurrentHashMap<>();
+        }
+        driversByUniqueId.put(driver.getUniqueId(), driver);
+    }
+
     @Override
     protected void addNewItem(BaseModel item) {
         super.addNewItem(item);
-        driversByUniqueId.put(((Driver) item).getUniqueId(), (Driver) item);
+        putUniqueDriverId((Driver) item);
     }
 
     @Override
@@ -44,7 +51,7 @@ public class DriversManager extends ExtendedObjectManager {
         if (!driver.getUniqueId().equals(cachedDriver.getUniqueId())) {
             driversByUniqueId.remove(cachedDriver.getUniqueId());
             cachedDriver.setUniqueId(driver.getUniqueId());
-            driversByUniqueId.put(cachedDriver.getUniqueId(), cachedDriver);
+            putUniqueDriverId(cachedDriver);
         }
         cachedDriver.setAttributes(driver.getAttributes());
     }

--- a/src/org/traccar/database/DriversManager.java
+++ b/src/org/traccar/database/DriversManager.java
@@ -16,7 +16,6 @@
  */
 package org.traccar.database;
 
-import java.sql.SQLException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -32,8 +31,8 @@ public class DriversManager extends ExtendedObjectManager {
     }
 
     @Override
-    public void addItem(BaseModel item) throws SQLException {
-        super.addItem(item);
+    protected void addNewItem(BaseModel item) {
+        super.addNewItem(item);
         driversByUniqueId.put(((Driver) item).getUniqueId(), (Driver) item);
     }
 

--- a/src/org/traccar/database/ExtendedObjectManager.java
+++ b/src/org/traccar/database/ExtendedObjectManager.java
@@ -37,6 +37,7 @@ public abstract class ExtendedObjectManager extends SimpleObjectManager {
 
     protected ExtendedObjectManager(DataManager dataManager, Class<? extends BaseModel> baseClass) {
         super(dataManager, baseClass);
+        refreshExtendedPermissions();
     }
 
     public final Set<Long> getGroupItems(long groupId) {

--- a/src/org/traccar/database/ExtendedObjectManager.java
+++ b/src/org/traccar/database/ExtendedObjectManager.java
@@ -27,6 +27,7 @@ import org.traccar.Context;
 import org.traccar.helper.Log;
 import org.traccar.model.Device;
 import org.traccar.model.Group;
+import org.traccar.model.Permission;
 import org.traccar.model.BaseModel;
 
 public abstract class ExtendedObjectManager extends SimpleObjectManager {
@@ -79,27 +80,24 @@ public abstract class ExtendedObjectManager extends SimpleObjectManager {
         if (getDataManager() != null) {
             try {
 
-                Collection<Map<String, Long>> databaseGroupPermissions =
+                Collection<Permission> databaseGroupPermissions =
                         getDataManager().getPermissions(Group.class, getBaseClass());
 
                 clearGroupItems();
-                for (Map<String, Long> groupPermission : databaseGroupPermissions) {
-                    getGroupItems(groupPermission.get(DataManager.makeNameId(Group.class)))
-                            .add(groupPermission.get(getBaseClassIdName()));
+                for (Permission groupPermission : databaseGroupPermissions) {
+                    getGroupItems(groupPermission.getOwnerId()).add(groupPermission.getPropertyId());
                 }
 
-                Collection<Map<String, Long>> databaseDevicePermissions =
+                Collection<Permission> databaseDevicePermissions =
                         getDataManager().getPermissions(Device.class, getBaseClass());
                 Collection<Device> allDevices = Context.getDeviceManager().getAllDevices();
 
                 clearDeviceItems();
                 deviceItemsWithGroups.clear();
 
-                for (Map<String, Long> devicePermission : databaseDevicePermissions) {
-                    getDeviceItems(devicePermission.get(DataManager.makeNameId(Device.class)))
-                            .add(devicePermission.get(getBaseClassIdName()));
-                    getAllDeviceItems(devicePermission.get(DataManager.makeNameId(Device.class)))
-                            .add(devicePermission.get(getBaseClassIdName()));
+                for (Permission devicePermission : databaseDevicePermissions) {
+                    getDeviceItems(devicePermission.getOwnerId()).add(devicePermission.getPropertyId());
+                    getAllDeviceItems(devicePermission.getOwnerId()).add(devicePermission.getPropertyId());
                 }
 
                 for (Device device : allDevices) {
@@ -114,7 +112,7 @@ public abstract class ExtendedObjectManager extends SimpleObjectManager {
                     }
                 }
 
-            } catch (SQLException error) {
+            } catch (SQLException | ClassNotFoundException error) {
                 Log.warning(error);
             }
         }

--- a/src/org/traccar/database/GeofenceManager.java
+++ b/src/org/traccar/database/GeofenceManager.java
@@ -27,8 +27,6 @@ public class GeofenceManager extends ExtendedObjectManager {
 
     public GeofenceManager(DataManager dataManager) {
         super(dataManager, Geofence.class);
-        refreshItems();
-        refreshExtendedPermissions();
     }
 
     @Override

--- a/src/org/traccar/database/PermissionsManager.java
+++ b/src/org/traccar/database/PermissionsManager.java
@@ -115,11 +115,10 @@ public class PermissionsManager {
     public final void refreshUserPermissions() {
         userPermissions.clear();
         try {
-            for (Map<String, Long> permission : dataManager.getPermissions(User.class, User.class)) {
-                getUserPermissions(permission.get(DataManager.makeNameId(User.class)))
-                        .add(permission.get(DataManager.makeNameId(ManagedUser.class)));
+            for (Permission permission : dataManager.getPermissions(User.class, User.class)) {
+                getUserPermissions(permission.getOwnerId()).add(permission.getPropertyId());
             }
-        } catch (SQLException error) {
+        } catch (SQLException | ClassNotFoundException error) {
             Log.warning(error);
         }
     }
@@ -130,23 +129,20 @@ public class PermissionsManager {
         try {
             GroupTree groupTree = new GroupTree(Context.getDeviceManager().getAllGroups(),
                     Context.getDeviceManager().getAllDevices());
-            for (Map<String, Long> groupPermission : dataManager.getPermissions(User.class, Group.class)) {
-                Set<Long> userGroupPermissions = getGroupPermissions(groupPermission
-                        .get(DataManager.makeNameId(User.class)));
-                Set<Long> userDevicePermissions = getDevicePermissions(groupPermission
-                        .get(DataManager.makeNameId(User.class)));
-                userGroupPermissions.add(groupPermission.get(DataManager.makeNameId(Group.class)));
-                for (Group group : groupTree.getGroups(groupPermission.get(DataManager.makeNameId(Group.class)))) {
+            for (Permission groupPermission : dataManager.getPermissions(User.class, Group.class)) {
+                Set<Long> userGroupPermissions = getGroupPermissions(groupPermission.getOwnerId());
+                Set<Long> userDevicePermissions = getDevicePermissions(groupPermission.getOwnerId());
+                userGroupPermissions.add(groupPermission.getPropertyId());
+                for (Group group : groupTree.getGroups(groupPermission.getPropertyId())) {
                     userGroupPermissions.add(group.getId());
                 }
-                for (Device device : groupTree.getDevices(groupPermission.get(DataManager.makeNameId(Group.class)))) {
+                for (Device device : groupTree.getDevices(groupPermission.getPropertyId())) {
                     userDevicePermissions.add(device.getId());
                 }
             }
 
-            for (Map<String, Long> devicePermission : dataManager.getPermissions(User.class, Device.class)) {
-                getDevicePermissions(devicePermission.get(DataManager.makeNameId(User.class)))
-                        .add(devicePermission.get(DataManager.makeNameId(Device.class)));
+            for (Permission devicePermission : dataManager.getPermissions(User.class, Device.class)) {
+                getDevicePermissions(devicePermission.getOwnerId()).add(devicePermission.getPropertyId());
             }
 
             groupDevices.clear();
@@ -156,7 +152,7 @@ public class PermissionsManager {
                 }
             }
 
-        } catch (SQLException error) {
+        } catch (SQLException | ClassNotFoundException error) {
             Log.warning(error);
         }
 

--- a/src/org/traccar/database/QueryBuilder.java
+++ b/src/org/traccar/database/QueryBuilder.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.traccar.Context;
 import org.traccar.helper.Log;
 import org.traccar.model.MiscFormatter;
+import org.traccar.model.Permission;
 
 import javax.sql.DataSource;
 import java.io.IOException;
@@ -488,19 +489,19 @@ public final class QueryBuilder {
         return 0;
     }
 
-    public <T> Collection<Map<String, T>> executeMapQuery(Class<T> clazz) throws SQLException {
-        List<Map<String, T>> result = new LinkedList<>();
+    public Collection<Permission> executePermissionsQuery() throws SQLException, ClassNotFoundException {
+        List<Permission> result = new LinkedList<>();
         if (query != null) {
             try {
                 try (ResultSet resultSet = statement.executeQuery()) {
                     ResultSetMetaData resultMetaData = resultSet.getMetaData();
                     while (resultSet.next()) {
-                        LinkedHashMap<String, T> map = new LinkedHashMap<>();
+                        LinkedHashMap<String, Long> map = new LinkedHashMap<>();
                         for (int i = 1; i <= resultMetaData.getColumnCount(); i++) {
                             String label = resultMetaData.getColumnLabel(i);
-                            map.put(label, resultSet.getObject(label, clazz));
+                            map.put(label, resultSet.getLong(label));
                         }
-                        result.add(map);
+                        result.add(new Permission(map));
                     }
                 }
             } finally {

--- a/src/org/traccar/database/SimpleObjectManager.java
+++ b/src/org/traccar/database/SimpleObjectManager.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.traccar.Context;
 import org.traccar.helper.Log;
 import org.traccar.model.BaseModel;
+import org.traccar.model.Permission;
 import org.traccar.model.User;
 
 public abstract class SimpleObjectManager {
@@ -117,11 +118,10 @@ public abstract class SimpleObjectManager {
         if (dataManager != null) {
             try {
                 clearUserItems();
-                for (Map<String, Long> permission : dataManager.getPermissions(User.class, baseClass)) {
-                    getUserItems(permission.get(DataManager.makeNameId(User.class)))
-                            .add(permission.get(baseClassIdName));
+                for (Permission permission : dataManager.getPermissions(User.class, baseClass)) {
+                    getUserItems(permission.getOwnerId()).add(permission.getPropertyId());
                 }
-            } catch (SQLException error) {
+            } catch (SQLException | ClassNotFoundException error) {
                 Log.warning(error);
             }
         }

--- a/src/org/traccar/database/SimpleObjectManager.java
+++ b/src/org/traccar/database/SimpleObjectManager.java
@@ -99,7 +99,7 @@ public abstract class SimpleObjectManager {
                     if (items.containsKey(item.getId())) {
                         updateCachedItem(item);
                     } else {
-                        items.put(item.getId(), item);
+                        addNewItem(item);
                     }
                 }
                 for (Long cachedItemId : items.keySet()) {
@@ -127,9 +127,13 @@ public abstract class SimpleObjectManager {
         }
     }
 
+    protected void addNewItem(BaseModel item) {
+        items.put(item.getId(), item);
+    }
+
     public void addItem(BaseModel item) throws SQLException {
         dataManager.addObject(item);
-        items.put(item.getId(), item);
+        addNewItem(item);
     }
 
     protected void updateCachedItem(BaseModel item) {

--- a/src/org/traccar/database/SimpleObjectManager.java
+++ b/src/org/traccar/database/SimpleObjectManager.java
@@ -162,7 +162,7 @@ public abstract class SimpleObjectManager {
         return result;
     }
 
-    public Set<Long> getAllItems() {
+    public final Set<Long> getAllItems() {
         return items.keySet();
     }
 

--- a/src/org/traccar/database/SimpleObjectManager.java
+++ b/src/org/traccar/database/SimpleObjectManager.java
@@ -67,10 +67,6 @@ public abstract class SimpleObjectManager {
         items.clear();
     }
 
-    protected void removeCachedItem(long itemId) {
-        items.remove(itemId);
-    }
-
     public final Set<Long> getUserItems(long userId) {
         if (!userItems.containsKey(userId)) {
             userItems.put(userId, new HashSet<Long>());
@@ -104,7 +100,7 @@ public abstract class SimpleObjectManager {
                 }
                 for (Long cachedItemId : items.keySet()) {
                     if (!databaseItemIds.contains(cachedItemId)) {
-                        items.remove(cachedItemId);
+                        removeCachedItem(cachedItemId);
                     }
                 }
             } catch (SQLException error) {
@@ -143,6 +139,10 @@ public abstract class SimpleObjectManager {
     public void updateItem(BaseModel item) throws SQLException {
         dataManager.updateObject(item);
         updateCachedItem(item);
+    }
+
+    protected void removeCachedItem(long itemId) {
+        items.remove(itemId);
     }
 
     public void removeItem(long itemId) throws SQLException {


### PR DESCRIPTION
Polished few things:

- Items cache:
  - Reorganized cache update, now it is similar to how we do it for Devices and Groups (do not clear items map, but update every item)
  - Used "overridable" functions `addNewItem`/`updateCachedItem` for two purposed update cache and update items. By default it just `put` but might be used to track additional maps (like uniqueIds) or update item by fields.
  - It is not necessary to override whole functions `addItem`/`updateItem`/`removeItem` and especially `refreshItems` just put manager specific code in `addNewItem`/`updateCachedItem`/`removeCachedItem` if necessary
  - Spread refresh calls by appropriate constructors

- Used `Permission` class also for retrieving permissions from database
  - Do not think we will use common function `executeMapQuery` in near future, replace it to particular `executePermissionsQuery`
  - Updating permission cache now looks much much clear.

Also fixed small issue in group cache update.