### PR TITLE
Implement delayed stop/motion events

### DIFF
--- a/src/org/traccar/Context.java
+++ b/src/org/traccar/Context.java
@@ -35,6 +35,7 @@ import org.traccar.database.DeviceManager;
 import org.traccar.database.DriversManager;
 import org.traccar.database.IdentityManager;
 import org.traccar.database.MediaManager;
+import org.traccar.database.MotionManager;
 import org.traccar.database.NotificationManager;
 import org.traccar.database.PermissionsManager;
 import org.traccar.database.GeofenceManager;
@@ -229,6 +230,12 @@ public final class Context {
         return smppClient;
     }
 
+    private static MotionManager motionManager;
+
+    public static MotionManager getMotionManager() {
+        return motionManager;
+    }
+
     public static void init(String[] arguments) throws Exception {
 
         config = new Config();
@@ -368,6 +375,11 @@ public final class Context {
 
         if (config.getBoolean("sms.smpp.enable")) {
             smppClient = new SmppClient();
+        }
+
+        if (config.getLong("event.motion.stopDelay") > 0 || config.getLong("event.motion.motionDelay") > 0) {
+            motionManager = new MotionManager(config.getLong("event.motion.stopDelay"),
+                    config.getLong("event.motion.motionDelay"));
         }
 
     }

--- a/src/org/traccar/database/MotionManager.java
+++ b/src/org/traccar/database/MotionManager.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.database;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.netty.util.Timeout;
+import org.jboss.netty.util.TimerTask;
+import org.traccar.Context;
+import org.traccar.GlobalTimer;
+import org.traccar.model.Event;
+import org.traccar.model.Position;
+
+public class MotionManager {
+
+    private final long stopTimeout;
+    private final long motionTimeout;
+
+    private final Map<Long, Timeout> stopTimeouts = new ConcurrentHashMap<>();
+    private final Map<Long, Timeout> motionTimeouts = new ConcurrentHashMap<>();
+
+    public MotionManager(long stopDelay, long motionDelay) {
+        stopTimeout = stopDelay * 1000;
+        motionTimeout = motionDelay * 1000;
+    }
+
+    public void updateDeviceMotion(final Position position, boolean oldMotion) {
+        boolean motion = position.getBoolean(Position.KEY_MOTION);
+        long deviceId = position.getDeviceId();
+        if (!motion) {
+            Timeout motionTimeout = motionTimeouts.remove(deviceId);
+            if (motionTimeout != null) {
+                motionTimeout.cancel();
+            }
+            if (oldMotion && (motionTimeout == null || !motionTimeout.isCancelled())
+                    && !stopTimeouts.containsKey(deviceId)) {
+                stopTimeouts.put(deviceId, GlobalTimer.getTimer().newTimeout(new TimerTask() {
+                    @Override
+                    public void run(Timeout timeout) throws Exception {
+                        if (!timeout.isCancelled() && Context.getNotificationManager() != null) {
+                            Context.getNotificationManager().updateEvent(
+                                    new Event(Event.TYPE_DEVICE_STOPPED, position.getDeviceId(), position.getId()),
+                                    position);
+                        }
+                    }
+                }, stopTimeout, TimeUnit.MILLISECONDS));
+            }
+        } else {
+            Timeout stopTimeout = stopTimeouts.remove(deviceId);
+            if (stopTimeout != null) {
+                stopTimeout.cancel();
+            }
+            if (!oldMotion && (stopTimeout == null || !stopTimeout.isCancelled())
+                    && !motionTimeouts.containsKey(deviceId)) {
+                motionTimeouts.put(deviceId, GlobalTimer.getTimer().newTimeout(new TimerTask() {
+                    @Override
+                    public void run(Timeout timeout) throws Exception {
+                        if (!timeout.isCancelled() && Context.getNotificationManager() != null) {
+                            Context.getNotificationManager().updateEvent(
+                                    new Event(Event.TYPE_DEVICE_MOVING, position.getDeviceId(), position.getId()),
+                                    position);
+                        }
+                    }
+                }, motionTimeout, TimeUnit.MILLISECONDS));
+            }
+        }
+    }
+
+}

--- a/src/org/traccar/events/MotionEventHandler.java
+++ b/src/org/traccar/events/MotionEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2016 - 2017 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,12 +43,16 @@ public class MotionEventHandler extends BaseEventHandler {
         if (lastPosition != null) {
             oldMotion = lastPosition.getBoolean(Position.KEY_MOTION);
         }
-        if (motion && !oldMotion) {
-            return Collections.singleton(
-                    new Event(Event.TYPE_DEVICE_MOVING, position.getDeviceId(), position.getId()));
-        } else if (!motion && oldMotion) {
-            return Collections.singleton(
-                    new Event(Event.TYPE_DEVICE_STOPPED, position.getDeviceId(), position.getId()));
+        if (Context.getMotionManager() != null) {
+            Context.getMotionManager().updateDeviceMotion(position, oldMotion);
+        } else {
+            if (motion && !oldMotion) {
+                return Collections.singleton(
+                        new Event(Event.TYPE_DEVICE_MOVING, position.getDeviceId(), position.getId()));
+            } else if (!motion && oldMotion) {
+                return Collections.singleton(
+                        new Event(Event.TYPE_DEVICE_STOPPED, position.getDeviceId(), position.getId()));
+            }
         }
         return null;
     }


### PR DESCRIPTION
Here is long-awaited feature: delayed stop/motion events. It may help avoid false events in traffic jams or fluctuations on parking.

It was inspired by timers used in `ConnectionManager`

If config parameters are not defined, old scheme is working (in case some resources troubles or for tests)
