### PR TITLE
Initialize some maps, because they might be accessed before initialized.

### DIFF
--- a/src/org/traccar/database/DataManager.java
+++ b/src/org/traccar/database/DataManager.java
@@ -37,11 +37,17 @@ import liquibase.resource.ResourceAccessor;
 
 import org.traccar.Config;
 import org.traccar.helper.Log;
+import org.traccar.model.Attribute;
 import org.traccar.model.AttributeAlias;
 import org.traccar.model.Device;
+import org.traccar.model.Driver;
 import org.traccar.model.Event;
+import org.traccar.model.Geofence;
+import org.traccar.model.Group;
+import org.traccar.model.ManagedUser;
 import org.traccar.model.Permission;
 import org.traccar.model.BaseModel;
+import org.traccar.model.Calendar;
 import org.traccar.model.Position;
 import org.traccar.model.Server;
 import org.traccar.model.Statistics;
@@ -269,8 +275,26 @@ public class DataManager {
     }
 
     public static Class<?> getClassByName(String name) throws ClassNotFoundException {
-        return Class.forName("org.traccar.model."
-                + name.substring(0, 1).toUpperCase() + name.replace("Id", "").substring(1));
+        switch (name.toLowerCase().replace("id", "")) {
+            case "device":
+                return Device.class;
+            case "group":
+                return Group.class;
+            case "user":
+                return User.class;
+            case "manageduser":
+                return ManagedUser.class;
+            case "geofence":
+                return Geofence.class;
+            case "driver":
+                return Driver.class;
+            case "attribute":
+                return Attribute.class;
+            case "calendar":
+                return Calendar.class;
+            default:
+                throw new ClassNotFoundException();
+        }
     }
 
     public static String makeNameId(Class<?> clazz) {

--- a/src/org/traccar/database/DeviceManager.java
+++ b/src/org/traccar/database/DeviceManager.java
@@ -57,6 +57,12 @@ public class DeviceManager extends BaseObjectManager<Device> implements Identity
     public DeviceManager(DataManager dataManager) {
         super(dataManager, Device.class);
         this.config = Context.getConfig();
+        if (devicesByPhone == null) {
+            devicesByPhone = new ConcurrentHashMap<>();
+        }
+        if (devicesByUniqueId == null) {
+            devicesByUniqueId = new ConcurrentHashMap<>();
+        }
         dataRefreshDelay = config.getLong("database.refreshDelay", DEFAULT_REFRESH_DELAY) * 1000;
         lookupGroupsAttribute = config.getBoolean("deviceManager.lookupGroupsAttribute");
         fallbackToText = config.getBoolean("command.fallbackToSms");

--- a/src/org/traccar/database/DriversManager.java
+++ b/src/org/traccar/database/DriversManager.java
@@ -27,6 +27,9 @@ public class DriversManager extends ExtendedObjectManager<Driver> {
 
     public DriversManager(DataManager dataManager) {
         super(dataManager, Driver.class);
+        if (driversByUniqueId == null) {
+            driversByUniqueId = new ConcurrentHashMap<>();
+        }
     }
 
     private void putUniqueDriverId(Driver driver) {

--- a/src/org/traccar/database/UsersManager.java
+++ b/src/org/traccar/database/UsersManager.java
@@ -29,6 +29,9 @@ public class UsersManager extends SimpleObjectManager<User> {
 
     public UsersManager(DataManager dataManager) {
         super(dataManager, User.class);
+        if (usersTokens == null) {
+            usersTokens = new ConcurrentHashMap<>();
+        }
     }
 
     private void putToken(User user) {


### PR DESCRIPTION
fix for https://www.traccar.org/forums/topic/build-source-code-error/
This maps might be not initialized if objects list is empty, but called `getXxxByUniqueId` function.
