### PR TITLE
Fix retrieving objects by unknown tokens/uniqueId

### DIFF
--- a/src/org/traccar/database/DriversManager.java
+++ b/src/org/traccar/database/DriversManager.java
@@ -23,7 +23,7 @@ import org.traccar.model.Driver;
 
 public class DriversManager extends ExtendedObjectManager<Driver> {
 
-    private Map<String, Long> driversByUniqueId;
+    private Map<String, Driver> driversByUniqueId;
 
     public DriversManager(DataManager dataManager) {
         super(dataManager, Driver.class);
@@ -36,7 +36,7 @@ public class DriversManager extends ExtendedObjectManager<Driver> {
         if (driversByUniqueId == null) {
             driversByUniqueId = new ConcurrentHashMap<>(getAllItems().size());
         }
-        driversByUniqueId.put(driver.getUniqueId(), driver.getId());
+        driversByUniqueId.put(driver.getUniqueId(), driver);
     }
 
     @Override
@@ -68,6 +68,6 @@ public class DriversManager extends ExtendedObjectManager<Driver> {
     }
 
     public Driver getDriverByUniqueId(String uniqueId) {
-        return getById(driversByUniqueId.get(uniqueId));
+        return driversByUniqueId.get(uniqueId);
     }
 }

--- a/src/org/traccar/database/UsersManager.java
+++ b/src/org/traccar/database/UsersManager.java
@@ -25,7 +25,7 @@ import org.traccar.model.User;
 
 public class UsersManager extends SimpleObjectManager<User> {
 
-    private Map<String, Long> usersTokens;
+    private Map<String, User> usersTokens;
 
     public UsersManager(DataManager dataManager) {
         super(dataManager, User.class);
@@ -39,7 +39,7 @@ public class UsersManager extends SimpleObjectManager<User> {
             usersTokens = new ConcurrentHashMap<>();
         }
         if (user.getToken() != null) {
-            usersTokens.put(user.getToken(), user.getId());
+            usersTokens.put(user.getToken(), user);
         }
     }
 
@@ -53,9 +53,7 @@ public class UsersManager extends SimpleObjectManager<User> {
     protected void updateCachedItem(User user) {
         User cachedUser = getById(user.getId());
         super.updateCachedItem(user);
-        if (user.getToken() != null) {
-            usersTokens.put(user.getToken(), user.getId());
-        }
+        putToken(user);
         if (cachedUser.getToken() != null && !cachedUser.getToken().equals(user.getToken())) {
             usersTokens.remove(cachedUser.getToken());
         }
@@ -82,7 +80,7 @@ public class UsersManager extends SimpleObjectManager<User> {
     }
 
     public User getUserByToken(String token) {
-        return getById(usersTokens.get(token));
+        return usersTokens.get(token);
     }
 
 }


### PR DESCRIPTION
There was a `NullPointerException` if we try to get object by unknown uniqueId or token.
I suppose there is no difference what to map String->Long or String->User, these are only links.
Replaced map to objects itself and now we correctly get `null` in `getByXXX` functions without additional checks. Also it is consistent with `DeviceManager`