### PR TITLE
Avoid unneeded log record and fix table name constructions

### DIFF
--- a/src/org/traccar/database/DataManager.java
+++ b/src/org/traccar/database/DataManager.java
@@ -222,11 +222,13 @@ public class DataManager {
             }
         }
         String query = config.getString(queryName);
-        if (query == null && generateQueries) {
-            query = constructObjectQuery(action, clazz, extended);
-            config.setString(queryName, query);
-        } else {
-            Log.info("Query not provided: " + queryName);
+        if (query == null) {
+            if (generateQueries) {
+                query = constructObjectQuery(action, clazz, extended);
+                config.setString(queryName, query);
+            } else {
+                Log.info("Query not provided: " + queryName);
+            }
         }
 
         return query;
@@ -242,11 +244,14 @@ public class DataManager {
             queryName = "database.unlink" + owner.getSimpleName() + property.getSimpleName();
         }
         String query = config.getString(queryName);
-        if (query == null && generateQueries) {
-            query = constructPermissionQuery(action, owner, property.equals(User.class) ? ManagedUser.class : property);
-            config.setString(queryName, query);
-        } else {
-            Log.info("Query not provided: " + queryName);
+        if (query == null) {
+            if (generateQueries) {
+                query = constructPermissionQuery(action, owner,
+                        property.equals(User.class) ? ManagedUser.class : property);
+                config.setString(queryName, query);
+            } else {
+                Log.info("Query not provided: " + queryName);
+            }
         }
 
         return query;
@@ -261,7 +266,11 @@ public class DataManager {
     }
 
     private static String getObjectsTableName(Class<?> clazz) {
-        return Introspector.decapitalize(clazz.getSimpleName()) + "s";
+        String result = Introspector.decapitalize(clazz.getSimpleName());
+        if (!result.endsWith("s")) {
+            result += "s";
+        }
+        return result;
     }
 
     private void initDatabaseSchema() throws SQLException, LiquibaseException {

--- a/src/org/traccar/database/DataManager.java
+++ b/src/org/traccar/database/DataManager.java
@@ -267,6 +267,7 @@ public class DataManager {
 
     private static String getObjectsTableName(Class<?> clazz) {
         String result = Introspector.decapitalize(clazz.getSimpleName());
+        // Add "s" ending if object name is not plural already
         if (!result.endsWith("s")) {
             result += "s";
         }


### PR DESCRIPTION
Two fixes:
- IF condition was wrong, log record was made if `query != null`. fixed that
- noticed incorrect table name construction
````
2017-08-02 00:10:12  WARN: Table 'traccar.statisticss' doesn't exist - MySQLSyntaxErrorException (... < QueryBuilder:477 < DataManager:445 < StatisticsManager:64 < ...)
````
There was two options: correct table name construction or rename `Statistics` to `Statistic` for consistence, decide first one. If it is better second, i'm ready to rename.