### PR TITLE
Remove "mail.smtp.auth" parameter

### DIFF
--- a/src/org/traccar/notification/NotificationMail.java
+++ b/src/org/traccar/notification/NotificationMail.java
@@ -68,8 +68,6 @@ public final class NotificationMail {
                 properties.put("mail.smtp.ssl.protocols", sslProtocols);
             }
 
-            properties.put("mail.smtp.auth", provider.getString("mail.smtp.auth"));
-
             String username = provider.getString("mail.smtp.username");
             if (username != null) {
                 properties.put("mail.smtp.username", username);


### PR DESCRIPTION
fix #3417 

We do not need it, because it automatically enabled if username and password provided.