### PR TITLE
Combine some GET functions

### DIFF
--- a/src/org/traccar/api/BaseObjectResource.java
+++ b/src/org/traccar/api/BaseObjectResource.java
@@ -17,6 +17,7 @@
 package org.traccar.api;
 
 import java.sql.SQLException;
+import java.util.Set;
 
 import javax.ws.rs.DELETE;
 import javax.ws.rs.POST;
@@ -28,6 +29,7 @@ import javax.ws.rs.core.Response;
 import org.traccar.Context;
 import org.traccar.database.BaseObjectManager;
 import org.traccar.database.ExtendedObjectManager;
+import org.traccar.database.ManagableObjects;
 import org.traccar.database.SimpleObjectManager;
 import org.traccar.model.BaseModel;
 import org.traccar.model.Device;
@@ -40,6 +42,29 @@ public abstract class BaseObjectResource<T extends BaseModel> extends BaseResour
 
     public BaseObjectResource(Class<T> baseClass) {
         this.baseClass = baseClass;
+    }
+
+    protected final Class<T> getBaseClass() {
+        return baseClass;
+    }
+
+    protected final Set<Long> getSimpleManagerItems(BaseObjectManager<T> manager, boolean all,  long userId) {
+        Set<Long> result = null;
+        if (all) {
+            if (Context.getPermissionsManager().isAdmin(getUserId())) {
+                result = manager.getAllItems();
+            } else {
+                Context.getPermissionsManager().checkManager(getUserId());
+                result = ((ManagableObjects) manager).getManagedItems(getUserId());
+            }
+        } else {
+            if (userId == 0) {
+                userId = getUserId();
+            }
+            Context.getPermissionsManager().checkUser(getUserId(), userId);
+            result = ((ManagableObjects) manager).getUserItems(userId);
+        }
+        return result;
     }
 
     @POST

--- a/src/org/traccar/api/ExtendedObjectResource.java
+++ b/src/org/traccar/api/ExtendedObjectResource.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.api;
+
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.QueryParam;
+
+import org.traccar.Context;
+import org.traccar.database.ExtendedObjectManager;
+import org.traccar.model.BaseModel;
+
+public class ExtendedObjectResource<T extends BaseModel> extends BaseObjectResource<T> {
+
+    public ExtendedObjectResource(Class<T> baseClass) {
+        super(baseClass);
+    }
+
+    @GET
+    public Collection<T> get(
+            @QueryParam("all") boolean all, @QueryParam("userId") long userId, @QueryParam("groupId") long groupId,
+            @QueryParam("deviceId") long deviceId, @QueryParam("refresh") boolean refresh) throws SQLException {
+
+        ExtendedObjectManager<T> manager = (ExtendedObjectManager<T>) Context.getManager(getBaseClass());
+        if (refresh) {
+            manager.refreshItems();
+        }
+
+        Set<Long> result = new HashSet<>(getSimpleManagerItems(manager, all, userId));
+
+        if (groupId != 0) {
+            Context.getPermissionsManager().checkGroup(getUserId(), groupId);
+            result.retainAll(manager.getGroupItems(groupId));
+        }
+
+        if (deviceId != 0) {
+            Context.getPermissionsManager().checkDevice(getUserId(), deviceId);
+            result.retainAll(manager.getDeviceItems(deviceId));
+        }
+        return manager.getItems(result);
+
+    }
+
+}

--- a/src/org/traccar/api/SimpleObjectResource.java
+++ b/src/org/traccar/api/SimpleObjectResource.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.api;
+
+import java.sql.SQLException;
+import java.util.Collection;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.QueryParam;
+
+import org.traccar.Context;
+import org.traccar.database.BaseObjectManager;
+import org.traccar.model.BaseModel;
+
+public class SimpleObjectResource<T extends BaseModel> extends BaseObjectResource<T> {
+
+    public SimpleObjectResource(Class<T> baseClass) {
+        super(baseClass);
+    }
+
+    @GET
+    public Collection<T> get(
+            @QueryParam("all") boolean all, @QueryParam("userId") long userId) throws SQLException {
+
+        BaseObjectManager<T> manager = Context.getManager(getBaseClass());
+        return manager.getItems(getSimpleManagerItems(manager, all, userId));
+    }
+
+}

--- a/src/org/traccar/api/resource/AttributeResource.java
+++ b/src/org/traccar/api/resource/AttributeResource.java
@@ -17,12 +17,8 @@
 package org.traccar.api.resource;
 
 import java.sql.SQLException;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
 
 import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -31,8 +27,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.traccar.Context;
-import org.traccar.api.BaseObjectResource;
-import org.traccar.database.AttributesManager;
+import org.traccar.api.ExtendedObjectResource;
 import org.traccar.model.Attribute;
 import org.traccar.model.Position;
 import org.traccar.processing.ComputedAttributesHandler;
@@ -40,49 +35,10 @@ import org.traccar.processing.ComputedAttributesHandler;
 @Path("attributes/computed")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-public class AttributeResource extends BaseObjectResource<Attribute> {
+public class AttributeResource extends ExtendedObjectResource<Attribute> {
 
     public AttributeResource() {
         super(Attribute.class);
-    }
-
-    @GET
-    public Collection<Attribute> get(
-            @QueryParam("all") boolean all, @QueryParam("userId") long userId, @QueryParam("groupId") long groupId,
-            @QueryParam("deviceId") long deviceId, @QueryParam("refresh") boolean refresh) throws SQLException {
-
-        AttributesManager attributesManager = Context.getAttributesManager();
-        if (refresh) {
-            attributesManager.refreshItems();
-        }
-
-        Set<Long> result = new HashSet<>();
-        if (all) {
-            if (Context.getPermissionsManager().isAdmin(getUserId())) {
-                result.addAll(attributesManager.getAllItems());
-            } else {
-                Context.getPermissionsManager().checkManager(getUserId());
-                result.addAll(attributesManager.getManagedItems(getUserId()));
-            }
-        } else {
-            if (userId == 0) {
-                userId = getUserId();
-            }
-            Context.getPermissionsManager().checkUser(getUserId(), userId);
-            result.addAll(attributesManager.getUserItems(userId));
-        }
-
-        if (groupId != 0) {
-            Context.getPermissionsManager().checkGroup(getUserId(), groupId);
-            result.retainAll(attributesManager.getGroupItems(groupId));
-        }
-
-        if (deviceId != 0) {
-            Context.getPermissionsManager().checkDevice(getUserId(), deviceId);
-            result.retainAll(attributesManager.getDeviceItems(deviceId));
-        }
-        return attributesManager.getItems(result);
-
     }
 
     @POST

--- a/src/org/traccar/api/resource/CalendarResource.java
+++ b/src/org/traccar/api/resource/CalendarResource.java
@@ -16,52 +16,21 @@
  */
 package org.traccar.api.resource;
 
-import java.sql.SQLException;
-import java.util.Collection;
-import java.util.Set;
-
 import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
-import org.traccar.Context;
-import org.traccar.api.BaseObjectResource;
-import org.traccar.database.CalendarManager;
+import org.traccar.api.SimpleObjectResource;
 import org.traccar.model.Calendar;
 
 @Path("calendars")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-public class CalendarResource extends BaseObjectResource<Calendar> {
+public class CalendarResource extends SimpleObjectResource<Calendar> {
 
     public CalendarResource() {
         super(Calendar.class);
-    }
-
-    @GET
-    public Collection<Calendar> get(
-            @QueryParam("all") boolean all, @QueryParam("userId") long userId) throws SQLException {
-
-        CalendarManager calendarManager = Context.getCalendarManager();
-        Set<Long> result = null;
-        if (all) {
-            if (Context.getPermissionsManager().isAdmin(getUserId())) {
-                result = calendarManager.getAllItems();
-            } else {
-                Context.getPermissionsManager().checkManager(getUserId());
-                result = calendarManager.getManagedItems(getUserId());
-            }
-        } else {
-            if (userId == 0) {
-                userId = getUserId();
-            }
-            Context.getPermissionsManager().checkUser(getUserId(), userId);
-            result = calendarManager.getUserItems(userId);
-        }
-        return calendarManager.getItems(result);
     }
 
 }

--- a/src/org/traccar/api/resource/DriverResource.java
+++ b/src/org/traccar/api/resource/DriverResource.java
@@ -16,69 +16,21 @@
  */
 package org.traccar.api.resource;
 
-import java.sql.SQLException;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
-
 import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
-import org.traccar.Context;
-import org.traccar.api.BaseObjectResource;
-import org.traccar.database.DriversManager;
+import org.traccar.api.ExtendedObjectResource;
 import org.traccar.model.Driver;
 
 @Path("drivers")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-public class DriverResource extends BaseObjectResource<Driver> {
+public class DriverResource extends ExtendedObjectResource<Driver> {
 
     public DriverResource() {
         super(Driver.class);
-    }
-
-    @GET
-    public Collection<Driver> get(
-            @QueryParam("all") boolean all, @QueryParam("userId") long userId, @QueryParam("groupId") long groupId,
-            @QueryParam("deviceId") long deviceId, @QueryParam("refresh") boolean refresh) throws SQLException {
-
-        DriversManager driversManager = Context.getDriversManager();
-        if (refresh) {
-            driversManager.refreshItems();
-        }
-
-        Set<Long> result = new HashSet<>();
-        if (all) {
-            if (Context.getPermissionsManager().isAdmin(getUserId())) {
-                result.addAll(driversManager.getAllItems());
-            } else {
-                Context.getPermissionsManager().checkManager(getUserId());
-                result.addAll(driversManager.getManagedItems(getUserId()));
-            }
-        } else {
-            if (userId == 0) {
-                userId = getUserId();
-            }
-            Context.getPermissionsManager().checkUser(getUserId(), userId);
-            result.addAll(driversManager.getUserItems(userId));
-        }
-
-        if (groupId != 0) {
-            Context.getPermissionsManager().checkGroup(getUserId(), groupId);
-            result.retainAll(driversManager.getGroupItems(groupId));
-        }
-
-        if (deviceId != 0) {
-            Context.getPermissionsManager().checkDevice(getUserId(), deviceId);
-            result.retainAll(driversManager.getDeviceItems(deviceId));
-        }
-        return driversManager.getItems(result);
-
     }
 
 }

--- a/src/org/traccar/api/resource/GeofenceResource.java
+++ b/src/org/traccar/api/resource/GeofenceResource.java
@@ -15,67 +15,21 @@
  */
 package org.traccar.api.resource;
 
-import org.traccar.Context;
-import org.traccar.api.BaseObjectResource;
-import org.traccar.database.GeofenceManager;
+import org.traccar.api.ExtendedObjectResource;
 import org.traccar.model.Geofence;
 
 import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
-
-import java.sql.SQLException;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
 
 @Path("geofences")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-public class GeofenceResource extends BaseObjectResource<Geofence> {
+public class GeofenceResource extends ExtendedObjectResource<Geofence> {
 
     public GeofenceResource() {
         super(Geofence.class);
     }
 
-    @GET
-    public Collection<Geofence> get(
-            @QueryParam("all") boolean all, @QueryParam("userId") long userId, @QueryParam("groupId") long groupId,
-            @QueryParam("deviceId") long deviceId, @QueryParam("refresh") boolean refresh) throws SQLException {
-
-        GeofenceManager geofenceManager = Context.getGeofenceManager();
-        if (refresh) {
-            geofenceManager.refreshItems();
-        }
-
-        Set<Long> result = new HashSet<>();
-        if (all) {
-            if (Context.getPermissionsManager().isAdmin(getUserId())) {
-                result.addAll(geofenceManager.getAllItems());
-            } else {
-                Context.getPermissionsManager().checkManager(getUserId());
-                result.addAll(geofenceManager.getManagedItems(getUserId()));
-            }
-        } else {
-            if (userId == 0) {
-                userId = getUserId();
-            }
-            Context.getPermissionsManager().checkUser(getUserId(), userId);
-            result.addAll(geofenceManager.getUserItems(userId));
-        }
-
-        if (groupId != 0) {
-            Context.getPermissionsManager().checkGroup(getUserId(), groupId);
-            result.retainAll(geofenceManager.getGroupItems(groupId));
-        }
-
-        if (deviceId != 0) {
-            Context.getPermissionsManager().checkDevice(getUserId(), deviceId);
-            result.retainAll(geofenceManager.getDeviceItems(deviceId));
-        }
-        return geofenceManager.getItems(result);
-    }
 }

--- a/src/org/traccar/api/resource/GroupResource.java
+++ b/src/org/traccar/api/resource/GroupResource.java
@@ -15,49 +15,21 @@
  */
 package org.traccar.api.resource;
 
-import org.traccar.Context;
-import org.traccar.api.BaseObjectResource;
-import org.traccar.database.GroupsManager;
+import org.traccar.api.SimpleObjectResource;
 import org.traccar.model.Group;
 
 import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
-import java.sql.SQLException;
-import java.util.Collection;
-import java.util.Set;
 
 @Path("groups")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-public class GroupResource extends BaseObjectResource<Group> {
+public class GroupResource extends SimpleObjectResource<Group> {
 
     public GroupResource() {
         super(Group.class);
     }
 
-    @GET
-    public Collection<Group> get(
-            @QueryParam("all") boolean all, @QueryParam("userId") long userId) throws SQLException {
-        GroupsManager groupsManager = Context.getGroupsManager();
-        Set<Long> result = null;
-        if (all) {
-            if (Context.getPermissionsManager().isAdmin(getUserId())) {
-                result = groupsManager.getAllItems();
-            } else {
-                Context.getPermissionsManager().checkManager(getUserId());
-                result = groupsManager.getManagedItems(getUserId());
-            }
-        } else {
-            if (userId == 0) {
-                userId = getUserId();
-            }
-            Context.getPermissionsManager().checkUser(getUserId(), userId);
-            result = groupsManager.getUserItems(userId);
-        }
-        return groupsManager.getItems(result);
-    }
 }


### PR DESCRIPTION
Put `getSimpleManagerItems` function to Base because it is impossible make strict inheritance Base->Simple->Extended because it is impossible override `@GET` and `get` with different set of parameters.

`ManagableObjects` interface become useful. 