### PR TITLE
Implement delayed overspeed events

### DIFF
--- a/src/org/traccar/BasePipelineFactory.java
+++ b/src/org/traccar/BasePipelineFactory.java
@@ -165,9 +165,9 @@ public abstract class BasePipelineFactory implements ChannelPipelineFactory {
 
         if (Context.getConfig().getBoolean("event.enable")) {
             commandResultEventHandler = new CommandResultEventHandler();
-            overspeedEventHandler = new OverspeedEventHandler();
+            overspeedEventHandler = Context.getOverspeedEventHandler();
             fuelDropEventHandler = new FuelDropEventHandler();
-            motionEventHandler = new MotionEventHandler();
+            motionEventHandler = Context.getMotionEventHandler();
             geofenceEventHandler = new GeofenceEventHandler();
             alertEventHandler = new AlertEventHandler();
             ignitionEventHandler = new IgnitionEventHandler();

--- a/src/org/traccar/Context.java
+++ b/src/org/traccar/Context.java
@@ -41,6 +41,8 @@ import org.traccar.database.GeofenceManager;
 import org.traccar.database.GroupsManager;
 import org.traccar.database.StatisticsManager;
 import org.traccar.database.UsersManager;
+import org.traccar.events.MotionEventHandler;
+import org.traccar.events.OverspeedEventHandler;
 import org.traccar.geocoder.BingMapsGeocoder;
 import org.traccar.geocoder.FactualGeocoder;
 import org.traccar.geocoder.GeocodeFarmGeocoder;
@@ -65,6 +67,7 @@ import org.traccar.geolocation.GeolocationProvider;
 import org.traccar.geolocation.MozillaGeolocationProvider;
 import org.traccar.geolocation.OpenCellIdGeolocationProvider;
 import org.traccar.notification.EventForwarder;
+import org.traccar.reports.ReportUtils;
 import org.traccar.smpp.SmppClient;
 import org.traccar.web.WebServer;
 
@@ -229,6 +232,18 @@ public final class Context {
         return smppClient;
     }
 
+    private static MotionEventHandler motionEventHandler;
+
+    public static MotionEventHandler getMotionEventHandler() {
+        return motionEventHandler;
+    }
+
+    private static OverspeedEventHandler overspeedEventHandler;
+
+    public static OverspeedEventHandler getOverspeedEventHandler() {
+        return overspeedEventHandler;
+    }
+
     public static void init(String[] arguments) throws Exception {
 
         config = new Config();
@@ -350,6 +365,11 @@ public final class Context {
 
             velocityEngine = new VelocityEngine();
             velocityEngine.init(velocityProperties);
+
+            motionEventHandler = new MotionEventHandler(ReportUtils.initTripsConfig());
+            overspeedEventHandler = new OverspeedEventHandler(
+                    Context.getConfig().getLong("event.overspeed.minimalDuration") * 1000,
+                    Context.getConfig().getBoolean("event.overspeed.notRepeat"));
         }
 
         serverManager = new ServerManager();

--- a/src/org/traccar/Context.java
+++ b/src/org/traccar/Context.java
@@ -67,7 +67,7 @@ import org.traccar.geolocation.GeolocationProvider;
 import org.traccar.geolocation.MozillaGeolocationProvider;
 import org.traccar.geolocation.OpenCellIdGeolocationProvider;
 import org.traccar.notification.EventForwarder;
-import org.traccar.reports.ReportUtils;
+import org.traccar.reports.model.TripsConfig;
 import org.traccar.smpp.SmppClient;
 import org.traccar.web.WebServer;
 
@@ -244,6 +244,21 @@ public final class Context {
         return overspeedEventHandler;
     }
 
+    private static TripsConfig tripsConfig;
+
+    public static TripsConfig getTripsConfig() {
+        return tripsConfig;
+    }
+
+    public static TripsConfig initTripsConfig() {
+        return new TripsConfig(
+                config.getLong("report.trip.minimalTripDistance", 500),
+                config.getLong("report.trip.minimalTripDuration", 300) * 1000,
+                config.getLong("report.trip.minimalParkingDuration", 300) * 1000,
+                config.getBoolean("report.trip.greedyParking"),
+                config.getLong("report.trip.minimalNoDataDuration", 3600) * 1000);
+    }
+
     public static void init(String[] arguments) throws Exception {
 
         config = new Config();
@@ -342,6 +357,8 @@ public final class Context {
 
         connectionManager = new ConnectionManager();
 
+        tripsConfig = initTripsConfig();
+
         if (config.getBoolean("event.enable")) {
             geofenceManager = new GeofenceManager(dataManager);
             calendarManager = new CalendarManager(dataManager);
@@ -366,7 +383,7 @@ public final class Context {
             velocityEngine = new VelocityEngine();
             velocityEngine.init(velocityProperties);
 
-            motionEventHandler = new MotionEventHandler(ReportUtils.initTripsConfig());
+            motionEventHandler = new MotionEventHandler(tripsConfig);
             overspeedEventHandler = new OverspeedEventHandler(
                     Context.getConfig().getLong("event.overspeed.minimalDuration") * 1000,
                     Context.getConfig().getBoolean("event.overspeed.notRepeat"));

--- a/src/org/traccar/database/ConnectionManager.java
+++ b/src/org/traccar/database/ConnectionManager.java
@@ -21,6 +21,7 @@ import org.jboss.netty.util.TimerTask;
 import org.traccar.Context;
 import org.traccar.GlobalTimer;
 import org.traccar.Protocol;
+import org.traccar.events.OverspeedEventHandler;
 import org.traccar.helper.Log;
 import org.traccar.model.Device;
 import org.traccar.model.DeviceState;
@@ -44,7 +45,10 @@ public class ConnectionManager {
 
     private final long deviceTimeout;
     private final boolean enableStatusEvents;
+    private final boolean updateDeviceState;
     private TripsConfig tripsConfig = null;
+    private long minimalOverspeedDuration;
+    private boolean overspeedNotRepeat;
 
     private final Map<Long, ActiveDevice> activeDevices = new ConcurrentHashMap<>();
     private final Map<Long, Set<UpdateListener>> listeners = new ConcurrentHashMap<>();
@@ -53,8 +57,11 @@ public class ConnectionManager {
     public ConnectionManager() {
         deviceTimeout = Context.getConfig().getLong("status.timeout", DEFAULT_TIMEOUT) * 1000;
         enableStatusEvents = Context.getConfig().getBoolean("event.enable");
-        if (Context.getConfig().getBoolean("status.updateDeviceState")) {
+        updateDeviceState = Context.getConfig().getBoolean("status.updateDeviceState");
+        if (updateDeviceState) {
             tripsConfig = ReportUtils.initTripsConfig();
+            minimalOverspeedDuration = Context.getConfig().getLong("event.overspeed.minimalDuration") * 1000;
+            overspeedNotRepeat = Context.getConfig().getBoolean("event.overspeed.notRepeat");
         }
     }
 
@@ -87,27 +94,23 @@ public class ConnectionManager {
 
         if (enableStatusEvents && !status.equals(oldStatus)) {
             String eventType;
-            Event stateEvent = null;
+            Set<Event> events = new HashSet<>();
             switch (status) {
                 case Device.STATUS_ONLINE:
                     eventType = Event.TYPE_DEVICE_ONLINE;
                     break;
                 case Device.STATUS_UNKNOWN:
                     eventType = Event.TYPE_DEVICE_UNKNOWN;
-                    if (tripsConfig != null) {
-                        stateEvent = updateDeviceState(deviceId);
+                    if (updateDeviceState) {
+                        events.addAll(updateDeviceState(deviceId));
                     }
                     break;
                 default:
                     eventType = Event.TYPE_DEVICE_OFFLINE;
-                    if (tripsConfig != null) {
-                        stateEvent = updateDeviceState(deviceId);
+                    if (updateDeviceState) {
+                        events.addAll(updateDeviceState(deviceId));
                     }
                     break;
-            }
-            Set<Event> events = new HashSet<>();
-            if (stateEvent != null) {
-                events.add(stateEvent);
             }
             events.add(new Event(eventType, deviceId));
             Context.getNotificationManager().updateEvents(events, null);
@@ -142,26 +145,41 @@ public class ConnectionManager {
         updateDevice(device);
     }
 
-    public Event updateDeviceState(long deviceId) {
+    public Set<Event> updateDeviceState(long deviceId) {
         DeviceState deviceState = Context.getDeviceManager().getDeviceState(deviceId);
-        if (deviceState == null || deviceState.getMotionState() == null) {
-            return null;
-        }
-        Event result = null;
-        Boolean oldMotion = deviceState.getMotionState();
+        Set<Event> result = new HashSet<>();
         long currentTime = System.currentTimeMillis();
-        boolean newMotion = !oldMotion;
-        Position motionPosition = deviceState.getMotionPosition();
-        if (motionPosition != null) {
+        if (deviceState.getMotionState() != null && deviceState.getMotionPosition() != null) {
+            boolean newMotion = !deviceState.getMotionState();
+            Position motionPosition = deviceState.getMotionPosition();
             long motionTime = motionPosition.getFixTime().getTime()
                     + (newMotion ? tripsConfig.getMinimalTripDuration() : tripsConfig.getMinimalParkingDuration());
             if (motionTime <= currentTime) {
                 String eventType = newMotion ? Event.TYPE_DEVICE_MOVING : Event.TYPE_DEVICE_STOPPED;
-                result = new Event(eventType, motionPosition.getDeviceId(), motionPosition.getId());
+                result.add(new Event(eventType, motionPosition.getDeviceId(), motionPosition.getId()));
                 deviceState.setMotionState(newMotion);
                 deviceState.setMotionPosition(null);
             }
         }
+        if (deviceState.getOverspeedState() != null && !deviceState.getOverspeedState()
+                && deviceState.getOverspeedPosition() != null) {
+            double speedLimit = Context.getDeviceManager().lookupAttributeDouble(deviceId,
+                    OverspeedEventHandler.ATTRIBUTE_SPEED_LIMIT, 0, false);
+            if (speedLimit != 0) {
+                Position overspeedPosition = deviceState.getOverspeedPosition();
+                long overspeedTime = overspeedPosition.getFixTime().getTime();
+                if (overspeedTime + minimalOverspeedDuration <= currentTime) {
+                    Event event = new Event(Event.TYPE_DEVICE_OVERSPEED, overspeedPosition.getDeviceId(),
+                            overspeedPosition.getId());
+                    event.set("speed", overspeedPosition.getSpeed());
+                    event.set(OverspeedEventHandler.ATTRIBUTE_SPEED_LIMIT, speedLimit);
+                    result.add(event);
+                    deviceState.setOverspeedState(overspeedNotRepeat);
+                    deviceState.setOverspeedPosition(null);
+                }
+            }
+        }
+
         return result;
     }
 

--- a/src/org/traccar/database/DeviceManager.java
+++ b/src/org/traccar/database/DeviceManager.java
@@ -392,7 +392,12 @@ public class DeviceManager extends BaseObjectManager<Device> implements Identity
     }
 
     public DeviceState getDeviceState(long deviceId) {
-        return deviceStates.get(deviceId);
+        DeviceState deviceState = deviceStates.get(deviceId);
+        if (deviceState == null) {
+            deviceState = new DeviceState();
+            deviceStates.put(deviceId, deviceState);
+        }
+        return deviceState;
     }
 
     public void setDeviceState(long deviceId, DeviceState deviceState) {

--- a/src/org/traccar/events/MotionEventHandler.java
+++ b/src/org/traccar/events/MotionEventHandler.java
@@ -36,6 +36,24 @@ public class MotionEventHandler extends BaseEventHandler {
         tripsConfig = ReportUtils.initTripsConfig();
     }
 
+    public static Event updateMotionState(DeviceState deviceState, TripsConfig tripsConfig) {
+        Event result = null;
+        if (deviceState.getMotionState() != null && deviceState.getMotionPosition() != null) {
+            boolean newMotion = !deviceState.getMotionState();
+            Position motionPosition = deviceState.getMotionPosition();
+            long currentTime = System.currentTimeMillis();
+            long motionTime = motionPosition.getFixTime().getTime()
+                    + (newMotion ? tripsConfig.getMinimalTripDuration() : tripsConfig.getMinimalParkingDuration());
+            if (motionTime <= currentTime) {
+                String eventType = newMotion ? Event.TYPE_DEVICE_MOVING : Event.TYPE_DEVICE_STOPPED;
+                result = new Event(eventType, motionPosition.getDeviceId(), motionPosition.getId());
+                deviceState.setMotionState(newMotion);
+                deviceState.setMotionPosition(null);
+            }
+        }
+        return result;
+    }
+
     public static Event updateMotionState(DeviceState deviceState, Position position, TripsConfig tripsConfig) {
         Event result = null;
         Boolean oldMotion = deviceState.getMotionState();

--- a/src/org/traccar/events/MotionEventHandler.java
+++ b/src/org/traccar/events/MotionEventHandler.java
@@ -77,7 +77,8 @@ public class MotionEventHandler extends BaseEventHandler {
     @Override
     protected Collection<Event> analyzePosition(Position position) {
 
-        Device device = Context.getIdentityManager().getById(position.getDeviceId());
+        long deviceId = position.getDeviceId();
+        Device device = Context.getIdentityManager().getById(deviceId);
         if (device == null) {
             return null;
         }
@@ -86,14 +87,9 @@ public class MotionEventHandler extends BaseEventHandler {
         }
 
         Event result = null;
-
-        long deviceId = position.getDeviceId();
         DeviceState deviceState = Context.getDeviceManager().getDeviceState(deviceId);
 
-        if (deviceState == null) {
-            deviceState = new DeviceState();
-            deviceState.setMotionState(position.getBoolean(Position.KEY_MOTION));
-        } else if (deviceState.getMotionState() == null) {
+        if (deviceState.getMotionState() == null) {
             deviceState.setMotionState(position.getBoolean(Position.KEY_MOTION));
         } else {
             result = updateMotionState(deviceState, position, tripsConfig);

--- a/src/org/traccar/events/OverspeedEventHandler.java
+++ b/src/org/traccar/events/OverspeedEventHandler.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import org.traccar.BaseEventHandler;
 import org.traccar.Context;
 import org.traccar.model.Device;
+import org.traccar.model.DeviceState;
 import org.traccar.model.Event;
 import org.traccar.model.Position;
 
@@ -29,15 +30,51 @@ public class OverspeedEventHandler extends BaseEventHandler {
     public static final String ATTRIBUTE_SPEED_LIMIT = "speedLimit";
 
     private boolean notRepeat;
+    private long minimalDuration;
 
     public OverspeedEventHandler() {
         notRepeat = Context.getConfig().getBoolean("event.overspeed.notRepeat");
+        minimalDuration = Context.getConfig().getLong("event.overspeed.minimalDuration") * 1000;
+    }
+
+    public static Event updateOverspeedState(DeviceState deviceState, Position position, double speedLimit,
+            long minimalOverspeedDuration, boolean notRepeat) {
+        Event result = null;
+
+        Boolean oldOverspeed = deviceState.getOverspeedState();
+
+        long currentTime = position.getFixTime().getTime();
+        boolean newOverspeed = position.getSpeed() > speedLimit;
+        if (newOverspeed && !oldOverspeed) {
+            if (deviceState.getOverspeedPosition() == null) {
+                deviceState.setOverspeedPosition(position);
+            }
+        } else if (oldOverspeed && !newOverspeed) {
+            deviceState.setOverspeedState(false);
+            deviceState.setOverspeedPosition(null);
+        } else {
+            deviceState.setOverspeedPosition(null);
+        }
+        Position overspeedPosition = deviceState.getOverspeedPosition();
+        if (overspeedPosition != null) {
+            long overspeedTime = overspeedPosition.getFixTime().getTime();
+            if (newOverspeed && overspeedTime + minimalOverspeedDuration <= currentTime) {
+                result = new Event(Event.TYPE_DEVICE_OVERSPEED, overspeedPosition.getDeviceId(),
+                        overspeedPosition.getId());
+                result.set("speed", overspeedPosition.getSpeed());
+                result.set(ATTRIBUTE_SPEED_LIMIT, speedLimit);
+                deviceState.setOverspeedState(notRepeat);
+                deviceState.setOverspeedPosition(null);
+            }
+        }
+        return result;
     }
 
     @Override
     protected Collection<Event> analyzePosition(Position position) {
 
-        Device device = Context.getIdentityManager().getById(position.getDeviceId());
+        long deviceId = position.getDeviceId();
+        Device device = Context.getIdentityManager().getById(deviceId);
         if (device == null) {
             return null;
         }
@@ -45,24 +82,23 @@ public class OverspeedEventHandler extends BaseEventHandler {
             return null;
         }
 
-        double speed = position.getSpeed();
-        double speedLimit = Context.getDeviceManager()
-                .lookupAttributeDouble(device.getId(), ATTRIBUTE_SPEED_LIMIT, 0, false);
+        double speedLimit = Context.getDeviceManager().lookupAttributeDouble(deviceId, ATTRIBUTE_SPEED_LIMIT, 0, false);
         if (speedLimit == 0) {
             return null;
         }
-        double oldSpeed = 0;
-        if (notRepeat) {
-            Position lastPosition = Context.getIdentityManager().getLastPosition(position.getDeviceId());
-            if (lastPosition != null) {
-                oldSpeed = lastPosition.getSpeed();
-            }
+
+        Event result = null;
+        DeviceState deviceState = Context.getDeviceManager().getDeviceState(deviceId);
+
+        if (deviceState.getOverspeedState() == null) {
+            deviceState.setOverspeedState(position.getSpeed() > speedLimit);
+        } else {
+            result = updateOverspeedState(deviceState, position, speedLimit, minimalDuration, notRepeat);
         }
-        if (speed > speedLimit && oldSpeed <= speedLimit) {
-            Event event = new Event(Event.TYPE_DEVICE_OVERSPEED, position.getDeviceId(), position.getId());
-            event.set("speed", speed);
-            event.set(ATTRIBUTE_SPEED_LIMIT, speedLimit);
-            return Collections.singleton(event);
+
+        Context.getDeviceManager().setDeviceState(deviceId, deviceState);
+        if (result != null) {
+            return Collections.singleton(result);
         }
         return null;
     }

--- a/src/org/traccar/events/OverspeedEventHandler.java
+++ b/src/org/traccar/events/OverspeedEventHandler.java
@@ -37,6 +37,26 @@ public class OverspeedEventHandler extends BaseEventHandler {
         minimalDuration = Context.getConfig().getLong("event.overspeed.minimalDuration") * 1000;
     }
 
+    public static Event updateOverspeedState(DeviceState deviceState, double speedLimit,
+            long minimalDuration, boolean notRepeat) {
+        Event result = null;
+        if (deviceState.getOverspeedState() != null && !deviceState.getOverspeedState()
+                && deviceState.getOverspeedPosition() != null && speedLimit != 0) {
+            long currentTime = System.currentTimeMillis();
+            Position overspeedPosition = deviceState.getOverspeedPosition();
+            long overspeedTime = overspeedPosition.getFixTime().getTime();
+            if (overspeedTime + minimalDuration <= currentTime) {
+                result = new Event(Event.TYPE_DEVICE_OVERSPEED, overspeedPosition.getDeviceId(),
+                        overspeedPosition.getId());
+                result.set("speed", overspeedPosition.getSpeed());
+                result.set(ATTRIBUTE_SPEED_LIMIT, speedLimit);
+                deviceState.setOverspeedState(notRepeat);
+                deviceState.setOverspeedPosition(null);
+            }
+        }
+        return result;
+    }
+
     public static Event updateOverspeedState(DeviceState deviceState, Position position, double speedLimit,
             long minimalOverspeedDuration, boolean notRepeat) {
         Event result = null;

--- a/src/org/traccar/model/DeviceState.java
+++ b/src/org/traccar/model/DeviceState.java
@@ -38,4 +38,24 @@ public class DeviceState {
         return motionPosition;
     }
 
+    private Boolean overspeedState;
+
+    public void setOverspeedState(boolean overspeedState) {
+        this.overspeedState = overspeedState;
+    }
+
+    public Boolean getOverspeedState() {
+        return overspeedState;
+    }
+
+    private Position overspeedPosition;
+
+    public void setOverspeedPosition(Position overspeedPosition) {
+        this.overspeedPosition = overspeedPosition;
+    }
+
+    public Position getOverspeedPosition() {
+        return overspeedPosition;
+    }
+
 }

--- a/src/org/traccar/reports/ReportUtils.java
+++ b/src/org/traccar/reports/ReportUtils.java
@@ -155,15 +155,6 @@ public final class ReportUtils {
         transformer.write();
     }
 
-    public static TripsConfig initTripsConfig() {
-        return new TripsConfig(
-                Context.getConfig().getLong("report.trip.minimalTripDistance", 500),
-                Context.getConfig().getLong("report.trip.minimalTripDuration", 300) * 1000,
-                Context.getConfig().getLong("report.trip.minimalParkingDuration", 300) * 1000,
-                Context.getConfig().getBoolean("report.trip.greedyParking"),
-                Context.getConfig().getLong("report.trip.minimalNoDataDuration", 3600) * 1000);
-    }
-
     private static TripReport calculateTrip(
             ArrayList<Position> positions, int startIndex, int endIndex, boolean ignoreOdometer) {
         Position startTrip = positions.get(startIndex);

--- a/src/org/traccar/reports/Stops.java
+++ b/src/org/traccar/reports/Stops.java
@@ -33,7 +33,6 @@ import org.traccar.model.Group;
 import org.traccar.reports.model.BaseReport;
 import org.traccar.reports.model.DeviceReport;
 import org.traccar.reports.model.StopReport;
-import org.traccar.reports.model.TripsConfig;
 
 public final class Stops {
 
@@ -43,13 +42,11 @@ public final class Stops {
     private static Collection<StopReport> detectStops(long deviceId, Date from, Date to) throws SQLException {
         double speedThreshold = Context.getConfig().getDouble("event.motion.speedThreshold", 0.01);
 
-        TripsConfig tripsConfig = ReportUtils.initTripsConfig();
-
         boolean ignoreOdometer = Context.getDeviceManager()
                 .lookupAttributeBoolean(deviceId, "report.ignoreOdometer", false, true);
 
-        Collection<? extends BaseReport> result = ReportUtils.detectTripsAndStops(tripsConfig,
-                ignoreOdometer, speedThreshold,
+        Collection<? extends BaseReport> result = ReportUtils.detectTripsAndStops(
+                Context.getTripsConfig(), ignoreOdometer, speedThreshold,
                 Context.getDataManager().getPositions(deviceId, from, to), false);
 
         return (Collection<StopReport>) result;

--- a/src/org/traccar/reports/Trips.java
+++ b/src/org/traccar/reports/Trips.java
@@ -32,7 +32,6 @@ import org.traccar.model.Group;
 import org.traccar.reports.model.BaseReport;
 import org.traccar.reports.model.DeviceReport;
 import org.traccar.reports.model.TripReport;
-import org.traccar.reports.model.TripsConfig;
 
 public final class Trips {
 
@@ -42,13 +41,11 @@ public final class Trips {
     private static Collection<TripReport> detectTrips(long deviceId, Date from, Date to) throws SQLException {
         double speedThreshold = Context.getConfig().getDouble("event.motion.speedThreshold", 0.01);
 
-        TripsConfig tripsConfig = ReportUtils.initTripsConfig();
-
         boolean ignoreOdometer = Context.getDeviceManager()
                 .lookupAttributeBoolean(deviceId, "report.ignoreOdometer", false, true);
 
-        Collection<? extends BaseReport> result = ReportUtils.detectTripsAndStops(tripsConfig,
-                ignoreOdometer, speedThreshold,
+        Collection<? extends BaseReport> result = ReportUtils.detectTripsAndStops(
+                Context.getTripsConfig(), ignoreOdometer, speedThreshold,
                 Context.getDataManager().getPositions(deviceId, from, to), true);
 
         return (Collection<TripReport>) result;

--- a/test/org/traccar/events/MotionEventHandlerTest.java
+++ b/test/org/traccar/events/MotionEventHandlerTest.java
@@ -27,7 +27,7 @@ public class MotionEventHandlerTest extends BaseTest {
     }
 
     @Test
-    public void testMotionEventHandler() throws Exception {
+    public void testMotionWithPosition() throws Exception {
         TripsConfig tripsConfig = new TripsConfig(500, 300 * 1000, 300 * 1000, false, 0);
 
         Position position = new Position();
@@ -58,6 +58,25 @@ public class MotionEventHandlerTest extends BaseTest {
         nextPosition.setTime(date("2017-01-01 00:06:00"));
         nextPosition.set(Position.KEY_TOTAL_DISTANCE, 200);
         event = MotionEventHandler.updateMotionState(deviceState, nextPosition, tripsConfig);
+        assertNotNull(event);
+        assertEquals(Event.TYPE_DEVICE_MOVING, event.getType());
+        assertTrue(deviceState.getMotionState());
+        assertNull(deviceState.getMotionPosition());
+    }
+
+    @Test
+    public void testMotionWithStatus() throws Exception {
+        TripsConfig tripsConfig = new TripsConfig(500, 300 * 1000, 300 * 1000, false, 0);
+
+        Position position = new Position();
+        position.setTime(new Date(System.currentTimeMillis() - 360000));
+        position.set(Position.KEY_MOTION, true);
+        DeviceState deviceState = new DeviceState();
+        deviceState.setMotionState(false);
+        deviceState.setMotionPosition(position);
+
+        Event event = MotionEventHandler.updateMotionState(deviceState, tripsConfig);
+
         assertNotNull(event);
         assertEquals(Event.TYPE_DEVICE_MOVING, event.getType());
         assertTrue(deviceState.getMotionState());

--- a/test/org/traccar/events/MotionEventHandlerTest.java
+++ b/test/org/traccar/events/MotionEventHandlerTest.java
@@ -28,7 +28,8 @@ public class MotionEventHandlerTest extends BaseTest {
 
     @Test
     public void testMotionWithPosition() throws Exception {
-        TripsConfig tripsConfig = new TripsConfig(500, 300 * 1000, 300 * 1000, false, 0);
+        MotionEventHandler motionEventHandler = new MotionEventHandler(
+                new TripsConfig(500, 300 * 1000, 300 * 1000, false, 0));
 
         Position position = new Position();
         position.setTime(date("2017-01-01 00:00:00"));
@@ -43,11 +44,11 @@ public class MotionEventHandlerTest extends BaseTest {
         nextPosition.set(Position.KEY_MOTION, true);
         nextPosition.set(Position.KEY_TOTAL_DISTANCE, 200);
 
-        Event event = MotionEventHandler.updateMotionState(deviceState, nextPosition, tripsConfig);
+        Event event = motionEventHandler.updateMotionState(deviceState, nextPosition);
         assertNull(event);
 
         nextPosition.set(Position.KEY_TOTAL_DISTANCE, 600);
-        event = MotionEventHandler.updateMotionState(deviceState, nextPosition, tripsConfig);        
+        event = motionEventHandler.updateMotionState(deviceState, nextPosition);        
         assertNotNull(event);
         assertEquals(Event.TYPE_DEVICE_MOVING, event.getType());
         assertTrue(deviceState.getMotionState());
@@ -57,7 +58,7 @@ public class MotionEventHandlerTest extends BaseTest {
         deviceState.setMotionPosition(position);
         nextPosition.setTime(date("2017-01-01 00:06:00"));
         nextPosition.set(Position.KEY_TOTAL_DISTANCE, 200);
-        event = MotionEventHandler.updateMotionState(deviceState, nextPosition, tripsConfig);
+        event = motionEventHandler.updateMotionState(deviceState, nextPosition);
         assertNotNull(event);
         assertEquals(Event.TYPE_DEVICE_MOVING, event.getType());
         assertTrue(deviceState.getMotionState());
@@ -66,7 +67,8 @@ public class MotionEventHandlerTest extends BaseTest {
 
     @Test
     public void testMotionWithStatus() throws Exception {
-        TripsConfig tripsConfig = new TripsConfig(500, 300 * 1000, 300 * 1000, false, 0);
+        MotionEventHandler motionEventHandler = new MotionEventHandler(
+                new TripsConfig(500, 300 * 1000, 300 * 1000, false, 0));
 
         Position position = new Position();
         position.setTime(new Date(System.currentTimeMillis() - 360000));
@@ -75,7 +77,7 @@ public class MotionEventHandlerTest extends BaseTest {
         deviceState.setMotionState(false);
         deviceState.setMotionPosition(position);
 
-        Event event = MotionEventHandler.updateMotionState(deviceState, tripsConfig);
+        Event event = motionEventHandler.updateMotionState(deviceState);
 
         assertNotNull(event);
         assertEquals(Event.TYPE_DEVICE_MOVING, event.getType());

--- a/test/org/traccar/events/OverspeedEventHandlerTest.java
+++ b/test/org/traccar/events/OverspeedEventHandlerTest.java
@@ -2,7 +2,6 @@ package org.traccar.events;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -26,7 +25,7 @@ public class OverspeedEventHandlerTest  extends BaseTest {
         return dateFormat.parse(time);
     }
 
-    private void testOverspeed(boolean notRepeat) throws Exception {
+    private void testOverspeedWithPosition(boolean notRepeat) throws Exception {
         Position position = new Position();
         position.setTime(date("2017-01-01 00:00:00"));
         position.setSpeed(50);
@@ -55,12 +54,12 @@ public class OverspeedEventHandlerTest  extends BaseTest {
 
         assertEquals(notRepeat, deviceState.getOverspeedState());
         assertNull(deviceState.getOverspeedPosition());
-        
+
         nextPosition.setTime(date("2017-01-01 00:00:30"));
         event = OverspeedEventHandler.updateOverspeedState(deviceState, nextPosition, 40, 15000, notRepeat);
         assertNull(event);
         assertEquals(notRepeat, deviceState.getOverspeedState());
-        
+
         if (notRepeat) {
             assertNull(deviceState.getOverspeedPosition());
         } else {
@@ -76,10 +75,29 @@ public class OverspeedEventHandlerTest  extends BaseTest {
         assertNull(deviceState.getOverspeedPosition());
     }
 
+    private void testOverspeedWithStatus(boolean notRepeat) throws Exception {
+        Position position = new Position();
+        position.setTime(new Date(System.currentTimeMillis() - 30000));
+        position.setSpeed(50);
+        DeviceState deviceState = new DeviceState();
+        deviceState.setOverspeedState(false);
+        deviceState.setOverspeedPosition(position);
+
+        Event event = OverspeedEventHandler.updateOverspeedState(deviceState, 40, 15000, notRepeat);
+
+        assertNotNull(event);
+        assertEquals(Event.TYPE_DEVICE_OVERSPEED, event.getType());
+        assertEquals(notRepeat, deviceState.getOverspeedState());
+
+    }
+
     @Test
     public void testOverspeedEventHandler() throws Exception {
-        testOverspeed(false);
-        testOverspeed(true);
+        testOverspeedWithPosition(false);
+        testOverspeedWithPosition(true);
+
+        testOverspeedWithStatus(false);
+        testOverspeedWithStatus(true);
     }
 
 }

--- a/test/org/traccar/events/OverspeedEventHandlerTest.java
+++ b/test/org/traccar/events/OverspeedEventHandlerTest.java
@@ -26,13 +26,15 @@ public class OverspeedEventHandlerTest  extends BaseTest {
     }
 
     private void testOverspeedWithPosition(boolean notRepeat) throws Exception {
+        OverspeedEventHandler overspeedEventHandler = new OverspeedEventHandler(15000, notRepeat);
+
         Position position = new Position();
         position.setTime(date("2017-01-01 00:00:00"));
         position.setSpeed(50);
         DeviceState deviceState = new DeviceState();
         deviceState.setOverspeedState(false);
 
-        Event event = OverspeedEventHandler.updateOverspeedState(deviceState, position, 40, 15000, notRepeat);
+        Event event = overspeedEventHandler.updateOverspeedState(deviceState, position, 40);
         assertNull(event);
         assertFalse(deviceState.getOverspeedState());
         assertEquals(position, deviceState.getOverspeedPosition());
@@ -41,12 +43,12 @@ public class OverspeedEventHandlerTest  extends BaseTest {
         nextPosition.setTime(date("2017-01-01 00:00:10"));
         nextPosition.setSpeed(55);
 
-        event = OverspeedEventHandler.updateOverspeedState(deviceState, nextPosition, 40, 15000, notRepeat);
+        event = overspeedEventHandler.updateOverspeedState(deviceState, nextPosition, 40);
         assertNull(event);
 
         nextPosition.setTime(date("2017-01-01 00:00:20"));
 
-        event = OverspeedEventHandler.updateOverspeedState(deviceState, nextPosition, 40, 15000, notRepeat);
+        event = overspeedEventHandler.updateOverspeedState(deviceState, nextPosition, 40);
         assertNotNull(event);
         assertEquals(Event.TYPE_DEVICE_OVERSPEED, event.getType());
         assertEquals(50, event.getDouble("speed"), 0.1);
@@ -56,7 +58,7 @@ public class OverspeedEventHandlerTest  extends BaseTest {
         assertNull(deviceState.getOverspeedPosition());
 
         nextPosition.setTime(date("2017-01-01 00:00:30"));
-        event = OverspeedEventHandler.updateOverspeedState(deviceState, nextPosition, 40, 15000, notRepeat);
+        event = overspeedEventHandler.updateOverspeedState(deviceState, nextPosition, 40);
         assertNull(event);
         assertEquals(notRepeat, deviceState.getOverspeedState());
 
@@ -69,13 +71,15 @@ public class OverspeedEventHandlerTest  extends BaseTest {
         nextPosition.setTime(date("2017-01-01 00:00:40"));
         nextPosition.setSpeed(30);
 
-        event = OverspeedEventHandler.updateOverspeedState(deviceState, nextPosition, 40, 15000, notRepeat);
+        event = overspeedEventHandler.updateOverspeedState(deviceState, nextPosition, 40);
         assertNull(event);
         assertFalse(deviceState.getOverspeedState());
         assertNull(deviceState.getOverspeedPosition());
     }
 
     private void testOverspeedWithStatus(boolean notRepeat) throws Exception {
+        OverspeedEventHandler overspeedEventHandler = new OverspeedEventHandler(15000, notRepeat);
+
         Position position = new Position();
         position.setTime(new Date(System.currentTimeMillis() - 30000));
         position.setSpeed(50);
@@ -83,12 +87,11 @@ public class OverspeedEventHandlerTest  extends BaseTest {
         deviceState.setOverspeedState(false);
         deviceState.setOverspeedPosition(position);
 
-        Event event = OverspeedEventHandler.updateOverspeedState(deviceState, 40, 15000, notRepeat);
+        Event event = overspeedEventHandler.updateOverspeedState(deviceState, 40);
 
         assertNotNull(event);
         assertEquals(Event.TYPE_DEVICE_OVERSPEED, event.getType());
         assertEquals(notRepeat, deviceState.getOverspeedState());
-
     }
 
     @Test

--- a/test/org/traccar/events/OverspeedEventHandlerTest.java
+++ b/test/org/traccar/events/OverspeedEventHandlerTest.java
@@ -1,0 +1,85 @@
+package org.traccar.events;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+import org.junit.Test;
+import org.traccar.BaseTest;
+import org.traccar.model.DeviceState;
+import org.traccar.model.Event;
+import org.traccar.model.Position;
+
+public class OverspeedEventHandlerTest  extends BaseTest {
+
+    private Date date(String time) throws ParseException {
+        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return dateFormat.parse(time);
+    }
+
+    private void testOverspeed(boolean notRepeat) throws Exception {
+        Position position = new Position();
+        position.setTime(date("2017-01-01 00:00:00"));
+        position.setSpeed(50);
+        DeviceState deviceState = new DeviceState();
+        deviceState.setOverspeedState(false);
+
+        Event event = OverspeedEventHandler.updateOverspeedState(deviceState, position, 40, 15000, notRepeat);
+        assertNull(event);
+        assertFalse(deviceState.getOverspeedState());
+        assertEquals(position, deviceState.getOverspeedPosition());
+
+        Position nextPosition = new Position();
+        nextPosition.setTime(date("2017-01-01 00:00:10"));
+        nextPosition.setSpeed(55);
+
+        event = OverspeedEventHandler.updateOverspeedState(deviceState, nextPosition, 40, 15000, notRepeat);
+        assertNull(event);
+
+        nextPosition.setTime(date("2017-01-01 00:00:20"));
+
+        event = OverspeedEventHandler.updateOverspeedState(deviceState, nextPosition, 40, 15000, notRepeat);
+        assertNotNull(event);
+        assertEquals(Event.TYPE_DEVICE_OVERSPEED, event.getType());
+        assertEquals(50, event.getDouble("speed"), 0.1);
+        assertEquals(40, event.getDouble(OverspeedEventHandler.ATTRIBUTE_SPEED_LIMIT), 0.1);
+
+        assertEquals(notRepeat, deviceState.getOverspeedState());
+        assertNull(deviceState.getOverspeedPosition());
+        
+        nextPosition.setTime(date("2017-01-01 00:00:30"));
+        event = OverspeedEventHandler.updateOverspeedState(deviceState, nextPosition, 40, 15000, notRepeat);
+        assertNull(event);
+        assertEquals(notRepeat, deviceState.getOverspeedState());
+        
+        if (notRepeat) {
+            assertNull(deviceState.getOverspeedPosition());
+        } else {
+            assertNotNull(deviceState.getOverspeedPosition());
+        }
+
+        nextPosition.setTime(date("2017-01-01 00:00:40"));
+        nextPosition.setSpeed(30);
+
+        event = OverspeedEventHandler.updateOverspeedState(deviceState, nextPosition, 40, 15000, notRepeat);
+        assertNull(event);
+        assertFalse(deviceState.getOverspeedState());
+        assertNull(deviceState.getOverspeedPosition());
+    }
+
+    @Test
+    public void testOverspeedEventHandler() throws Exception {
+        testOverspeed(false);
+        testOverspeed(true);
+    }
+
+}


### PR DESCRIPTION
Implementation is simpler than motion because there is no "not-overspeed" event.
Logic stayed the same, but with delay. For example:
`minimalDuration = 15 seconds`, but device "overspeeding"  for a minute, if `notRepeat = false`  about 4 events will be generated (if reported with enough frequency) if `notRepeat = true` - only one event.

Also made a few small optimizations with previous code.
- Initialize `DeviceState` in get method
- Unwrapped some not obvious nested checks 