### PR TITLE
Split Drivers and Groups management

### DIFF
--- a/src/org/traccar/BaseProtocolDecoder.java
+++ b/src/org/traccar/BaseProtocolDecoder.java
@@ -51,7 +51,7 @@ public abstract class BaseProtocolDecoder extends ExtendedObjectDecoder {
             Log.info("Automatically registered device " + uniqueId);
 
             if (defaultGroupId != 0) {
-                Context.getPermissionsManager().refreshPermissions();
+                Context.getPermissionsManager().refreshDeviceAndGroupPermissions();
                 Context.getPermissionsManager().refreshAllExtendedPermissions();
             }
 

--- a/src/org/traccar/BaseProtocolDecoder.java
+++ b/src/org/traccar/BaseProtocolDecoder.java
@@ -75,7 +75,7 @@ public abstract class BaseProtocolDecoder extends ExtendedObjectDecoder {
             try {
                 for (String uniqueId : uniqueIds) {
                     if (uniqueId != null) {
-                        Device device = Context.getIdentityManager().getDeviceByUniqueId(uniqueId);
+                        Device device = Context.getIdentityManager().getByUniqueId(uniqueId);
                         if (device != null) {
                             deviceId = device.getId();
                             break;

--- a/src/org/traccar/BaseProtocolDecoder.java
+++ b/src/org/traccar/BaseProtocolDecoder.java
@@ -46,7 +46,7 @@ public abstract class BaseProtocolDecoder extends ExtendedObjectDecoder {
         }
 
         try {
-            Context.getDeviceManager().addDevice(device);
+            Context.getDeviceManager().addItem(device);
 
             Log.info("Automatically registered device " + uniqueId);
 

--- a/src/org/traccar/BaseProtocolEncoder.java
+++ b/src/org/traccar/BaseProtocolEncoder.java
@@ -25,12 +25,12 @@ import org.traccar.model.Device;
 public abstract class BaseProtocolEncoder extends OneToOneEncoder {
 
     protected String getUniqueId(long deviceId) {
-        return Context.getIdentityManager().getDeviceById(deviceId).getUniqueId();
+        return Context.getIdentityManager().getById(deviceId).getUniqueId();
     }
 
     protected void initDevicePassword(Command command, String defaultPassword) {
         if (!command.getAttributes().containsKey(Command.KEY_DEVICE_PASSWORD)) {
-            Device device = Context.getIdentityManager().getDeviceById(command.getDeviceId());
+            Device device = Context.getIdentityManager().getById(command.getDeviceId());
             String password = device.getString(Command.KEY_DEVICE_PASSWORD);
             if (password != null) {
                 command.set(Command.KEY_DEVICE_PASSWORD, password);

--- a/src/org/traccar/Context.java
+++ b/src/org/traccar/Context.java
@@ -37,6 +37,7 @@ import org.traccar.database.MediaManager;
 import org.traccar.database.NotificationManager;
 import org.traccar.database.PermissionsManager;
 import org.traccar.database.GeofenceManager;
+import org.traccar.database.GroupsManager;
 import org.traccar.database.StatisticsManager;
 import org.traccar.database.UsersManager;
 import org.traccar.geocoder.BingMapsGeocoder;
@@ -103,6 +104,12 @@ public final class Context {
 
     public static UsersManager getUsersManager() {
         return usersManager;
+    }
+
+    private static GroupsManager groupsManager;
+
+    public static GroupsManager getGroupsManager() {
+        return groupsManager;
     }
 
     private static DeviceManager deviceManager;
@@ -241,9 +248,7 @@ public final class Context {
 
         if (dataManager != null) {
             usersManager = new UsersManager(dataManager);
-        }
-
-        if (dataManager != null) {
+            groupsManager = new GroupsManager(dataManager);
             deviceManager = new DeviceManager(dataManager);
         }
 

--- a/src/org/traccar/FilterHandler.java
+++ b/src/org/traccar/FilterHandler.java
@@ -184,7 +184,7 @@ public class FilterHandler extends BaseDataHandler {
             message.append("Position filtered by ");
             message.append(filterType.toString());
             message.append("filters from device: ");
-            message.append(Context.getIdentityManager().getDeviceById(position.getDeviceId()).getUniqueId());
+            message.append(Context.getIdentityManager().getById(position.getDeviceId()).getUniqueId());
             message.append(" with id: ");
             message.append(position.getDeviceId());
 

--- a/src/org/traccar/MainEventHandler.java
+++ b/src/org/traccar/MainEventHandler.java
@@ -55,7 +55,7 @@ public class MainEventHandler extends IdleStateAwareChannelHandler {
                 Log.warning(error);
             }
 
-            String uniqueId = Context.getIdentityManager().getDeviceById(position.getDeviceId()).getUniqueId();
+            String uniqueId = Context.getIdentityManager().getById(position.getDeviceId()).getUniqueId();
 
             // Log position
             StringBuilder s = new StringBuilder();

--- a/src/org/traccar/WebDataHandler.java
+++ b/src/org/traccar/WebDataHandler.java
@@ -75,7 +75,7 @@ public class WebDataHandler extends BaseDataHandler {
 
     public String formatRequest(Position position) {
 
-        Device device = Context.getIdentityManager().getDeviceById(position.getDeviceId());
+        Device device = Context.getIdentityManager().getById(position.getDeviceId());
 
         String request = url
                 .replace("{name}", device.getName())

--- a/src/org/traccar/api/resource/AttributeResource.java
+++ b/src/org/traccar/api/resource/AttributeResource.java
@@ -81,7 +81,7 @@ public class AttributeResource extends BaseResource {
             Context.getPermissionsManager().checkDevice(getUserId(), deviceId);
             result.retainAll(attributesManager.getDeviceItems(deviceId));
         }
-        return attributesManager.getItems(Attribute.class, result);
+        return attributesManager.getItems(result);
 
     }
 

--- a/src/org/traccar/api/resource/CalendarResource.java
+++ b/src/org/traccar/api/resource/CalendarResource.java
@@ -18,6 +18,7 @@ package org.traccar.api.resource;
 
 import java.sql.SQLException;
 import java.util.Collection;
+import java.util.Set;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -47,20 +48,22 @@ public class CalendarResource extends BaseResource {
             @QueryParam("all") boolean all, @QueryParam("userId") long userId) throws SQLException {
 
         CalendarManager calendarManager = Context.getCalendarManager();
+        Set<Long> result = null;
         if (all) {
             if (Context.getPermissionsManager().isAdmin(getUserId())) {
-                return calendarManager.getItems(Calendar.class, calendarManager.getAllItems());
+                result = calendarManager.getAllItems();
             } else {
                 Context.getPermissionsManager().checkManager(getUserId());
-                return calendarManager.getItems(Calendar.class, calendarManager.getManagedItems(getUserId()));
+                result = calendarManager.getManagedItems(getUserId());
             }
         } else {
             if (userId == 0) {
                 userId = getUserId();
             }
             Context.getPermissionsManager().checkUser(getUserId(), userId);
-            return calendarManager.getItems(Calendar.class, calendarManager.getUserItems(userId));
+            result = calendarManager.getUserItems(userId);
         }
+        return calendarManager.getItems(result);
     }
 
     @POST

--- a/src/org/traccar/api/resource/DeviceResource.java
+++ b/src/org/traccar/api/resource/DeviceResource.java
@@ -68,7 +68,7 @@ public class DeviceResource extends BaseResource {
         } else {
             result = new HashSet<Long>();
             for (String uniqueId : uniqueIds) {
-                Device device = deviceManager.getDeviceByUniqueId(uniqueId);
+                Device device = deviceManager.getByUniqueId(uniqueId);
                 Context.getPermissionsManager().checkDevice(getUserId(), device.getId());
                 result.add(device.getId());
             }
@@ -77,7 +77,7 @@ public class DeviceResource extends BaseResource {
                 result.add(deviceId);
             }
         }
-        return deviceManager.getItems(Device.class, result);
+        return deviceManager.getItems(result);
     }
 
     @POST

--- a/src/org/traccar/api/resource/DriverResource.java
+++ b/src/org/traccar/api/resource/DriverResource.java
@@ -79,7 +79,7 @@ public class DriverResource extends BaseResource {
             Context.getPermissionsManager().checkDevice(getUserId(), deviceId);
             result.retainAll(driversManager.getDeviceItems(deviceId));
         }
-        return driversManager.getItems(Driver.class, result);
+        return driversManager.getItems(result);
 
     }
 

--- a/src/org/traccar/api/resource/GeofenceResource.java
+++ b/src/org/traccar/api/resource/GeofenceResource.java
@@ -78,7 +78,7 @@ public class GeofenceResource extends BaseResource {
             Context.getPermissionsManager().checkDevice(getUserId(), deviceId);
             result.retainAll(geofenceManager.getDeviceItems(deviceId));
         }
-        return geofenceManager.getItems(Geofence.class, result);
+        return geofenceManager.getItems(result);
 
     }
 

--- a/src/org/traccar/api/resource/GroupResource.java
+++ b/src/org/traccar/api/resource/GroupResource.java
@@ -60,7 +60,7 @@ public class GroupResource extends BaseResource {
             Context.getPermissionsManager().checkUser(getUserId(), userId);
             result = groupsManager.getUserItems(userId);
         }
-        return groupsManager.getItems(Group.class, result);
+        return groupsManager.getItems(result);
     }
 
     @POST

--- a/src/org/traccar/api/resource/PositionResource.java
+++ b/src/org/traccar/api/resource/PositionResource.java
@@ -87,7 +87,7 @@ public class PositionResource extends BaseResource {
             @QueryParam("deviceId") long deviceId, @QueryParam("from") String from, @QueryParam("to") String to)
             throws SQLException {
         Context.getPermissionsManager().checkDevice(getUserId(), deviceId);
-        GpxBuilder gpx = new GpxBuilder(Context.getIdentityManager().getDeviceById(deviceId).getName());
+        GpxBuilder gpx = new GpxBuilder(Context.getIdentityManager().getById(deviceId).getName());
         gpx.addPositions(Context.getDataManager().getPositions(
                 deviceId, DateUtil.parseDate(from), DateUtil.parseDate(to)));
         return Response.ok(gpx.build()).header(HttpHeaders.CONTENT_DISPOSITION, CONTENT_DISPOSITION_VALUE_GPX).build();

--- a/src/org/traccar/api/resource/UserResource.java
+++ b/src/org/traccar/api/resource/UserResource.java
@@ -58,7 +58,7 @@ public class UserResource extends BaseResource {
         } else {
             throw new SecurityException("Admin or manager access required");
         }
-        return usersManager.getItems(User.class, result);
+        return usersManager.getItems(result);
     }
 
     @PermitAll

--- a/src/org/traccar/api/resource/UserResource.java
+++ b/src/org/traccar/api/resource/UserResource.java
@@ -49,13 +49,12 @@ public class UserResource extends BaseResource {
         Set<Long> result = null;
         if (Context.getPermissionsManager().isAdmin(getUserId())) {
             if (userId != 0) {
-                result = usersManager.getManagedItems(userId);
+                result = usersManager.getUserItems(userId);
             } else {
                 result = usersManager.getAllItems();
             }
         } else if (Context.getPermissionsManager().isManager(getUserId())) {
             result = usersManager.getManagedItems(getUserId());
-            result.add(getUserId());
         } else {
             throw new SecurityException("Admin or manager access required");
         }
@@ -110,12 +109,8 @@ public class UserResource extends BaseResource {
         Context.getPermissionsManager().checkReadonly(getUserId());
         Context.getPermissionsManager().checkUser(getUserId(), id);
         Context.getUsersManager().removeItem(id);
-        if (Context.getGeofenceManager() != null) {
-            Context.getGeofenceManager().refreshUserItems();
-        }
-        if (Context.getNotificationManager() != null) {
-            Context.getNotificationManager().refresh();
-        }
+        Context.getPermissionsManager().refreshDeviceAndGroupPermissions();
+        Context.getPermissionsManager().refreshAllUsersPermissions();
         return Response.noContent().build();
     }
 

--- a/src/org/traccar/database/AttributesManager.java
+++ b/src/org/traccar/database/AttributesManager.java
@@ -26,9 +26,14 @@ public class AttributesManager extends ExtendedObjectManager {
     }
 
     @Override
+    public Attribute getById(long calendarId) {
+        return (Attribute) super.getById(calendarId);
+    }
+
+    @Override
     public void updateCachedItem(BaseModel item) {
         Attribute attribute = (Attribute) item;
-        Attribute cachedAttribute = (Attribute) getById(item.getId());
+        Attribute cachedAttribute = getById(item.getId());
         cachedAttribute.setDescription(attribute.getDescription());
         cachedAttribute.setAttribute(attribute.getAttribute());
         cachedAttribute.setExpression(attribute.getExpression());

--- a/src/org/traccar/database/AttributesManager.java
+++ b/src/org/traccar/database/AttributesManager.java
@@ -17,23 +17,16 @@
 package org.traccar.database;
 
 import org.traccar.model.Attribute;
-import org.traccar.model.BaseModel;
 
-public class AttributesManager extends ExtendedObjectManager {
+public class AttributesManager extends ExtendedObjectManager<Attribute> {
 
     public AttributesManager(DataManager dataManager) {
         super(dataManager, Attribute.class);
     }
 
     @Override
-    public Attribute getById(long calendarId) {
-        return (Attribute) super.getById(calendarId);
-    }
-
-    @Override
-    public void updateCachedItem(BaseModel item) {
-        Attribute attribute = (Attribute) item;
-        Attribute cachedAttribute = getById(item.getId());
+    public void updateCachedItem(Attribute attribute) {
+        Attribute cachedAttribute = getById(attribute.getId());
         cachedAttribute.setDescription(attribute.getDescription());
         cachedAttribute.setAttribute(attribute.getAttribute());
         cachedAttribute.setExpression(attribute.getExpression());

--- a/src/org/traccar/database/BaseObjectManager.java
+++ b/src/org/traccar/database/BaseObjectManager.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.database;
+
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.traccar.helper.Log;
+import org.traccar.model.BaseModel;
+
+public class BaseObjectManager {
+
+    private final DataManager dataManager;
+
+    private Map<Long, BaseModel> items;
+    private Class<? extends BaseModel> baseClass;
+
+    protected BaseObjectManager(DataManager dataManager, Class<? extends BaseModel> baseClass) {
+        this.dataManager = dataManager;
+        this.baseClass = baseClass;
+        refreshItems();
+    }
+
+    protected final DataManager getDataManager() {
+        return dataManager;
+    }
+
+    protected final Class<? extends BaseModel> getBaseClass() {
+        return baseClass;
+    }
+
+    public final BaseModel getById(long itemId) {
+        return items.get(itemId);
+    }
+
+    public void refreshItems() {
+        if (dataManager != null) {
+            try {
+                Collection<? extends BaseModel> databaseItems = dataManager.getObjects(baseClass);
+                if (items == null) {
+                    items = new ConcurrentHashMap<>(databaseItems.size());
+                }
+                Set<Long> databaseItemIds = new HashSet<>();
+                for (BaseModel item : databaseItems) {
+                    databaseItemIds.add(item.getId());
+                    if (items.containsKey(item.getId())) {
+                        updateCachedItem(item);
+                    } else {
+                        addNewItem(item);
+                    }
+                }
+                for (Long cachedItemId : items.keySet()) {
+                    if (!databaseItemIds.contains(cachedItemId)) {
+                        removeCachedItem(cachedItemId);
+                    }
+                }
+            } catch (SQLException error) {
+                Log.warning(error);
+            }
+        }
+    }
+
+    protected void addNewItem(BaseModel item) {
+        items.put(item.getId(), item);
+    }
+
+    public void addItem(BaseModel item) throws SQLException {
+        dataManager.addObject(item);
+        addNewItem(item);
+    }
+
+    protected void updateCachedItem(BaseModel item) {
+        items.put(item.getId(), item);
+    }
+
+    public void updateItem(BaseModel item) throws SQLException {
+        dataManager.updateObject(item);
+        updateCachedItem(item);
+    }
+
+    protected void removeCachedItem(long itemId) {
+        items.remove(itemId);
+    }
+
+    public void removeItem(long itemId) throws SQLException {
+        BaseModel item = getById(itemId);
+        if (item != null) {
+            dataManager.removeObject(baseClass, itemId);
+            removeCachedItem(itemId);
+        }
+    }
+
+    public final <T> Collection<T> getItems(Class<T> clazz, Set<Long> itemIds) {
+        Collection<T> result = new LinkedList<>();
+        for (long itemId : itemIds) {
+            result.add((T) getById(itemId));
+        }
+        return result;
+    }
+
+    public Set<Long> getAllItems() {
+        return items.keySet();
+    }
+
+}

--- a/src/org/traccar/database/BaseObjectManager.java
+++ b/src/org/traccar/database/BaseObjectManager.java
@@ -27,14 +27,14 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.traccar.helper.Log;
 import org.traccar.model.BaseModel;
 
-public class BaseObjectManager {
+public class BaseObjectManager<T extends BaseModel> {
 
     private final DataManager dataManager;
 
-    private Map<Long, BaseModel> items;
-    private Class<? extends BaseModel> baseClass;
+    private Map<Long, T> items;
+    private Class<T> baseClass;
 
-    protected BaseObjectManager(DataManager dataManager, Class<? extends BaseModel> baseClass) {
+    protected BaseObjectManager(DataManager dataManager, Class<T> baseClass) {
         this.dataManager = dataManager;
         this.baseClass = baseClass;
         refreshItems();
@@ -44,23 +44,23 @@ public class BaseObjectManager {
         return dataManager;
     }
 
-    protected final Class<? extends BaseModel> getBaseClass() {
+    protected final Class<T> getBaseClass() {
         return baseClass;
     }
 
-    public BaseModel getById(long itemId) {
+    public T getById(long itemId) {
         return items.get(itemId);
     }
 
     public void refreshItems() {
         if (dataManager != null) {
             try {
-                Collection<? extends BaseModel> databaseItems = dataManager.getObjects(baseClass);
+                Collection<T> databaseItems = dataManager.getObjects(baseClass);
                 if (items == null) {
                     items = new ConcurrentHashMap<>(databaseItems.size());
                 }
                 Set<Long> databaseItemIds = new HashSet<>();
-                for (BaseModel item : databaseItems) {
+                for (T item : databaseItems) {
                     databaseItemIds.add(item.getId());
                     if (items.containsKey(item.getId())) {
                         updateCachedItem(item);
@@ -79,20 +79,20 @@ public class BaseObjectManager {
         }
     }
 
-    protected void addNewItem(BaseModel item) {
+    protected void addNewItem(T item) {
         items.put(item.getId(), item);
     }
 
-    public void addItem(BaseModel item) throws SQLException {
+    public void addItem(T item) throws SQLException {
         dataManager.addObject(item);
         addNewItem(item);
     }
 
-    protected void updateCachedItem(BaseModel item) {
+    protected void updateCachedItem(T item) {
         items.put(item.getId(), item);
     }
 
-    public void updateItem(BaseModel item) throws SQLException {
+    public void updateItem(T item) throws SQLException {
         dataManager.updateObject(item);
         updateCachedItem(item);
     }
@@ -109,10 +109,10 @@ public class BaseObjectManager {
         }
     }
 
-    public final <T> Collection<T> getItems(Class<T> clazz, Set<Long> itemIds) {
+    public final Collection<T> getItems(Set<Long> itemIds) {
         Collection<T> result = new LinkedList<>();
         for (long itemId : itemIds) {
-            result.add((T) getById(itemId));
+            result.add(getById(itemId));
         }
         return result;
     }

--- a/src/org/traccar/database/BaseObjectManager.java
+++ b/src/org/traccar/database/BaseObjectManager.java
@@ -48,7 +48,7 @@ public class BaseObjectManager {
         return baseClass;
     }
 
-    public final BaseModel getById(long itemId) {
+    public BaseModel getById(long itemId) {
         return items.get(itemId);
     }
 

--- a/src/org/traccar/database/CalendarManager.java
+++ b/src/org/traccar/database/CalendarManager.java
@@ -24,4 +24,9 @@ public class CalendarManager extends SimpleObjectManager {
         super(dataManager, Calendar.class);
     }
 
+    @Override
+    public Calendar getById(long calendarId) {
+        return (Calendar) super.getById(calendarId);
+    }
+
 }

--- a/src/org/traccar/database/CalendarManager.java
+++ b/src/org/traccar/database/CalendarManager.java
@@ -18,15 +18,10 @@ package org.traccar.database;
 
 import org.traccar.model.Calendar;
 
-public class CalendarManager extends SimpleObjectManager {
+public class CalendarManager extends SimpleObjectManager<Calendar> {
 
     public CalendarManager(DataManager dataManager) {
         super(dataManager, Calendar.class);
-    }
-
-    @Override
-    public Calendar getById(long calendarId) {
-        return (Calendar) super.getById(calendarId);
     }
 
 }

--- a/src/org/traccar/database/ConnectionManager.java
+++ b/src/org/traccar/database/ConnectionManager.java
@@ -70,7 +70,7 @@ public class ConnectionManager {
     }
 
     public void updateDevice(final long deviceId, String status, Date time) {
-        Device device = Context.getIdentityManager().getDeviceById(deviceId);
+        Device device = Context.getIdentityManager().getById(deviceId);
         if (device == null) {
             return;
         }

--- a/src/org/traccar/database/DeviceManager.java
+++ b/src/org/traccar/database/DeviceManager.java
@@ -143,8 +143,8 @@ public class DeviceManager extends BaseObjectManager implements IdentityManager,
 
     @Override
     protected void addNewItem(BaseModel item) {
-        Device device = (Device) item;
         super.addNewItem(item);
+        Device device = (Device) item;
         putUniqueDeviceId(device);
         if (device.getPhone() != null  && !device.getPhone().isEmpty()) {
             putPhone(device);
@@ -160,7 +160,7 @@ public class DeviceManager extends BaseObjectManager implements IdentityManager,
     @Override
     protected void updateCachedItem(BaseModel item) {
         Device device = (Device) item;
-        Device cachedDevice = (Device) getById(device.getId());
+        Device cachedDevice = getDeviceById(device.getId());
         cachedDevice.setName(device.getName());
         cachedDevice.setGroupId(device.getGroupId());
         cachedDevice.setCategory(device.getCategory());
@@ -182,7 +182,7 @@ public class DeviceManager extends BaseObjectManager implements IdentityManager,
 
     @Override
     protected void removeCachedItem(long deviceId) {
-        Device cachedDevice = (Device) getById(deviceId);
+        Device cachedDevice = getDeviceById(deviceId);
         if (cachedDevice != null) {
             String deviceUniqueId = cachedDevice.getUniqueId();
             String phone = cachedDevice.getPhone();
@@ -197,7 +197,7 @@ public class DeviceManager extends BaseObjectManager implements IdentityManager,
 
     public void updateDeviceStatus(Device device) throws SQLException {
         getDataManager().updateDeviceStatus(device);
-        Device cachedDevice = (Device) getById(device.getId());
+        Device cachedDevice = getDeviceById(device.getId());
         if (cachedDevice != null) {
             cachedDevice.setStatus(device.getStatus());
         }
@@ -226,7 +226,7 @@ public class DeviceManager extends BaseObjectManager implements IdentityManager,
 
             getDataManager().updateLatestPosition(position);
 
-            Device device = (Device) getById(position.getDeviceId());
+            Device device = getDeviceById(position.getDeviceId());
             if (device != null) {
                 device.setPositionId(position.getId());
             }
@@ -311,7 +311,7 @@ public class DeviceManager extends BaseObjectManager implements IdentityManager,
             if (result == null && lookupGroupsAttribute) {
                 long groupId = device.getGroupId();
                 while (groupId != 0) {
-                    Group group = (Group) Context.getGroupsManager().getById(groupId);
+                    Group group = Context.getGroupsManager().getById(groupId);
                     if (group != null) {
                         result = group.getString(attributeName);
                         if (result != null) {
@@ -352,7 +352,7 @@ public class DeviceManager extends BaseObjectManager implements IdentityManager,
             Position lastPosition = getLastPosition(deviceId);
             if (lastPosition != null) {
                 BaseProtocol protocol = Context.getServerManager().getProtocol(lastPosition.getProtocol());
-                protocol.sendTextCommand(((Device) getById(deviceId)).getPhone(), command);
+                protocol.sendTextCommand(getDeviceById(deviceId).getPhone(), command);
             } else if (command.getType().equals(Command.TYPE_CUSTOM)) {
                 Context.getSmppManager().sendMessageSync(((Device) getById(deviceId)).getPhone(),
                         command.getString(Command.KEY_DATA), true);

--- a/src/org/traccar/database/DriversManager.java
+++ b/src/org/traccar/database/DriversManager.java
@@ -20,37 +20,30 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.traccar.model.Driver;
-import org.traccar.model.BaseModel;
 
-public class DriversManager extends ExtendedObjectManager {
+public class DriversManager extends ExtendedObjectManager<Driver> {
 
-    private Map<String, Driver> driversByUniqueId;
+    private Map<String, Long> driversByUniqueId;
 
     public DriversManager(DataManager dataManager) {
         super(dataManager, Driver.class);
     }
 
-    @Override
-    public Driver getById(long driverId) {
-        return (Driver) super.getById(driverId);
-    }
-
     private void putUniqueDriverId(Driver driver) {
         if (driversByUniqueId == null) {
-            driversByUniqueId = new ConcurrentHashMap<>();
+            driversByUniqueId = new ConcurrentHashMap<>(getAllItems().size());
         }
-        driversByUniqueId.put(driver.getUniqueId(), driver);
+        driversByUniqueId.put(driver.getUniqueId(), driver.getId());
     }
 
     @Override
-    protected void addNewItem(BaseModel item) {
-        super.addNewItem(item);
-        putUniqueDriverId((Driver) item);
+    protected void addNewItem(Driver driver) {
+        super.addNewItem(driver);
+        putUniqueDriverId(driver);
     }
 
     @Override
-    protected void updateCachedItem(BaseModel item) {
-        Driver driver = (Driver) item;
+    protected void updateCachedItem(Driver driver) {
         Driver cachedDriver = getById(driver.getId());
         cachedDriver.setName(driver.getName());
         if (!driver.getUniqueId().equals(cachedDriver.getUniqueId())) {
@@ -72,6 +65,6 @@ public class DriversManager extends ExtendedObjectManager {
     }
 
     public Driver getDriverByUniqueId(String uniqueId) {
-        return driversByUniqueId.get(uniqueId);
+        return getById(driversByUniqueId.get(uniqueId));
     }
 }

--- a/src/org/traccar/database/DriversManager.java
+++ b/src/org/traccar/database/DriversManager.java
@@ -30,6 +30,11 @@ public class DriversManager extends ExtendedObjectManager {
         super(dataManager, Driver.class);
     }
 
+    @Override
+    public Driver getById(long driverId) {
+        return (Driver) super.getById(driverId);
+    }
+
     private void putUniqueDriverId(Driver driver) {
         if (driversByUniqueId == null) {
             driversByUniqueId = new ConcurrentHashMap<>();
@@ -46,7 +51,7 @@ public class DriversManager extends ExtendedObjectManager {
     @Override
     protected void updateCachedItem(BaseModel item) {
         Driver driver = (Driver) item;
-        Driver cachedDriver = (Driver) getById(driver.getId());
+        Driver cachedDriver = getById(driver.getId());
         cachedDriver.setName(driver.getName());
         if (!driver.getUniqueId().equals(cachedDriver.getUniqueId())) {
             driversByUniqueId.remove(cachedDriver.getUniqueId());
@@ -58,7 +63,7 @@ public class DriversManager extends ExtendedObjectManager {
 
     @Override
     protected void removeCachedItem(long driverId) {
-        Driver cachedDriver = (Driver) getById(driverId);
+        Driver cachedDriver = getById(driverId);
         if (cachedDriver != null) {
             String driverUniqueId = cachedDriver.getUniqueId();
             super.removeCachedItem(driverId);

--- a/src/org/traccar/database/ExtendedObjectManager.java
+++ b/src/org/traccar/database/ExtendedObjectManager.java
@@ -48,19 +48,11 @@ public abstract class ExtendedObjectManager extends SimpleObjectManager {
         return groupItems.get(groupId);
     }
 
-    protected final void clearGroupItems() {
-        groupItems.clear();
-    }
-
     public final Set<Long> getDeviceItems(long deviceId) {
         if (!deviceItems.containsKey(deviceId)) {
             deviceItems.put(deviceId, new HashSet<Long>());
         }
         return deviceItems.get(deviceId);
-    }
-
-    protected final void clearDeviceItems() {
-        deviceItems.clear();
     }
 
     public Set<Long> getAllDeviceItems(long deviceId) {
@@ -83,16 +75,15 @@ public abstract class ExtendedObjectManager extends SimpleObjectManager {
                 Collection<Permission> databaseGroupPermissions =
                         getDataManager().getPermissions(Group.class, getBaseClass());
 
-                clearGroupItems();
+                groupItems.clear();
                 for (Permission groupPermission : databaseGroupPermissions) {
                     getGroupItems(groupPermission.getOwnerId()).add(groupPermission.getPropertyId());
                 }
 
                 Collection<Permission> databaseDevicePermissions =
                         getDataManager().getPermissions(Device.class, getBaseClass());
-                Collection<Device> allDevices = Context.getDeviceManager().getAllDevices();
 
-                clearDeviceItems();
+                deviceItems.clear();
                 deviceItemsWithGroups.clear();
 
                 for (Permission devicePermission : databaseDevicePermissions) {
@@ -100,12 +91,13 @@ public abstract class ExtendedObjectManager extends SimpleObjectManager {
                     getAllDeviceItems(devicePermission.getOwnerId()).add(devicePermission.getPropertyId());
                 }
 
-                for (Device device : allDevices) {
+                for (Device device : Context.getDeviceManager().getAllDevices()) {
                     long groupId = device.getGroupId();
                     while (groupId != 0) {
                         getAllDeviceItems(device.getId()).addAll(getGroupItems(groupId));
-                        if (Context.getDeviceManager().getGroupById(groupId) != null) {
-                            groupId = Context.getDeviceManager().getGroupById(groupId).getGroupId();
+                        Group group = (Group) Context.getGroupsManager().getById(groupId);
+                        if (group != null) {
+                            groupId = group.getGroupId();
                         } else {
                             groupId = 0;
                         }

--- a/src/org/traccar/database/ExtendedObjectManager.java
+++ b/src/org/traccar/database/ExtendedObjectManager.java
@@ -30,13 +30,13 @@ import org.traccar.model.Group;
 import org.traccar.model.Permission;
 import org.traccar.model.BaseModel;
 
-public abstract class ExtendedObjectManager extends SimpleObjectManager {
+public abstract class ExtendedObjectManager<T extends BaseModel> extends SimpleObjectManager<T> {
 
     private final Map<Long, Set<Long>> deviceItems = new ConcurrentHashMap<>();
     private final Map<Long, Set<Long>> deviceItemsWithGroups = new ConcurrentHashMap<>();
     private final Map<Long, Set<Long>> groupItems = new ConcurrentHashMap<>();
 
-    protected ExtendedObjectManager(DataManager dataManager, Class<? extends BaseModel> baseClass) {
+    protected ExtendedObjectManager(DataManager dataManager, Class<T> baseClass) {
         super(dataManager, baseClass);
         refreshExtendedPermissions();
     }

--- a/src/org/traccar/database/GeofenceManager.java
+++ b/src/org/traccar/database/GeofenceManager.java
@@ -23,15 +23,10 @@ import org.traccar.model.Device;
 import org.traccar.model.Geofence;
 import org.traccar.model.Position;
 
-public class GeofenceManager extends ExtendedObjectManager {
+public class GeofenceManager extends ExtendedObjectManager<Geofence> {
 
     public GeofenceManager(DataManager dataManager) {
         super(dataManager, Geofence.class);
-    }
-
-    @Override
-    public Geofence getById(long geofenceId) {
-        return (Geofence) super.getById(geofenceId);
     }
 
     @Override

--- a/src/org/traccar/database/GeofenceManager.java
+++ b/src/org/traccar/database/GeofenceManager.java
@@ -30,6 +30,11 @@ public class GeofenceManager extends ExtendedObjectManager {
     }
 
     @Override
+    public Geofence getById(long geofenceId) {
+        return (Geofence) super.getById(geofenceId);
+    }
+
+    @Override
     public final void refreshExtendedPermissions() {
         super.refreshExtendedPermissions();
         recalculateDevicesGeofences();
@@ -38,7 +43,7 @@ public class GeofenceManager extends ExtendedObjectManager {
     public List<Long> getCurrentDeviceGeofences(Position position) {
         List<Long> result = new ArrayList<>();
         for (long geofenceId : getAllDeviceItems(position.getDeviceId())) {
-            Geofence geofence = (Geofence) getById(geofenceId);
+            Geofence geofence = getById(geofenceId);
             if (geofence != null && geofence.getGeometry()
                     .containsPoint(position.getLatitude(), position.getLongitude())) {
                 result.add(geofenceId);

--- a/src/org/traccar/database/GroupsManager.java
+++ b/src/org/traccar/database/GroupsManager.java
@@ -23,7 +23,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.traccar.Context;
 import org.traccar.helper.Log;
-import org.traccar.model.BaseModel;
 import org.traccar.model.Group;
 
 public class GroupsManager extends BaseObjectManager<Group> implements ManagableObjects {
@@ -37,14 +36,14 @@ public class GroupsManager extends BaseObjectManager<Group> implements Managable
                 DeviceManager.DEFAULT_REFRESH_DELAY) * 1000;
     }
 
-    private void checkGroupCycles(BaseModel group) {
+    private void checkGroupCycles(Group group) {
         Set<Long> groups = new HashSet<>();
         while (group != null) {
             if (groups.contains(group.getId())) {
                 throw new IllegalArgumentException("Cycle in group hierarchy");
             }
             groups.add(group.getId());
-            group = getById(((Group) group).getGroupId());
+            group = getById(group.getGroupId());
         }
     }
 

--- a/src/org/traccar/database/GroupsManager.java
+++ b/src/org/traccar/database/GroupsManager.java
@@ -26,7 +26,7 @@ import org.traccar.helper.Log;
 import org.traccar.model.BaseModel;
 import org.traccar.model.Group;
 
-public class GroupsManager extends BaseObjectManager implements ManagableObjects {
+public class GroupsManager extends BaseObjectManager<Group> implements ManagableObjects {
 
     private AtomicLong groupsLastUpdate = new AtomicLong();
     private final long dataRefreshDelay;
@@ -35,11 +35,6 @@ public class GroupsManager extends BaseObjectManager implements ManagableObjects
         super(dataManager, Group.class);
         dataRefreshDelay = Context.getConfig().getLong("database.refreshDelay",
                 DeviceManager.DEFAULT_REFRESH_DELAY) * 1000;
-    }
-
-    @Override
-    public Group getById(long groupId) {
-        return (Group) super.getById(groupId);
     }
 
     private void checkGroupCycles(BaseModel group) {
@@ -76,15 +71,15 @@ public class GroupsManager extends BaseObjectManager implements ManagableObjects
     }
 
     @Override
-    protected void addNewItem(BaseModel item) {
-        checkGroupCycles(item);
-        super.addNewItem(item);
+    protected void addNewItem(Group group) {
+        checkGroupCycles(group);
+        super.addNewItem(group);
     }
 
     @Override
-    protected void updateCachedItem(BaseModel item) {
-        checkGroupCycles(item);
-        super.updateCachedItem(item);
+    protected void updateCachedItem(Group group) {
+        checkGroupCycles(group);
+        super.updateCachedItem(group);
     }
 
     @Override

--- a/src/org/traccar/database/GroupsManager.java
+++ b/src/org/traccar/database/GroupsManager.java
@@ -37,6 +37,11 @@ public class GroupsManager extends BaseObjectManager implements ManagableObjects
                 DeviceManager.DEFAULT_REFRESH_DELAY) * 1000;
     }
 
+    @Override
+    public Group getById(long groupId) {
+        return (Group) super.getById(groupId);
+    }
+
     private void checkGroupCycles(BaseModel group) {
         Set<Long> groups = new HashSet<>();
         while (group != null) {

--- a/src/org/traccar/database/GroupsManager.java
+++ b/src/org/traccar/database/GroupsManager.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.database;
+
+import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.traccar.Context;
+import org.traccar.helper.Log;
+import org.traccar.model.BaseModel;
+import org.traccar.model.Group;
+
+public class GroupsManager extends BaseObjectManager implements ManagableObjects {
+
+    private AtomicLong groupsLastUpdate = new AtomicLong();
+    private final long dataRefreshDelay;
+
+    public GroupsManager(DataManager dataManager) {
+        super(dataManager, Group.class);
+        dataRefreshDelay = Context.getConfig().getLong("database.refreshDelay",
+                DeviceManager.DEFAULT_REFRESH_DELAY) * 1000;
+    }
+
+    private void checkGroupCycles(BaseModel group) {
+        Set<Long> groups = new HashSet<>();
+        while (group != null) {
+            if (groups.contains(group.getId())) {
+                throw new IllegalArgumentException("Cycle in group hierarchy");
+            }
+            groups.add(group.getId());
+            group = getById(((Group) group).getGroupId());
+        }
+    }
+
+    private void updateGroupCache(boolean force) throws SQLException {
+        long lastUpdate = groupsLastUpdate.get();
+        if ((force || System.currentTimeMillis() - lastUpdate > dataRefreshDelay)
+                && groupsLastUpdate.compareAndSet(lastUpdate, System.currentTimeMillis())) {
+            refreshItems();
+        }
+    }
+
+    @Override
+    public Set<Long> getAllItems() {
+        Set<Long> result = super.getAllItems();
+        if (result.isEmpty()) {
+            try {
+                updateGroupCache(true);
+            } catch (SQLException e) {
+                Log.warning(e);
+            }
+            result = super.getAllItems();
+        }
+        return result;
+    }
+
+    @Override
+    protected void addNewItem(BaseModel item) {
+        checkGroupCycles(item);
+        super.addNewItem(item);
+    }
+
+    @Override
+    protected void updateCachedItem(BaseModel item) {
+        checkGroupCycles(item);
+        super.updateCachedItem(item);
+    }
+
+    @Override
+    public Set<Long> getUserItems(long userId) {
+        if (Context.getPermissionsManager() != null) {
+            return Context.getPermissionsManager().getGroupPermissions(userId);
+        } else {
+            return new HashSet<>();
+        }
+    }
+
+    @Override
+    public Set<Long> getManagedItems(long userId) {
+        Set<Long> result = new HashSet<>();
+        result.addAll(getUserItems(userId));
+        for (long managedUserId : Context.getUsersManager().getUserItems(userId)) {
+            result.addAll(getUserItems(managedUserId));
+        }
+        return result;
+    }
+
+}

--- a/src/org/traccar/database/IdentityManager.java
+++ b/src/org/traccar/database/IdentityManager.java
@@ -20,9 +20,9 @@ import org.traccar.model.Position;
 
 public interface IdentityManager {
 
-    Device getDeviceById(long id);
+    Device getById(long id);
 
-    Device getDeviceByUniqueId(String uniqueId) throws Exception;
+    Device getByUniqueId(String uniqueId) throws Exception;
 
     Position getLastPosition(long deviceId);
 

--- a/src/org/traccar/database/ManagableObjects.java
+++ b/src/org/traccar/database/ManagableObjects.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.database;
+
+import java.util.Set;
+
+public interface ManagableObjects {
+
+    Set<Long> getUserItems(long userId);
+
+    Set<Long> getManagedItems(long userId);
+
+}

--- a/src/org/traccar/database/PermissionsManager.java
+++ b/src/org/traccar/database/PermissionsManager.java
@@ -51,7 +51,7 @@ public class PermissionsManager {
         this.dataManager = dataManager;
         this.usersManager = usersManager;
         refreshServer();
-        refreshPermissions();
+        refreshDeviceAndGroupPermissions();
     }
 
     public User getUser(long userId) {
@@ -94,11 +94,12 @@ public class PermissionsManager {
         }
     }
 
-    public final void refreshPermissions() {
+    public final void refreshDeviceAndGroupPermissions() {
         groupPermissions.clear();
         devicePermissions.clear();
         try {
-            GroupTree groupTree = new GroupTree(Context.getDeviceManager().getAllGroups(),
+            GroupTree groupTree = new GroupTree(Context.getGroupsManager().getItems(
+                    Group.class, Context.getGroupsManager().getAllItems()),
                     Context.getDeviceManager().getAllDevices());
             for (Permission groupPermission : dataManager.getPermissions(User.class, Group.class)) {
                 Set<Long> userGroupPermissions = getGroupPermissions(groupPermission.getOwnerId());
@@ -117,9 +118,9 @@ public class PermissionsManager {
             }
 
             groupDevices.clear();
-            for (Group group : Context.getDeviceManager().getAllGroups()) {
-                for (Device device : groupTree.getDevices(group.getId())) {
-                    getGroupDevices(group.getId()).add(device.getId());
+            for (long groupId : Context.getGroupsManager().getAllItems()) {
+                for (Device device : groupTree.getDevices(groupId)) {
+                    getGroupDevices(groupId).add(device.getId());
                 }
             }
 
@@ -159,14 +160,14 @@ public class PermissionsManager {
 
     public void checkManager(long userId, long managedUserId) throws SecurityException {
         checkManager(userId);
-        if (!usersManager.getManagedItems(userId).contains(managedUserId)) {
+        if (!usersManager.getUserItems(userId).contains(managedUserId)) {
             throw new SecurityException("User access denied");
         }
     }
 
     public void checkUserLimit(long userId) throws SecurityException {
         int userLimit = getUser(userId).getUserLimit();
-        if (userLimit != -1 && usersManager.getManagedItems(userId).size() >= userLimit) {
+        if (userLimit != -1 && usersManager.getUserItems(userId).size() >= userLimit) {
             throw new SecurityException("Manager user limit reached");
         }
     }
@@ -176,9 +177,9 @@ public class PermissionsManager {
         if (deviceLimit != -1) {
             int deviceCount = 0;
             if (isManager(userId)) {
-                deviceCount = Context.getDeviceManager().getManagedDevices(userId).size();
+                deviceCount = Context.getDeviceManager().getManagedItems(userId).size();
             } else {
-                deviceCount = getDevicePermissions(userId).size();
+                deviceCount = Context.getDeviceManager().getUserItems(userId).size();
             }
             if (deviceCount >= deviceLimit) {
                 throw new SecurityException("User device limit reached");
@@ -254,7 +255,7 @@ public class PermissionsManager {
     public void checkGroup(long userId, long groupId) throws SecurityException {
         if (!getGroupPermissions(userId).contains(groupId) && !isAdmin(userId)) {
             checkManager(userId);
-            for (long managedUserId : usersManager.getManagedItems(userId)) {
+            for (long managedUserId : usersManager.getUserItems(userId)) {
                 if (getGroupPermissions(managedUserId).contains(groupId)) {
                     return;
                 }
@@ -264,10 +265,10 @@ public class PermissionsManager {
     }
 
     public void checkDevice(long userId, long deviceId) throws SecurityException {
-        if (!getDevicePermissions(userId).contains(deviceId) && !isAdmin(userId)) {
+        if (!Context.getDeviceManager().getUserItems(userId).contains(deviceId) && !isAdmin(userId)) {
             checkManager(userId);
-            for (long managedUserId : usersManager.getManagedItems(userId)) {
-                if (getDevicePermissions(managedUserId).contains(deviceId)) {
+            for (long managedUserId : usersManager.getUserItems(userId)) {
+                if (Context.getDeviceManager().getUserItems(managedUserId).contains(deviceId)) {
                     return;
                 }
             }
@@ -314,6 +315,18 @@ public class PermissionsManager {
         }
     }
 
+    public void refreshAllUsersPermissions() {
+        if (Context.getGeofenceManager() != null) {
+            Context.getGeofenceManager().refreshUserItems();
+        }
+        Context.getCalendarManager().refreshUserItems();
+        Context.getDriversManager().refreshUserItems();
+        Context.getAttributesManager().refreshUserItems();
+        if (Context.getNotificationManager() != null) {
+            Context.getNotificationManager().refresh();
+        }
+    }
+
     public void refreshAllExtendedPermissions() {
         if (Context.getGeofenceManager() != null) {
             Context.getGeofenceManager().refreshExtendedPermissions();
@@ -326,7 +339,7 @@ public class PermissionsManager {
         if (permission.getOwnerClass().equals(User.class)) {
             if (permission.getPropertyClass().equals(Device.class)
                     || permission.getPropertyClass().equals(Group.class)) {
-                refreshPermissions();
+                refreshDeviceAndGroupPermissions();
                 refreshAllExtendedPermissions();
             } else if (permission.getPropertyClass().equals(ManagedUser.class)) {
                 usersManager.refreshUserItems();

--- a/src/org/traccar/database/PermissionsManager.java
+++ b/src/org/traccar/database/PermissionsManager.java
@@ -18,6 +18,7 @@ package org.traccar.database;
 import org.traccar.Context;
 import org.traccar.helper.Log;
 import org.traccar.model.Attribute;
+import org.traccar.model.BaseModel;
 import org.traccar.model.Calendar;
 import org.traccar.model.Device;
 import org.traccar.model.Driver;
@@ -99,7 +100,7 @@ public class PermissionsManager {
         devicePermissions.clear();
         try {
             GroupTree groupTree = new GroupTree(Context.getGroupsManager().getItems(
-                    Group.class, Context.getGroupsManager().getAllItems()),
+                    Context.getGroupsManager().getAllItems()),
                     Context.getDeviceManager().getAllDevices());
             for (Permission groupPermission : dataManager.getPermissions(User.class, Group.class)) {
                 Set<Long> userGroupPermissions = getGroupPermissions(groupPermission.getOwnerId());
@@ -284,7 +285,7 @@ public class PermissionsManager {
 
     public void checkPermission(Class<?> object, long userId, long objectId)
             throws SecurityException {
-        SimpleObjectManager manager = null;
+        SimpleObjectManager<? extends BaseModel> manager = null;
 
         if (object.equals(Device.class)) {
             checkDevice(userId, objectId);

--- a/src/org/traccar/database/SimpleObjectManager.java
+++ b/src/org/traccar/database/SimpleObjectManager.java
@@ -28,11 +28,12 @@ import org.traccar.model.BaseModel;
 import org.traccar.model.Permission;
 import org.traccar.model.User;
 
-public abstract class SimpleObjectManager extends BaseObjectManager implements ManagableObjects {
+public abstract class SimpleObjectManager<T extends BaseModel> extends BaseObjectManager<T>
+        implements ManagableObjects {
 
     private Map<Long, Set<Long>> userItems;
 
-    protected SimpleObjectManager(DataManager dataManager, Class<? extends BaseModel> baseClass) {
+    protected SimpleObjectManager(DataManager dataManager, Class<T> baseClass) {
         super(dataManager, baseClass);
     }
 

--- a/src/org/traccar/database/SimpleObjectManager.java
+++ b/src/org/traccar/database/SimpleObjectManager.java
@@ -17,9 +17,7 @@
 package org.traccar.database;
 
 import java.sql.SQLException;
-import java.util.Collection;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -30,43 +28,15 @@ import org.traccar.model.BaseModel;
 import org.traccar.model.Permission;
 import org.traccar.model.User;
 
-public abstract class SimpleObjectManager {
+public abstract class SimpleObjectManager extends BaseObjectManager implements ManagableObjects {
 
-    private final DataManager dataManager;
-
-    private Map<Long, BaseModel> items;
-    private final Map<Long, Set<Long>> userItems = new ConcurrentHashMap<>();
-
-    private Class<? extends BaseModel> baseClass;
-    private String baseClassIdName;
+    private Map<Long, Set<Long>> userItems;
 
     protected SimpleObjectManager(DataManager dataManager, Class<? extends BaseModel> baseClass) {
-        this.dataManager = dataManager;
-        this.baseClass = baseClass;
-        baseClassIdName = DataManager.makeNameId(baseClass);
-        refreshItems();
+        super(dataManager, baseClass);
     }
 
-    protected final DataManager getDataManager() {
-        return dataManager;
-    }
-
-    protected final Class<? extends BaseModel> getBaseClass() {
-        return baseClass;
-    }
-
-    protected final String getBaseClassIdName() {
-        return baseClassIdName;
-    }
-
-    public final BaseModel getById(long itemId) {
-        return items.get(itemId);
-    }
-
-    protected final void clearItems() {
-        items.clear();
-    }
-
+    @Override
     public final Set<Long> getUserItems(long userId) {
         if (!userItems.containsKey(userId)) {
             userItems.put(userId, new HashSet<Long>());
@@ -74,47 +44,35 @@ public abstract class SimpleObjectManager {
         return userItems.get(userId);
     }
 
-    protected final void clearUserItems() {
-        userItems.clear();
+    @Override
+    public Set<Long> getManagedItems(long userId) {
+        Set<Long> result = new HashSet<>();
+        result.addAll(getUserItems(userId));
+        for (long managedUserId : Context.getUsersManager().getUserItems(userId)) {
+            result.addAll(getUserItems(managedUserId));
+        }
+        return result;
     }
 
     public final boolean checkItemPermission(long userId, long itemId) {
         return getUserItems(userId).contains(itemId);
     }
 
+    @Override
     public void refreshItems() {
-        if (dataManager != null) {
-            try {
-                Collection<? extends BaseModel> databaseItems = dataManager.getObjects(baseClass);
-                if (items == null) {
-                    items = new ConcurrentHashMap<>(databaseItems.size());
-                }
-                Set<Long> databaseItemIds = new HashSet<>();
-                for (BaseModel item : databaseItems) {
-                    databaseItemIds.add(item.getId());
-                    if (items.containsKey(item.getId())) {
-                        updateCachedItem(item);
-                    } else {
-                        addNewItem(item);
-                    }
-                }
-                for (Long cachedItemId : items.keySet()) {
-                    if (!databaseItemIds.contains(cachedItemId)) {
-                        removeCachedItem(cachedItemId);
-                    }
-                }
-            } catch (SQLException error) {
-                Log.warning(error);
-            }
-        }
+        super.refreshItems();
         refreshUserItems();
     }
 
     public final void refreshUserItems() {
-        if (dataManager != null) {
+        if (getDataManager() != null) {
             try {
-                clearUserItems();
-                for (Permission permission : dataManager.getPermissions(User.class, baseClass)) {
+                if (userItems != null) {
+                    userItems.clear();
+                } else {
+                    userItems = new ConcurrentHashMap<>();
+                }
+                for (Permission permission : getDataManager().getPermissions(User.class, getBaseClass())) {
                     getUserItems(permission.getOwnerId()).add(permission.getPropertyId());
                 }
             } catch (SQLException | ClassNotFoundException error) {
@@ -123,56 +81,10 @@ public abstract class SimpleObjectManager {
         }
     }
 
-    protected void addNewItem(BaseModel item) {
-        items.put(item.getId(), item);
-    }
-
-    public void addItem(BaseModel item) throws SQLException {
-        dataManager.addObject(item);
-        addNewItem(item);
-    }
-
-    protected void updateCachedItem(BaseModel item) {
-        items.put(item.getId(), item);
-    }
-
-    public void updateItem(BaseModel item) throws SQLException {
-        dataManager.updateObject(item);
-        updateCachedItem(item);
-    }
-
-    protected void removeCachedItem(long itemId) {
-        items.remove(itemId);
-    }
-
+    @Override
     public void removeItem(long itemId) throws SQLException {
-        BaseModel item = getById(itemId);
-        if (item != null) {
-            dataManager.removeObject(baseClass, itemId);
-            removeCachedItem(itemId);
-        }
+        super.removeItem(itemId);
         refreshUserItems();
-    }
-
-    public final <T> Collection<T> getItems(Class<T> clazz, Set<Long> itemIds) {
-        Collection<T> result = new LinkedList<>();
-        for (long itemId : itemIds) {
-            result.add((T) getById(itemId));
-        }
-        return result;
-    }
-
-    public final Set<Long> getAllItems() {
-        return items.keySet();
-    }
-
-    public Set<Long> getManagedItems(long userId) {
-        Set<Long> result = new HashSet<>();
-        result.addAll(getUserItems(userId));
-        for (long managedUserId : Context.getUsersManager().getManagedItems(userId)) {
-            result.addAll(getUserItems(managedUserId));
-        }
-        return result;
     }
 
 }

--- a/src/org/traccar/database/UsersManager.java
+++ b/src/org/traccar/database/UsersManager.java
@@ -32,6 +32,11 @@ public class UsersManager extends SimpleObjectManager {
         super(dataManager, User.class);
     }
 
+    @Override
+    public User getById(long userId) {
+        return (User) super.getById(userId);
+    }
+
     private void putToken(User user) {
         if (usersTokens == null) {
             usersTokens = new ConcurrentHashMap<>();
@@ -50,7 +55,7 @@ public class UsersManager extends SimpleObjectManager {
     @Override
     protected void updateCachedItem(BaseModel item) {
         User user = (User) item;
-        User cachedUser = (User) getById(item.getId());
+        User cachedUser = getById(item.getId());
         super.updateCachedItem(item);
         if (user.getToken() != null) {
             usersTokens.put(user.getToken(), user.getId());
@@ -62,7 +67,7 @@ public class UsersManager extends SimpleObjectManager {
 
     @Override
     protected void removeCachedItem(long userId) {
-        User cachedUser = (User) getById(userId);
+        User cachedUser = getById(userId);
         if (cachedUser != null) {
             String userToken = cachedUser.getToken();
             super.removeCachedItem(userId);
@@ -81,7 +86,7 @@ public class UsersManager extends SimpleObjectManager {
     }
 
     public User getUserByToken(String token) {
-        return (User) getById(usersTokens.get(token));
+        return getById(usersTokens.get(token));
     }
 
 }

--- a/src/org/traccar/database/UsersManager.java
+++ b/src/org/traccar/database/UsersManager.java
@@ -16,6 +16,7 @@
  */
 package org.traccar.database;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -73,7 +74,10 @@ public class UsersManager extends SimpleObjectManager {
 
     @Override
     public Set<Long> getManagedItems(long userId) {
-        return getUserItems(userId);
+        Set<Long> result = new HashSet<>();
+        result.addAll(getUserItems(userId));
+        result.add(userId);
+        return result;
     }
 
     public User getUserByToken(String token) {

--- a/src/org/traccar/database/UsersManager.java
+++ b/src/org/traccar/database/UsersManager.java
@@ -21,20 +21,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.traccar.model.BaseModel;
 import org.traccar.model.User;
 
-public class UsersManager extends SimpleObjectManager {
+public class UsersManager extends SimpleObjectManager<User> {
 
     private Map<String, Long> usersTokens;
 
     public UsersManager(DataManager dataManager) {
         super(dataManager, User.class);
-    }
-
-    @Override
-    public User getById(long userId) {
-        return (User) super.getById(userId);
     }
 
     private void putToken(User user) {
@@ -47,16 +41,15 @@ public class UsersManager extends SimpleObjectManager {
     }
 
     @Override
-    protected void addNewItem(BaseModel item) {
-        super.addNewItem(item);
-        putToken((User) item);
+    protected void addNewItem(User user) {
+        super.addNewItem(user);
+        putToken(user);
     }
 
     @Override
-    protected void updateCachedItem(BaseModel item) {
-        User user = (User) item;
-        User cachedUser = getById(item.getId());
-        super.updateCachedItem(item);
+    protected void updateCachedItem(User user) {
+        User cachedUser = getById(user.getId());
+        super.updateCachedItem(user);
         if (user.getToken() != null) {
             usersTokens.put(user.getToken(), user.getId());
         }

--- a/src/org/traccar/events/FuelDropEventHandler.java
+++ b/src/org/traccar/events/FuelDropEventHandler.java
@@ -31,7 +31,7 @@ public class FuelDropEventHandler extends BaseEventHandler {
     @Override
     protected Collection<Event> analyzePosition(Position position) {
 
-        Device device = Context.getIdentityManager().getDeviceById(position.getDeviceId());
+        Device device = Context.getIdentityManager().getById(position.getDeviceId());
         if (device == null) {
             return null;
         }

--- a/src/org/traccar/events/GeofenceEventHandler.java
+++ b/src/org/traccar/events/GeofenceEventHandler.java
@@ -25,7 +25,6 @@ import org.traccar.database.GeofenceManager;
 import org.traccar.model.Calendar;
 import org.traccar.model.Device;
 import org.traccar.model.Event;
-import org.traccar.model.Geofence;
 import org.traccar.model.Position;
 
 public class GeofenceEventHandler extends BaseEventHandler {
@@ -38,7 +37,7 @@ public class GeofenceEventHandler extends BaseEventHandler {
 
     @Override
     protected Collection<Event> analyzePosition(Position position) {
-        Device device = Context.getIdentityManager().getDeviceById(position.getDeviceId());
+        Device device = Context.getIdentityManager().getById(position.getDeviceId());
         if (device == null) {
             return null;
         }
@@ -59,8 +58,8 @@ public class GeofenceEventHandler extends BaseEventHandler {
 
         Collection<Event> events = new ArrayList<>();
         for (long geofenceId : newGeofences) {
-            long calendarId = ((Geofence) geofenceManager.getById(geofenceId)).getCalendarId();
-            Calendar calendar = calendarId != 0 ? (Calendar) Context.getCalendarManager().getById(calendarId) : null;
+            long calendarId = geofenceManager.getById(geofenceId).getCalendarId();
+            Calendar calendar = calendarId != 0 ? Context.getCalendarManager().getById(calendarId) : null;
             if (calendar == null || calendar.checkMoment(position.getFixTime())) {
                 Event event = new Event(Event.TYPE_GEOFENCE_ENTER, position.getDeviceId(), position.getId());
                 event.setGeofenceId(geofenceId);
@@ -68,8 +67,8 @@ public class GeofenceEventHandler extends BaseEventHandler {
             }
         }
         for (long geofenceId : oldGeofences) {
-            long calendarId = ((Geofence) geofenceManager.getById(geofenceId)).getCalendarId();
-            Calendar calendar = calendarId != 0 ? (Calendar) Context.getCalendarManager().getById(calendarId) : null;
+            long calendarId = geofenceManager.getById(geofenceId).getCalendarId();
+            Calendar calendar = calendarId != 0 ? Context.getCalendarManager().getById(calendarId) : null;
             if (calendar == null || calendar.checkMoment(position.getFixTime())) {
                 Event event = new Event(Event.TYPE_GEOFENCE_EXIT, position.getDeviceId(), position.getId());
                 event.setGeofenceId(geofenceId);

--- a/src/org/traccar/events/IgnitionEventHandler.java
+++ b/src/org/traccar/events/IgnitionEventHandler.java
@@ -29,7 +29,7 @@ public class IgnitionEventHandler extends BaseEventHandler {
 
     @Override
     protected Collection<Event> analyzePosition(Position position) {
-        Device device = Context.getIdentityManager().getDeviceById(position.getDeviceId());
+        Device device = Context.getIdentityManager().getById(position.getDeviceId());
         if (device == null || !Context.getIdentityManager().isLatestPosition(position)) {
             return null;
         }

--- a/src/org/traccar/events/MaintenanceEventHandler.java
+++ b/src/org/traccar/events/MaintenanceEventHandler.java
@@ -32,7 +32,7 @@ public class MaintenanceEventHandler extends BaseEventHandler {
 
     @Override
     protected Collection<Event> analyzePosition(Position position) {
-        Device device = Context.getIdentityManager().getDeviceById(position.getDeviceId());
+        Device device = Context.getIdentityManager().getById(position.getDeviceId());
         if (device == null || !Context.getIdentityManager().isLatestPosition(position)) {
             return null;
         }

--- a/src/org/traccar/events/MotionEventHandler.java
+++ b/src/org/traccar/events/MotionEventHandler.java
@@ -29,7 +29,7 @@ public class MotionEventHandler extends BaseEventHandler {
     @Override
     protected Collection<Event> analyzePosition(Position position) {
 
-        Device device = Context.getIdentityManager().getDeviceById(position.getDeviceId());
+        Device device = Context.getIdentityManager().getById(position.getDeviceId());
         if (device == null) {
             return null;
         }

--- a/src/org/traccar/events/OverspeedEventHandler.java
+++ b/src/org/traccar/events/OverspeedEventHandler.java
@@ -37,7 +37,7 @@ public class OverspeedEventHandler extends BaseEventHandler {
     @Override
     protected Collection<Event> analyzePosition(Position position) {
 
-        Device device = Context.getIdentityManager().getDeviceById(position.getDeviceId());
+        Device device = Context.getIdentityManager().getById(position.getDeviceId());
         if (device == null) {
             return null;
         }

--- a/src/org/traccar/notification/EventForwarder.java
+++ b/src/org/traccar/notification/EventForwarder.java
@@ -69,7 +69,7 @@ public final class EventForwarder {
             data.put(KEY_POSITION, position);
         }
         if (event.getDeviceId() != 0) {
-            Device device = Context.getIdentityManager().getDeviceById(event.getDeviceId());
+            Device device = Context.getIdentityManager().getById(event.getDeviceId());
             if (device != null) {
                 data.put(KEY_DEVICE, device);
             }

--- a/src/org/traccar/notification/NotificationFormatter.java
+++ b/src/org/traccar/notification/NotificationFormatter.java
@@ -40,7 +40,7 @@ public final class NotificationFormatter {
 
     public static VelocityContext prepareContext(long userId, Event event, Position position) {
         User user = Context.getPermissionsManager().getUser(userId);
-        Device device = Context.getIdentityManager().getDeviceById(event.getDeviceId());
+        Device device = Context.getIdentityManager().getById(event.getDeviceId());
 
         VelocityContext velocityContext = new VelocityContext();
         velocityContext.put("user", user);

--- a/src/org/traccar/processing/ComputedAttributesHandler.java
+++ b/src/org/traccar/processing/ComputedAttributesHandler.java
@@ -51,7 +51,7 @@ public class ComputedAttributesHandler extends BaseDataHandler {
     private MapContext prepareContext(Position position) {
         MapContext result = new MapContext();
         if (mapDeviceAttributes) {
-            Device device = Context.getIdentityManager().getDeviceById(position.getDeviceId());
+            Device device = Context.getIdentityManager().getById(position.getDeviceId());
             if (device != null) {
                 for (Object key : device.getAttributes().keySet()) {
                     result.set((String) key, device.getAttributes().get(key));
@@ -86,7 +86,7 @@ public class ComputedAttributesHandler extends BaseDataHandler {
 
     @Override
     protected Position handlePosition(Position position) {
-        Collection<Attribute> attributes = Context.getAttributesManager().getItems(Attribute.class,
+        Collection<Attribute> attributes = Context.getAttributesManager().getItems(
                 Context.getAttributesManager().getAllDeviceItems(position.getDeviceId()));
         for (Attribute attribute : attributes) {
             if (attribute.getAttribute() != null) {

--- a/src/org/traccar/protocol/Gt06ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gt06ProtocolDecoder.java
@@ -555,7 +555,7 @@ public class Gt06ProtocolDecoder extends BaseProtocolDecoder {
             if (photo.writableBytes() > 0) {
                 sendPhotoRequest(channel, pictureId);
             } else {
-                Device device = Context.getDeviceManager().getDeviceById(deviceSession.getDeviceId());
+                Device device = Context.getDeviceManager().getById(deviceSession.getDeviceId());
                 Context.getMediaManager().writeFile(device.getUniqueId(), photo, "jpg");
                 photos.remove(pictureId);
             }

--- a/src/org/traccar/protocol/MeitrackProtocolDecoder.java
+++ b/src/org/traccar/protocol/MeitrackProtocolDecoder.java
@@ -160,7 +160,7 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
             }
         }
 
-        String deviceModel = Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getModel();
+        String deviceModel = Context.getIdentityManager().getById(deviceSession.getDeviceId()).getModel();
         if (deviceModel == null) {
             deviceModel = "";
         }
@@ -316,7 +316,7 @@ public class MeitrackProtocolDecoder extends BaseProtocolDecoder {
             case "D03":
                 if (channel != null) {
                     DeviceSession deviceSession = getDeviceSession(channel, remoteAddress);
-                    String imei = Context.getIdentityManager().getDeviceById(deviceSession.getDeviceId()).getUniqueId();
+                    String imei = Context.getIdentityManager().getById(deviceSession.getDeviceId()).getUniqueId();
                     channel.write("@@O46," + imei + ",D00,camera_picture.jpg,0*00\r\n");
                 }
                 return null;

--- a/src/org/traccar/reports/Events.java
+++ b/src/org/traccar/reports/Events.java
@@ -92,7 +92,7 @@ public final class Events {
             deviceEvents.setDeviceName(device.getName());
             sheetNames.add(WorkbookUtil.createSafeSheetName(deviceEvents.getDeviceName()));
             if (device.getGroupId() != 0) {
-                Group group = Context.getDeviceManager().getGroupById(device.getGroupId());
+                Group group = (Group) Context.getGroupsManager().getById(device.getGroupId());
                 if (group != null) {
                     deviceEvents.setGroupName(group.getName());
                 }

--- a/src/org/traccar/reports/Events.java
+++ b/src/org/traccar/reports/Events.java
@@ -88,7 +88,7 @@ public final class Events {
                 }
             }
             DeviceReport deviceEvents = new DeviceReport();
-            Device device = Context.getIdentityManager().getDeviceById(deviceId);
+            Device device = Context.getIdentityManager().getById(deviceId);
             deviceEvents.setDeviceName(device.getName());
             sheetNames.add(WorkbookUtil.createSafeSheetName(deviceEvents.getDeviceName()));
             if (device.getGroupId() != 0) {

--- a/src/org/traccar/reports/Events.java
+++ b/src/org/traccar/reports/Events.java
@@ -92,7 +92,7 @@ public final class Events {
             deviceEvents.setDeviceName(device.getName());
             sheetNames.add(WorkbookUtil.createSafeSheetName(deviceEvents.getDeviceName()));
             if (device.getGroupId() != 0) {
-                Group group = (Group) Context.getGroupsManager().getById(device.getGroupId());
+                Group group = Context.getGroupsManager().getById(device.getGroupId());
                 if (group != null) {
                     deviceEvents.setGroupName(group.getName());
                 }

--- a/src/org/traccar/reports/ReportUtils.java
+++ b/src/org/traccar/reports/ReportUtils.java
@@ -176,7 +176,7 @@ public final class ReportUtils {
         long tripDuration = endTrip.getFixTime().getTime() - startTrip.getFixTime().getTime();
         long deviceId = startTrip.getDeviceId();
         trip.setDeviceId(deviceId);
-        trip.setDeviceName(Context.getIdentityManager().getDeviceById(deviceId).getName());
+        trip.setDeviceName(Context.getIdentityManager().getById(deviceId).getName());
 
         trip.setStartPositionId(startTrip.getId());
         trip.setStartLat(startTrip.getLatitude());
@@ -210,7 +210,7 @@ public final class ReportUtils {
 
         long deviceId = startStop.getDeviceId();
         stop.setDeviceId(deviceId);
-        stop.setDeviceName(Context.getIdentityManager().getDeviceById(deviceId).getName());
+        stop.setDeviceName(Context.getIdentityManager().getById(deviceId).getName());
 
         stop.setPositionId(startStop.getId());
         stop.setLatitude(startStop.getLatitude());

--- a/src/org/traccar/reports/Route.java
+++ b/src/org/traccar/reports/Route.java
@@ -57,7 +57,7 @@ public final class Route {
             Collection<Position> positions = Context.getDataManager()
                     .getPositions(deviceId, from, to);
             DeviceReport deviceRoutes = new DeviceReport();
-            Device device = Context.getIdentityManager().getDeviceById(deviceId);
+            Device device = Context.getIdentityManager().getById(deviceId);
             deviceRoutes.setDeviceName(device.getName());
             sheetNames.add(WorkbookUtil.createSafeSheetName(deviceRoutes.getDeviceName()));
             if (device.getGroupId() != 0) {

--- a/src/org/traccar/reports/Route.java
+++ b/src/org/traccar/reports/Route.java
@@ -61,7 +61,7 @@ public final class Route {
             deviceRoutes.setDeviceName(device.getName());
             sheetNames.add(WorkbookUtil.createSafeSheetName(deviceRoutes.getDeviceName()));
             if (device.getGroupId() != 0) {
-                Group group = (Group) Context.getGroupsManager().getById(device.getGroupId());
+                Group group = Context.getGroupsManager().getById(device.getGroupId());
                 if (group != null) {
                     deviceRoutes.setGroupName(group.getName());
                 }

--- a/src/org/traccar/reports/Route.java
+++ b/src/org/traccar/reports/Route.java
@@ -61,7 +61,7 @@ public final class Route {
             deviceRoutes.setDeviceName(device.getName());
             sheetNames.add(WorkbookUtil.createSafeSheetName(deviceRoutes.getDeviceName()));
             if (device.getGroupId() != 0) {
-                Group group = Context.getDeviceManager().getGroupById(device.getGroupId());
+                Group group = (Group) Context.getGroupsManager().getById(device.getGroupId());
                 if (group != null) {
                     deviceRoutes.setGroupName(group.getName());
                 }

--- a/src/org/traccar/reports/Stops.java
+++ b/src/org/traccar/reports/Stops.java
@@ -78,7 +78,7 @@ public final class Stops {
             deviceStops.setDeviceName(device.getName());
             sheetNames.add(WorkbookUtil.createSafeSheetName(deviceStops.getDeviceName()));
             if (device.getGroupId() != 0) {
-                Group group = (Group) Context.getGroupsManager().getById(device.getGroupId());
+                Group group = Context.getGroupsManager().getById(device.getGroupId());
                 if (group != null) {
                     deviceStops.setGroupName(group.getName());
                 }

--- a/src/org/traccar/reports/Stops.java
+++ b/src/org/traccar/reports/Stops.java
@@ -74,7 +74,7 @@ public final class Stops {
             Context.getPermissionsManager().checkDevice(userId, deviceId);
             Collection<StopReport> stops = detectStops(deviceId, from, to);
             DeviceReport deviceStops = new DeviceReport();
-            Device device = Context.getIdentityManager().getDeviceById(deviceId);
+            Device device = Context.getIdentityManager().getById(deviceId);
             deviceStops.setDeviceName(device.getName());
             sheetNames.add(WorkbookUtil.createSafeSheetName(deviceStops.getDeviceName()));
             if (device.getGroupId() != 0) {

--- a/src/org/traccar/reports/Stops.java
+++ b/src/org/traccar/reports/Stops.java
@@ -78,7 +78,7 @@ public final class Stops {
             deviceStops.setDeviceName(device.getName());
             sheetNames.add(WorkbookUtil.createSafeSheetName(deviceStops.getDeviceName()));
             if (device.getGroupId() != 0) {
-                Group group = Context.getDeviceManager().getGroupById(device.getGroupId());
+                Group group = (Group) Context.getGroupsManager().getById(device.getGroupId());
                 if (group != null) {
                     deviceStops.setGroupName(group.getName());
                 }

--- a/src/org/traccar/reports/Summary.java
+++ b/src/org/traccar/reports/Summary.java
@@ -38,7 +38,7 @@ public final class Summary {
     private static SummaryReport calculateSummaryResult(long deviceId, Date from, Date to) throws SQLException {
         SummaryReport result = new SummaryReport();
         result.setDeviceId(deviceId);
-        result.setDeviceName(Context.getIdentityManager().getDeviceById(deviceId).getName());
+        result.setDeviceName(Context.getIdentityManager().getById(deviceId).getName());
         Collection<Position> positions = Context.getDataManager().getPositions(deviceId, from, to);
         if (positions != null && !positions.isEmpty()) {
             Position firstPosition = null;

--- a/src/org/traccar/reports/Trips.java
+++ b/src/org/traccar/reports/Trips.java
@@ -73,7 +73,7 @@ public final class Trips {
             Context.getPermissionsManager().checkDevice(userId, deviceId);
             Collection<TripReport> trips = detectTrips(deviceId, from, to);
             DeviceReport deviceTrips = new DeviceReport();
-            Device device = Context.getIdentityManager().getDeviceById(deviceId);
+            Device device = Context.getIdentityManager().getById(deviceId);
             deviceTrips.setDeviceName(device.getName());
             sheetNames.add(WorkbookUtil.createSafeSheetName(deviceTrips.getDeviceName()));
             if (device.getGroupId() != 0) {

--- a/src/org/traccar/reports/Trips.java
+++ b/src/org/traccar/reports/Trips.java
@@ -77,7 +77,7 @@ public final class Trips {
             deviceTrips.setDeviceName(device.getName());
             sheetNames.add(WorkbookUtil.createSafeSheetName(deviceTrips.getDeviceName()));
             if (device.getGroupId() != 0) {
-                Group group = Context.getDeviceManager().getGroupById(device.getGroupId());
+                Group group = (Group) Context.getGroupsManager().getById(device.getGroupId());
                 if (group != null) {
                     deviceTrips.setGroupName(group.getName());
                 }

--- a/src/org/traccar/reports/Trips.java
+++ b/src/org/traccar/reports/Trips.java
@@ -77,7 +77,7 @@ public final class Trips {
             deviceTrips.setDeviceName(device.getName());
             sheetNames.add(WorkbookUtil.createSafeSheetName(deviceTrips.getDeviceName()));
             if (device.getGroupId() != 0) {
-                Group group = (Group) Context.getGroupsManager().getById(device.getGroupId());
+                Group group = Context.getGroupsManager().getById(device.getGroupId());
                 if (group != null) {
                     deviceTrips.setGroupName(group.getName());
                 }

--- a/test/org/traccar/BaseTest.java
+++ b/test/org/traccar/BaseTest.java
@@ -18,12 +18,12 @@ public class BaseTest {
             }
 
             @Override
-            public Device getDeviceById(long id) {
+            public Device getById(long id) {
                 return createDevice();
             }
 
             @Override
-            public Device getDeviceByUniqueId(String uniqueId) {
+            public Device getByUniqueId(String uniqueId) {
                 return createDevice();
             }
             


### PR DESCRIPTION
The main problem is that devices and groups relationship is complex, we use `GroupTree` to trace it.
The next problem is that we have to have list of devices and groups before creating the tree.
I decided to add new layer in object managers structure and it looks next:

- `BaseObjectManager` class that only stores objects cache and do add/update/remove
- `ManagableObjects` (probably need to be renamed) interface that implements two functions `getUserItems` and `getManagedItems`. `getManagedItems` are the same in 3 classes, but it is impossible to use `default` in Java 7. This interface used only to strict the code.
- `SimpleObjectManager` class that implements `ManagableObjects` and store User -> Object permissions
- `ExtendedObjectManager` is not changed, it stores Device -> Object and Group -> Object permissions

I leaved this complex devices and groups tree in `PermissionsManager` and just apply to it from Device and Group managers.

Now objects API resources look very similar and this will allow combine them on some future stage.

Some comments in code.