### PR TITLE
Combine PUT/POST/DELETE functions in object resources

### DIFF
--- a/src/org/traccar/Context.java
+++ b/src/org/traccar/Context.java
@@ -378,7 +378,7 @@ public final class Context {
         identityManager = testIdentityManager;
     }
 
-    public static <T extends BaseModel> BaseObjectManager<T> getManager(Class<? extends BaseModel> clazz) {
+    public static <T extends BaseModel> BaseObjectManager<T> getManager(Class<T> clazz) {
         if (clazz.equals(Device.class)) {
             return (BaseObjectManager<T>) deviceManager;
         } else if (clazz.equals(Group.class)) {

--- a/src/org/traccar/Context.java
+++ b/src/org/traccar/Context.java
@@ -28,6 +28,7 @@ import org.eclipse.jetty.util.URIUtil;
 import org.traccar.database.AliasesManager;
 import org.traccar.database.CalendarManager;
 import org.traccar.database.AttributesManager;
+import org.traccar.database.BaseObjectManager;
 import org.traccar.database.ConnectionManager;
 import org.traccar.database.DataManager;
 import org.traccar.database.DeviceManager;
@@ -51,6 +52,14 @@ import org.traccar.geocoder.OpenCageGeocoder;
 import org.traccar.geocoder.Geocoder;
 import org.traccar.geolocation.UnwiredGeolocationProvider;
 import org.traccar.helper.Log;
+import org.traccar.model.Attribute;
+import org.traccar.model.BaseModel;
+import org.traccar.model.Calendar;
+import org.traccar.model.Device;
+import org.traccar.model.Driver;
+import org.traccar.model.Geofence;
+import org.traccar.model.Group;
+import org.traccar.model.User;
 import org.traccar.geolocation.GoogleGeolocationProvider;
 import org.traccar.geolocation.GeolocationProvider;
 import org.traccar.geolocation.MozillaGeolocationProvider;
@@ -367,6 +376,25 @@ public final class Context {
         config = new Config();
         objectMapper = new ObjectMapper();
         identityManager = testIdentityManager;
+    }
+
+    public static <T extends BaseModel> BaseObjectManager<T> getManager(Class<? extends BaseModel> clazz) {
+        if (clazz.equals(Device.class)) {
+            return (BaseObjectManager<T>) deviceManager;
+        } else if (clazz.equals(Group.class)) {
+            return (BaseObjectManager<T>) groupsManager;
+        } else if (clazz.equals(User.class)) {
+            return (BaseObjectManager<T>) usersManager;
+        } else if (clazz.equals(Calendar.class)) {
+            return (BaseObjectManager<T>) calendarManager;
+        } else if (clazz.equals(Attribute.class)) {
+            return (BaseObjectManager<T>) attributesManager;
+        } else if (clazz.equals(Geofence.class)) {
+            return (BaseObjectManager<T>) geofenceManager;
+        } else if (clazz.equals(Driver.class)) {
+            return (BaseObjectManager<T>) driversManager;
+        }
+        return null;
     }
 
 }

--- a/src/org/traccar/api/BaseObjectResource.java
+++ b/src/org/traccar/api/BaseObjectResource.java
@@ -101,9 +101,9 @@ public abstract class BaseObjectResource<T extends BaseModel> extends BaseResour
 
         if (manager instanceof SimpleObjectManager) {
             ((SimpleObjectManager<T>) manager).refreshUserItems();
-        }
-        if (manager instanceof ExtendedObjectManager) {
-            ((ExtendedObjectManager<T>) manager).refreshExtendedPermissions();
+            if (manager instanceof ExtendedObjectManager) {
+                ((ExtendedObjectManager<T>) manager).refreshExtendedPermissions();
+            }
         }
         if (baseClass.equals(Group.class) || baseClass.equals(Device.class) || baseClass.equals(User.class)) {
             Context.getPermissionsManager().refreshDeviceAndGroupPermissions();

--- a/src/org/traccar/api/BaseObjectResource.java
+++ b/src/org/traccar/api/BaseObjectResource.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.api;
+
+import java.sql.SQLException;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Response;
+
+import org.traccar.Context;
+import org.traccar.database.BaseObjectManager;
+import org.traccar.database.ExtendedObjectManager;
+import org.traccar.database.SimpleObjectManager;
+import org.traccar.model.BaseModel;
+import org.traccar.model.Device;
+import org.traccar.model.Group;
+import org.traccar.model.User;
+
+public class BaseObjectResource<T extends BaseModel> extends BaseResource {
+
+    private Class<T> baseClass;
+
+    public BaseObjectResource(Class<T> baseClass) {
+        this.baseClass = baseClass;
+    }
+
+    @POST
+    public Response add(T entity) throws SQLException {
+        Context.getPermissionsManager().checkReadonly(getUserId());
+        if (baseClass.equals(Device.class)) {
+            Context.getPermissionsManager().checkDeviceReadonly(getUserId());
+            Context.getPermissionsManager().checkDeviceLimit(getUserId());
+        }
+
+        BaseObjectManager<T> manager = Context.getManager(baseClass);
+        manager.addItem(entity);
+
+        Context.getDataManager().linkObject(User.class, getUserId(), baseClass, entity.getId(), true);
+
+        if (manager instanceof SimpleObjectManager) {
+            ((SimpleObjectManager<T>) manager).refreshUserItems();
+        }
+        if (baseClass.equals(Group.class) || baseClass.equals(Device.class)) {
+            Context.getPermissionsManager().refreshDeviceAndGroupPermissions();
+            Context.getPermissionsManager().refreshAllExtendedPermissions();
+        }
+        return Response.ok(entity).build();
+    }
+
+    @Path("{id}")
+    @PUT
+    public Response update(T entity) throws SQLException {
+        Context.getPermissionsManager().checkReadonly(getUserId());
+        if (baseClass.equals(Device.class)) {
+            Context.getPermissionsManager().checkDeviceReadonly(getUserId());
+        }
+        if (baseClass.equals(User.class)) {
+            User before = Context.getPermissionsManager().getUser(entity.getId());
+            Context.getPermissionsManager().checkUserUpdate(getUserId(), before, (User) entity);
+        }
+        Context.getPermissionsManager().checkPermission(baseClass, getUserId(), entity.getId());
+
+        Context.getManager(baseClass).updateItem(entity);
+
+        if (baseClass.equals(Group.class) || baseClass.equals(Device.class)) {
+            Context.getPermissionsManager().refreshDeviceAndGroupPermissions();
+            Context.getPermissionsManager().refreshAllExtendedPermissions();
+        }
+        if (baseClass.equals(User.class) && Context.getNotificationManager() != null) {
+            Context.getNotificationManager().refresh();
+        }
+        return Response.ok(entity).build();
+    }
+
+    @Path("{id}")
+    @DELETE
+    public Response remove(@PathParam("id") long id) throws SQLException {
+        Context.getPermissionsManager().checkReadonly(getUserId());
+        if (baseClass.equals(Device.class)) {
+            Context.getPermissionsManager().checkDeviceReadonly(getUserId());
+        }
+        Context.getPermissionsManager().checkPermission(baseClass, getUserId(), id);
+
+        BaseObjectManager<T> manager = Context.getManager(baseClass);
+        manager.removeItem(id);
+
+        if (manager instanceof SimpleObjectManager) {
+            ((SimpleObjectManager<T>) manager).refreshUserItems();
+        }
+        if (manager instanceof ExtendedObjectManager) {
+            ((ExtendedObjectManager<T>) manager).refreshExtendedPermissions();
+        }
+        if (baseClass.equals(Group.class) || baseClass.equals(Device.class) || baseClass.equals(User.class)) {
+            Context.getPermissionsManager().refreshDeviceAndGroupPermissions();
+            if (baseClass.equals(User.class)) {
+                Context.getPermissionsManager().refreshAllUsersPermissions();
+            } else {
+                Context.getPermissionsManager().refreshAllExtendedPermissions();
+            }
+        }
+        // deprecated
+        if (baseClass.equals(Device.class)) {
+            Context.getAliasesManager().removeDevice(id);
+        }
+        return Response.noContent().build();
+    }
+
+}

--- a/src/org/traccar/api/BaseObjectResource.java
+++ b/src/org/traccar/api/BaseObjectResource.java
@@ -34,7 +34,7 @@ import org.traccar.model.Device;
 import org.traccar.model.Group;
 import org.traccar.model.User;
 
-public class BaseObjectResource<T extends BaseModel> extends BaseResource {
+public abstract class BaseObjectResource<T extends BaseModel> extends BaseResource {
 
     private Class<T> baseClass;
 
@@ -57,8 +57,7 @@ public class BaseObjectResource<T extends BaseModel> extends BaseResource {
 
         if (manager instanceof SimpleObjectManager) {
             ((SimpleObjectManager<T>) manager).refreshUserItems();
-        }
-        if (baseClass.equals(Group.class) || baseClass.equals(Device.class)) {
+        } else if (baseClass.equals(Group.class) || baseClass.equals(Device.class)) {
             Context.getPermissionsManager().refreshDeviceAndGroupPermissions();
             Context.getPermissionsManager().refreshAllExtendedPermissions();
         }
@@ -71,8 +70,7 @@ public class BaseObjectResource<T extends BaseModel> extends BaseResource {
         Context.getPermissionsManager().checkReadonly(getUserId());
         if (baseClass.equals(Device.class)) {
             Context.getPermissionsManager().checkDeviceReadonly(getUserId());
-        }
-        if (baseClass.equals(User.class)) {
+        } else if (baseClass.equals(User.class)) {
             User before = Context.getPermissionsManager().getUser(entity.getId());
             Context.getPermissionsManager().checkUserUpdate(getUserId(), before, (User) entity);
         }
@@ -83,8 +81,7 @@ public class BaseObjectResource<T extends BaseModel> extends BaseResource {
         if (baseClass.equals(Group.class) || baseClass.equals(Device.class)) {
             Context.getPermissionsManager().refreshDeviceAndGroupPermissions();
             Context.getPermissionsManager().refreshAllExtendedPermissions();
-        }
-        if (baseClass.equals(User.class) && Context.getNotificationManager() != null) {
+        } else if (baseClass.equals(User.class) && Context.getNotificationManager() != null) {
             Context.getNotificationManager().refresh();
         }
         return Response.ok(entity).build();
@@ -116,7 +113,7 @@ public class BaseObjectResource<T extends BaseModel> extends BaseResource {
                 Context.getPermissionsManager().refreshAllExtendedPermissions();
             }
         }
-        // deprecated
+        // Next should be removed with Attribute Aliases
         if (baseClass.equals(Device.class)) {
             Context.getAliasesManager().removeDevice(id);
         }

--- a/src/org/traccar/api/resource/CalendarResource.java
+++ b/src/org/traccar/api/resource/CalendarResource.java
@@ -21,27 +21,25 @@ import java.util.Collection;
 import java.util.Set;
 
 import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
 import org.traccar.Context;
-import org.traccar.api.BaseResource;
+import org.traccar.api.BaseObjectResource;
 import org.traccar.database.CalendarManager;
 import org.traccar.model.Calendar;
-import org.traccar.model.User;
 
 @Path("calendars")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-public class CalendarResource extends BaseResource {
+public class CalendarResource extends BaseObjectResource<Calendar> {
+
+    public CalendarResource() {
+        super(Calendar.class);
+    }
 
     @GET
     public Collection<Calendar> get(
@@ -66,30 +64,4 @@ public class CalendarResource extends BaseResource {
         return calendarManager.getItems(result);
     }
 
-    @POST
-    public Response add(Calendar entity) throws SQLException {
-        Context.getPermissionsManager().checkReadonly(getUserId());
-        Context.getCalendarManager().addItem(entity);
-        Context.getDataManager().linkObject(User.class, getUserId(), entity.getClass(), entity.getId(), true);
-        Context.getCalendarManager().refreshUserItems();
-        return Response.ok(entity).build();
-    }
-
-    @Path("{id}")
-    @PUT
-    public Response update(Calendar entity) throws SQLException {
-        Context.getPermissionsManager().checkReadonly(getUserId());
-        Context.getPermissionsManager().checkPermission(Calendar.class, getUserId(), entity.getId());
-        Context.getCalendarManager().updateItem(entity);
-        return Response.ok(entity).build();
-    }
-
-    @Path("{id}")
-    @DELETE
-    public Response remove(@PathParam("id") long id) throws SQLException {
-        Context.getPermissionsManager().checkReadonly(getUserId());
-        Context.getPermissionsManager().checkPermission(Calendar.class, getUserId(), id);
-        Context.getCalendarManager().removeItem(id);
-        return Response.noContent().build();
-    }
 }

--- a/src/org/traccar/api/resource/DeviceResource.java
+++ b/src/org/traccar/api/resource/DeviceResource.java
@@ -16,19 +16,15 @@
 package org.traccar.api.resource;
 
 import org.traccar.Context;
-import org.traccar.api.BaseResource;
+import org.traccar.api.BaseObjectResource;
 import org.traccar.database.DeviceManager;
 import org.traccar.model.Device;
 import org.traccar.model.DeviceTotalDistance;
-import org.traccar.model.User;
 
 import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
@@ -43,7 +39,11 @@ import java.util.Set;
 @Path("devices")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-public class DeviceResource extends BaseResource {
+public class DeviceResource extends BaseObjectResource<Device> {
+
+    public DeviceResource() {
+        super(Device.class);
+    }
 
     @GET
     public Collection<Device> get(
@@ -78,43 +78,6 @@ public class DeviceResource extends BaseResource {
             }
         }
         return deviceManager.getItems(result);
-    }
-
-    @POST
-    public Response add(Device entity) throws SQLException {
-        Context.getPermissionsManager().checkReadonly(getUserId());
-        Context.getPermissionsManager().checkDeviceReadonly(getUserId());
-        Context.getPermissionsManager().checkDeviceLimit(getUserId());
-        Context.getDeviceManager().addItem(entity);
-        Context.getDataManager().linkObject(User.class, getUserId(), entity.getClass(), entity.getId(), true);
-        Context.getPermissionsManager().refreshDeviceAndGroupPermissions();
-        Context.getPermissionsManager().refreshAllExtendedPermissions();
-        return Response.ok(entity).build();
-    }
-
-    @Path("{id}")
-    @PUT
-    public Response update(Device entity) throws SQLException {
-        Context.getPermissionsManager().checkReadonly(getUserId());
-        Context.getPermissionsManager().checkDeviceReadonly(getUserId());
-        Context.getPermissionsManager().checkDevice(getUserId(), entity.getId());
-        Context.getDeviceManager().updateItem(entity);
-        Context.getPermissionsManager().refreshDeviceAndGroupPermissions();
-        Context.getPermissionsManager().refreshAllExtendedPermissions();
-        return Response.ok(entity).build();
-    }
-
-    @Path("{id}")
-    @DELETE
-    public Response remove(@PathParam("id") long id) throws SQLException {
-        Context.getPermissionsManager().checkReadonly(getUserId());
-        Context.getPermissionsManager().checkDeviceReadonly(getUserId());
-        Context.getPermissionsManager().checkDevice(getUserId(), id);
-        Context.getDeviceManager().removeItem(id);
-        Context.getPermissionsManager().refreshDeviceAndGroupPermissions();
-        Context.getPermissionsManager().refreshAllExtendedPermissions();
-        Context.getAliasesManager().removeDevice(id);
-        return Response.noContent().build();
     }
 
     @Path("{id}/distance")

--- a/src/org/traccar/api/resource/DriverResource.java
+++ b/src/org/traccar/api/resource/DriverResource.java
@@ -22,27 +22,25 @@ import java.util.HashSet;
 import java.util.Set;
 
 import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
 import org.traccar.Context;
-import org.traccar.api.BaseResource;
+import org.traccar.api.BaseObjectResource;
 import org.traccar.database.DriversManager;
 import org.traccar.model.Driver;
-import org.traccar.model.User;
 
 @Path("drivers")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-public class DriverResource extends BaseResource {
+public class DriverResource extends BaseObjectResource<Driver> {
+
+    public DriverResource() {
+        super(Driver.class);
+    }
 
     @GET
     public Collection<Driver> get(
@@ -81,33 +79,6 @@ public class DriverResource extends BaseResource {
         }
         return driversManager.getItems(result);
 
-    }
-
-    @POST
-    public Response add(Driver entity) throws SQLException {
-        Context.getPermissionsManager().checkReadonly(getUserId());
-        Context.getDriversManager().addItem(entity);
-        Context.getDataManager().linkObject(User.class, getUserId(), entity.getClass(), entity.getId(), true);
-        Context.getDriversManager().refreshUserItems();
-        return Response.ok(entity).build();
-    }
-
-    @Path("{id}")
-    @PUT
-    public Response update(Driver entity) throws SQLException {
-        Context.getPermissionsManager().checkReadonly(getUserId());
-        Context.getPermissionsManager().checkPermission(Driver.class, getUserId(), entity.getId());
-        Context.getDriversManager().updateItem(entity);
-        return Response.ok(entity).build();
-    }
-
-    @Path("{id}")
-    @DELETE
-    public Response remove(@PathParam("id") long id) throws SQLException {
-        Context.getPermissionsManager().checkReadonly(getUserId());
-        Context.getPermissionsManager().checkPermission(Driver.class, getUserId(), id);
-        Context.getDriversManager().removeItem(id);
-        return Response.noContent().build();
     }
 
 }

--- a/src/org/traccar/api/resource/GeofenceResource.java
+++ b/src/org/traccar/api/resource/GeofenceResource.java
@@ -16,22 +16,16 @@
 package org.traccar.api.resource;
 
 import org.traccar.Context;
-import org.traccar.api.BaseResource;
+import org.traccar.api.BaseObjectResource;
 import org.traccar.database.GeofenceManager;
 import org.traccar.model.Geofence;
-import org.traccar.model.User;
 
 import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
 import java.sql.SQLException;
 import java.util.Collection;
@@ -41,7 +35,11 @@ import java.util.Set;
 @Path("geofences")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-public class GeofenceResource extends BaseResource {
+public class GeofenceResource extends BaseObjectResource<Geofence> {
+
+    public GeofenceResource() {
+        super(Geofence.class);
+    }
 
     @GET
     public Collection<Geofence> get(
@@ -79,34 +77,5 @@ public class GeofenceResource extends BaseResource {
             result.retainAll(geofenceManager.getDeviceItems(deviceId));
         }
         return geofenceManager.getItems(result);
-
     }
-
-    @POST
-    public Response add(Geofence entity) throws SQLException {
-        Context.getPermissionsManager().checkReadonly(getUserId());
-        Context.getGeofenceManager().addItem(entity);
-        Context.getDataManager().linkObject(User.class, getUserId(), entity.getClass(), entity.getId(), true);
-        Context.getGeofenceManager().refreshUserItems();
-        return Response.ok(entity).build();
-    }
-
-    @Path("{id}")
-    @PUT
-    public Response update(Geofence entity) throws SQLException {
-        Context.getPermissionsManager().checkReadonly(getUserId());
-        Context.getPermissionsManager().checkPermission(Geofence.class, getUserId(), entity.getId());
-        Context.getGeofenceManager().updateItem(entity);
-        return Response.ok(entity).build();
-    }
-
-    @Path("{id}")
-    @DELETE
-    public Response remove(@PathParam("id") long id) throws SQLException {
-        Context.getPermissionsManager().checkReadonly(getUserId());
-        Context.getPermissionsManager().checkPermission(Geofence.class, getUserId(), id);
-        Context.getGeofenceManager().removeItem(id);
-        return Response.noContent().build();
-    }
-
 }

--- a/src/org/traccar/api/resource/GroupResource.java
+++ b/src/org/traccar/api/resource/GroupResource.java
@@ -16,22 +16,16 @@
 package org.traccar.api.resource;
 
 import org.traccar.Context;
-import org.traccar.api.BaseResource;
+import org.traccar.api.BaseObjectResource;
 import org.traccar.database.GroupsManager;
 import org.traccar.model.Group;
-import org.traccar.model.User;
 
 import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Set;
@@ -39,7 +33,11 @@ import java.util.Set;
 @Path("groups")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-public class GroupResource extends BaseResource {
+public class GroupResource extends BaseObjectResource<Group> {
+
+    public GroupResource() {
+        super(Group.class);
+    }
 
     @GET
     public Collection<Group> get(
@@ -62,37 +60,4 @@ public class GroupResource extends BaseResource {
         }
         return groupsManager.getItems(result);
     }
-
-    @POST
-    public Response add(Group entity) throws SQLException {
-        Context.getPermissionsManager().checkReadonly(getUserId());
-        Context.getGroupsManager().addItem(entity);
-        Context.getDataManager().linkObject(User.class, getUserId(), entity.getClass(), entity.getId(), true);
-        Context.getPermissionsManager().refreshDeviceAndGroupPermissions();
-        Context.getPermissionsManager().refreshAllExtendedPermissions();
-        return Response.ok(entity).build();
-    }
-
-    @Path("{id}")
-    @PUT
-    public Response update(Group entity) throws SQLException {
-        Context.getPermissionsManager().checkReadonly(getUserId());
-        Context.getPermissionsManager().checkGroup(getUserId(), entity.getId());
-        Context.getGroupsManager().updateItem(entity);
-        Context.getPermissionsManager().refreshDeviceAndGroupPermissions();
-        Context.getPermissionsManager().refreshAllExtendedPermissions();
-        return Response.ok(entity).build();
-    }
-
-    @Path("{id}")
-    @DELETE
-    public Response remove(@PathParam("id") long id) throws SQLException {
-        Context.getPermissionsManager().checkReadonly(getUserId());
-        Context.getPermissionsManager().checkGroup(getUserId(), id);
-        Context.getGroupsManager().removeItem(id);
-        Context.getPermissionsManager().refreshDeviceAndGroupPermissions();
-        Context.getPermissionsManager().refreshAllExtendedPermissions();
-        return Response.noContent().build();
-    }
-
 }

--- a/src/org/traccar/api/resource/UserResource.java
+++ b/src/org/traccar/api/resource/UserResource.java
@@ -16,19 +16,16 @@
 package org.traccar.api.resource;
 
 import org.traccar.Context;
-import org.traccar.api.BaseResource;
+import org.traccar.api.BaseObjectResource;
 import org.traccar.database.UsersManager;
 import org.traccar.model.ManagedUser;
 import org.traccar.model.User;
 
 import javax.annotation.security.PermitAll;
 import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
@@ -41,7 +38,11 @@ import java.util.Set;
 @Path("users")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-public class UserResource extends BaseResource {
+public class UserResource extends BaseObjectResource<User> {
+
+    public UserResource() {
+        super(User.class);
+    }
 
     @GET
     public Collection<User> get(@QueryParam("userId") long userId) throws SQLException {
@@ -61,6 +62,7 @@ public class UserResource extends BaseResource {
         return usersManager.getItems(result);
     }
 
+    @Override
     @PermitAll
     @POST
     public Response add(User entity) throws SQLException {
@@ -87,31 +89,6 @@ public class UserResource extends BaseResource {
             Context.getNotificationManager().refresh();
         }
         return Response.ok(entity).build();
-    }
-
-    @Path("{id}")
-    @PUT
-    public Response update(User entity) throws SQLException {
-        Context.getPermissionsManager().checkReadonly(getUserId());
-        User before = Context.getPermissionsManager().getUser(entity.getId());
-        Context.getPermissionsManager().checkUser(getUserId(), entity.getId());
-        Context.getPermissionsManager().checkUserUpdate(getUserId(), before, entity);
-        Context.getUsersManager().updateItem(entity);
-        if (Context.getNotificationManager() != null) {
-            Context.getNotificationManager().refresh();
-        }
-        return Response.ok(entity).build();
-    }
-
-    @Path("{id}")
-    @DELETE
-    public Response remove(@PathParam("id") long id) throws SQLException {
-        Context.getPermissionsManager().checkReadonly(getUserId());
-        Context.getPermissionsManager().checkUser(getUserId(), id);
-        Context.getUsersManager().removeItem(id);
-        Context.getPermissionsManager().refreshDeviceAndGroupPermissions();
-        Context.getPermissionsManager().refreshAllUsersPermissions();
-        return Response.noContent().build();
     }
 
 }


### PR DESCRIPTION
Implemented generic `BaseObjectResource` and combined all checks and updates in 3 functions.
They look rather complex, but really simple:
- Check before action
- Action: add/update/remove
- Refresh after action

Leaved `add` in users resource as is because it is too different.

I'm not very satisfied with `getManagers` function because of unchecked type casting warning, but it works correctly.

`@GET` functions not optimized for now, set of parameters and logic are different. Probably I'll implement some intermediate subclasses with common GET functions for `SimpleObjectManager`s and for `ExtendedObjectManager`s. They look similar.
