### PR TITLE
Map correct position to delayed event notification

### DIFF
--- a/src/org/traccar/BaseEventHandler.java
+++ b/src/org/traccar/BaseEventHandler.java
@@ -15,7 +15,7 @@
  */
 package org.traccar;
 
-import java.util.Collection;
+import java.util.Map;
 
 import org.traccar.model.Event;
 import org.traccar.model.Position;
@@ -25,13 +25,13 @@ public abstract class BaseEventHandler extends BaseDataHandler {
     @Override
     protected Position handlePosition(Position position) {
 
-        Collection<Event> events = analyzePosition(position);
+        Map<Event, Position> events = analyzePosition(position);
         if (events != null && Context.getNotificationManager() != null) {
-            Context.getNotificationManager().updateEvents(events, position);
+            Context.getNotificationManager().updateEvents(events);
         }
         return position;
     }
 
-    protected abstract Collection<Event> analyzePosition(Position position);
+    protected abstract Map<Event, Position> analyzePosition(Position position);
 
 }

--- a/src/org/traccar/database/NotificationManager.java
+++ b/src/org/traccar/database/NotificationManager.java
@@ -48,8 +48,13 @@ public class NotificationManager {
     }
 
     public void updateEvent(Event event, Position position) {
+        Position relatedPosition = position;
         try {
             dataManager.addObject(event);
+            if (event.getPositionId() != 0 && (relatedPosition == null
+                    || event.getPositionId() != relatedPosition.getId())) {
+                relatedPosition = dataManager.getObject(Position.class, event.getPositionId());
+            }
         } catch (SQLException error) {
             Log.warning(error);
         }
@@ -64,16 +69,16 @@ public class NotificationManager {
                         Context.getConnectionManager().updateEvent(userId, event);
                     }
                     if (notification.getMail()) {
-                        NotificationMail.sendMailAsync(userId, event, position);
+                        NotificationMail.sendMailAsync(userId, event, relatedPosition);
                     }
                     if (notification.getSms()) {
-                        NotificationSms.sendSmsAsync(userId, event, position);
+                        NotificationSms.sendSmsAsync(userId, event, relatedPosition);
                     }
                 }
             }
         }
         if (Context.getEventForwarder() != null) {
-            Context.getEventForwarder().forwardEvent(event, position);
+            Context.getEventForwarder().forwardEvent(event, relatedPosition);
         }
     }
 

--- a/src/org/traccar/database/NotificationManager.java
+++ b/src/org/traccar/database/NotificationManager.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -48,13 +49,8 @@ public class NotificationManager {
     }
 
     public void updateEvent(Event event, Position position) {
-        Position relatedPosition = position;
         try {
             dataManager.addObject(event);
-            if (event.getPositionId() != 0 && (relatedPosition == null
-                    || event.getPositionId() != relatedPosition.getId())) {
-                relatedPosition = dataManager.getObject(Position.class, event.getPositionId());
-            }
         } catch (SQLException error) {
             Log.warning(error);
         }
@@ -69,22 +65,22 @@ public class NotificationManager {
                         Context.getConnectionManager().updateEvent(userId, event);
                     }
                     if (notification.getMail()) {
-                        NotificationMail.sendMailAsync(userId, event, relatedPosition);
+                        NotificationMail.sendMailAsync(userId, event, position);
                     }
                     if (notification.getSms()) {
-                        NotificationSms.sendSmsAsync(userId, event, relatedPosition);
+                        NotificationSms.sendSmsAsync(userId, event, position);
                     }
                 }
             }
         }
         if (Context.getEventForwarder() != null) {
-            Context.getEventForwarder().forwardEvent(event, relatedPosition);
+            Context.getEventForwarder().forwardEvent(event, position);
         }
     }
 
-    public void updateEvents(Collection<Event> events, Position position) {
-        for (Event event : events) {
-            updateEvent(event, position);
+    public void updateEvents(Map<Event, Position> events) {
+        for (Entry<Event, Position> event : events.entrySet()) {
+            updateEvent(event.getKey(), event.getValue());
         }
     }
 

--- a/src/org/traccar/events/AlertEventHandler.java
+++ b/src/org/traccar/events/AlertEventHandler.java
@@ -15,8 +15,8 @@
  */
 package org.traccar.events;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 import org.traccar.BaseEventHandler;
 import org.traccar.model.Event;
@@ -25,12 +25,12 @@ import org.traccar.model.Position;
 public class AlertEventHandler extends BaseEventHandler {
 
     @Override
-    protected Collection<Event> analyzePosition(Position position) {
+    protected Map<Event, Position> analyzePosition(Position position) {
         Object alarm = position.getAttributes().get(Position.KEY_ALARM);
         if (alarm != null) {
             Event event = new Event(Event.TYPE_ALARM, position.getDeviceId(), position.getId());
             event.set(Position.KEY_ALARM, (String) alarm);
-            return Collections.singleton(event);
+            return Collections.singletonMap(event, position);
         }
         return null;
     }

--- a/src/org/traccar/events/CommandResultEventHandler.java
+++ b/src/org/traccar/events/CommandResultEventHandler.java
@@ -15,8 +15,8 @@
  */
 package org.traccar.events;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 import org.traccar.BaseEventHandler;
 import org.traccar.model.Event;
@@ -25,12 +25,12 @@ import org.traccar.model.Position;
 public class CommandResultEventHandler extends BaseEventHandler {
 
     @Override
-    protected Collection<Event> analyzePosition(Position position) {
+    protected Map<Event, Position> analyzePosition(Position position) {
         Object commandResult = position.getAttributes().get(Position.KEY_RESULT);
         if (commandResult != null) {
             Event event = new Event(Event.TYPE_COMMAND_RESULT, position.getDeviceId(), position.getId());
             event.set(Position.KEY_RESULT, (String) commandResult);
-            return Collections.singleton(event);
+            return Collections.singletonMap(event, position);
         }
         return null;
     }

--- a/src/org/traccar/events/DriverEventHandler.java
+++ b/src/org/traccar/events/DriverEventHandler.java
@@ -16,8 +16,8 @@
  */
 package org.traccar.events;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 import org.traccar.BaseEventHandler;
 import org.traccar.Context;
@@ -27,7 +27,7 @@ import org.traccar.model.Position;
 public class DriverEventHandler extends BaseEventHandler {
 
     @Override
-    protected Collection<Event> analyzePosition(Position position) {
+    protected Map<Event, Position> analyzePosition(Position position) {
         if (!Context.getIdentityManager().isLatestPosition(position)) {
             return null;
         }
@@ -41,7 +41,7 @@ public class DriverEventHandler extends BaseEventHandler {
             if (!driverUniqueId.equals(oldDriverUniqueId)) {
                 Event event = new Event(Event.TYPE_DRIVER_CHANGED, position.getDeviceId(), position.getId());
                 event.set(Position.KEY_DRIVER_UNIQUE_ID, driverUniqueId);
-                return Collections.singleton(event);
+                return Collections.singletonMap(event, position);
             }
         }
         return null;

--- a/src/org/traccar/events/FuelDropEventHandler.java
+++ b/src/org/traccar/events/FuelDropEventHandler.java
@@ -21,15 +21,15 @@ import org.traccar.model.Device;
 import org.traccar.model.Event;
 import org.traccar.model.Position;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 public class FuelDropEventHandler extends BaseEventHandler {
 
     public static final String ATTRIBUTE_FUEL_DROP_THRESHOLD = "fuelDropThreshold";
 
     @Override
-    protected Collection<Event> analyzePosition(Position position) {
+    protected Map<Event, Position> analyzePosition(Position position) {
 
         Device device = Context.getIdentityManager().getById(position.getDeviceId());
         if (device == null) {
@@ -52,7 +52,7 @@ public class FuelDropEventHandler extends BaseEventHandler {
                 if (drop >= fuelDropThreshold) {
                     Event event = new Event(Event.TYPE_DEVICE_FUEL_DROP, position.getDeviceId(), position.getId());
                     event.set(ATTRIBUTE_FUEL_DROP_THRESHOLD, fuelDropThreshold);
-                    return Collections.singleton(event);
+                    return Collections.singletonMap(event, position);
                 }
             }
         }

--- a/src/org/traccar/events/GeofenceEventHandler.java
+++ b/src/org/traccar/events/GeofenceEventHandler.java
@@ -16,8 +16,9 @@
 package org.traccar.events;
 
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.traccar.BaseEventHandler;
 import org.traccar.Context;
@@ -36,7 +37,7 @@ public class GeofenceEventHandler extends BaseEventHandler {
     }
 
     @Override
-    protected Collection<Event> analyzePosition(Position position) {
+    protected Map<Event, Position> analyzePosition(Position position) {
         Device device = Context.getIdentityManager().getById(position.getDeviceId());
         if (device == null) {
             return null;
@@ -56,14 +57,14 @@ public class GeofenceEventHandler extends BaseEventHandler {
 
         device.setGeofenceIds(currentGeofences);
 
-        Collection<Event> events = new ArrayList<>();
+        Map<Event, Position> events = new HashMap<>();
         for (long geofenceId : newGeofences) {
             long calendarId = geofenceManager.getById(geofenceId).getCalendarId();
             Calendar calendar = calendarId != 0 ? Context.getCalendarManager().getById(calendarId) : null;
             if (calendar == null || calendar.checkMoment(position.getFixTime())) {
                 Event event = new Event(Event.TYPE_GEOFENCE_ENTER, position.getDeviceId(), position.getId());
                 event.setGeofenceId(geofenceId);
-                events.add(event);
+                events.put(event, position);
             }
         }
         for (long geofenceId : oldGeofences) {
@@ -72,7 +73,7 @@ public class GeofenceEventHandler extends BaseEventHandler {
             if (calendar == null || calendar.checkMoment(position.getFixTime())) {
                 Event event = new Event(Event.TYPE_GEOFENCE_EXIT, position.getDeviceId(), position.getId());
                 event.setGeofenceId(geofenceId);
-                events.add(event);
+                events.put(event, position);
             }
         }
         return events;

--- a/src/org/traccar/events/IgnitionEventHandler.java
+++ b/src/org/traccar/events/IgnitionEventHandler.java
@@ -16,8 +16,8 @@
  */
 package org.traccar.events;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 import org.traccar.BaseEventHandler;
 import org.traccar.Context;
@@ -28,13 +28,13 @@ import org.traccar.model.Position;
 public class IgnitionEventHandler extends BaseEventHandler {
 
     @Override
-    protected Collection<Event> analyzePosition(Position position) {
+    protected Map<Event, Position> analyzePosition(Position position) {
         Device device = Context.getIdentityManager().getById(position.getDeviceId());
         if (device == null || !Context.getIdentityManager().isLatestPosition(position)) {
             return null;
         }
 
-        Collection<Event> result = null;
+        Map<Event, Position> result = null;
 
         if (position.getAttributes().containsKey(Position.KEY_IGNITION)) {
             boolean ignition = position.getBoolean(Position.KEY_IGNITION);
@@ -44,11 +44,11 @@ public class IgnitionEventHandler extends BaseEventHandler {
                 boolean oldIgnition = lastPosition.getBoolean(Position.KEY_IGNITION);
 
                 if (ignition && !oldIgnition) {
-                    result = Collections.singleton(
-                            new Event(Event.TYPE_IGNITION_ON, position.getDeviceId(), position.getId()));
+                    result = Collections.singletonMap(
+                            new Event(Event.TYPE_IGNITION_ON, position.getDeviceId(), position.getId()), position);
                 } else if (!ignition && oldIgnition) {
-                    result = Collections.singleton(
-                            new Event(Event.TYPE_IGNITION_OFF, position.getDeviceId(), position.getId()));
+                    result = Collections.singletonMap(
+                            new Event(Event.TYPE_IGNITION_OFF, position.getDeviceId(), position.getId()), position);
                 }
             }
         }

--- a/src/org/traccar/events/MaintenanceEventHandler.java
+++ b/src/org/traccar/events/MaintenanceEventHandler.java
@@ -16,8 +16,8 @@
  */
 package org.traccar.events;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 import org.traccar.BaseEventHandler;
 import org.traccar.Context;
@@ -31,7 +31,7 @@ public class MaintenanceEventHandler extends BaseEventHandler {
     public static final String ATTRIBUTE_MAINTENANCE_INTERVAL = "maintenance.interval";
 
     @Override
-    protected Collection<Event> analyzePosition(Position position) {
+    protected Map<Event, Position> analyzePosition(Position position) {
         Device device = Context.getIdentityManager().getById(position.getDeviceId());
         if (device == null || !Context.getIdentityManager().isLatestPosition(position)) {
             return null;
@@ -60,7 +60,7 @@ public class MaintenanceEventHandler extends BaseEventHandler {
         if ((long) (oldTotalDistance / maintenanceInterval) < (long) (newTotalDistance / maintenanceInterval)) {
             Event event = new Event(Event.TYPE_MAINTENANCE, position.getDeviceId(), position.getId());
             event.set(Position.KEY_TOTAL_DISTANCE, newTotalDistance);
-            return Collections.singleton(event);
+            return Collections.singletonMap(event, position);
         }
 
         return null;

--- a/src/org/traccar/events/OverspeedEventHandler.java
+++ b/src/org/traccar/events/OverspeedEventHandler.java
@@ -15,8 +15,8 @@
  */
 package org.traccar.events;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 import org.traccar.BaseEventHandler;
 import org.traccar.Context;
@@ -37,18 +37,18 @@ public class OverspeedEventHandler extends BaseEventHandler {
         this.minimalDuration = minimalDuration;
     }
 
-    private Event newEvent(DeviceState deviceState, double speedLimit) {
-        Event event = new Event(Event.TYPE_DEVICE_OVERSPEED, deviceState.getOverspeedPosition().getDeviceId(),
-                deviceState.getOverspeedPosition().getId());
+    private Map<Event, Position> newEvent(DeviceState deviceState, double speedLimit) {
+        Position position = deviceState.getOverspeedPosition();
+        Event event = new Event(Event.TYPE_DEVICE_OVERSPEED, position.getDeviceId(), position.getId());
         event.set("speed", deviceState.getOverspeedPosition().getSpeed());
         event.set(ATTRIBUTE_SPEED_LIMIT, speedLimit);
         deviceState.setOverspeedState(notRepeat);
         deviceState.setOverspeedPosition(null);
-        return event;
+        return Collections.singletonMap(event, position);
     }
 
-    public Event updateOverspeedState(DeviceState deviceState, double speedLimit) {
-        Event result = null;
+    public Map<Event, Position> updateOverspeedState(DeviceState deviceState, double speedLimit) {
+        Map<Event, Position> result = null;
         if (deviceState.getOverspeedState() != null && !deviceState.getOverspeedState()
                 && deviceState.getOverspeedPosition() != null && speedLimit != 0) {
             long currentTime = System.currentTimeMillis();
@@ -61,8 +61,8 @@ public class OverspeedEventHandler extends BaseEventHandler {
         return result;
     }
 
-    public Event updateOverspeedState(DeviceState deviceState, Position position, double speedLimit) {
-        Event result = null;
+    public Map<Event, Position> updateOverspeedState(DeviceState deviceState, Position position, double speedLimit) {
+        Map<Event, Position> result = null;
 
         Boolean oldOverspeed = deviceState.getOverspeedState();
 
@@ -89,7 +89,7 @@ public class OverspeedEventHandler extends BaseEventHandler {
     }
 
     @Override
-    protected Collection<Event> analyzePosition(Position position) {
+    protected Map<Event, Position> analyzePosition(Position position) {
 
         long deviceId = position.getDeviceId();
         Device device = Context.getIdentityManager().getById(deviceId);
@@ -105,7 +105,7 @@ public class OverspeedEventHandler extends BaseEventHandler {
             return null;
         }
 
-        Event result = null;
+        Map<Event, Position> result = null;
         DeviceState deviceState = Context.getDeviceManager().getDeviceState(deviceId);
 
         if (deviceState.getOverspeedState() == null) {
@@ -115,10 +115,7 @@ public class OverspeedEventHandler extends BaseEventHandler {
         }
 
         Context.getDeviceManager().setDeviceState(deviceId, deviceState);
-        if (result != null) {
-            return Collections.singleton(result);
-        }
-        return null;
+        return result;
     }
 
 }

--- a/src/org/traccar/reports/ReportUtils.java
+++ b/src/org/traccar/reports/ReportUtils.java
@@ -46,6 +46,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.TimeZone;
 
 public final class ReportUtils {
@@ -281,7 +282,7 @@ public final class ReportUtils {
             int startEventIndex = trips == deviceState.getMotionState() ? 0 : -1;
             int startNoEventIndex = -1;
             for (int i = 0; i < positions.size(); i++) {
-                Event event = motionHandler.updateMotionState(deviceState, positions.get(i),
+                Map<Event, Position> event = motionHandler.updateMotionState(deviceState, positions.get(i),
                         isMoving(positions, i, tripsConfig, speedThreshold));
                 if (deviceState.getMotionPosition() != null && startEventIndex == -1
                         && trips != deviceState.getMotionState()) {

--- a/src/org/traccar/reports/ReportUtils.java
+++ b/src/org/traccar/reports/ReportUtils.java
@@ -302,12 +302,10 @@ public final class ReportUtils {
                     startEventIndex = -1;
                 }
             }
-            if (startEventIndex != -1) {
-                if (startNoEventIndex != -1 || !trips) {
-                    result.add(calculateTripOrStop(positions, startEventIndex,
+            if (startEventIndex != -1 && (startNoEventIndex != -1 || !trips)) {
+                result.add(calculateTripOrStop(positions, startEventIndex,
                             startNoEventIndex != -1 ? startNoEventIndex : positions.size() - 1,
                             ignoreOdometer, reportClass));
-                }
             }
         }
         return result;

--- a/test/org/traccar/events/AlertEventHandlerTest.java
+++ b/test/org/traccar/events/AlertEventHandlerTest.java
@@ -3,7 +3,7 @@ package org.traccar.events;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import java.util.Collection;
+import java.util.Map;
 
 import org.junit.Test;
 import org.traccar.BaseTest;
@@ -19,9 +19,9 @@ public class AlertEventHandlerTest extends BaseTest {
         
         Position position = new Position();
         position.set(Position.KEY_ALARM, Position.ALARM_GENERAL);
-        Collection<Event> events = alertEventHandler.analyzePosition(position);
+        Map<Event, Position> events = alertEventHandler.analyzePosition(position);
         assertNotNull(events);
-        Event event = (Event) events.toArray()[0];
+        Event event = events.keySet().iterator().next();
         assertEquals(Event.TYPE_ALARM, event.getType());
     }
 

--- a/test/org/traccar/events/CommandResultEventHandlerTest.java
+++ b/test/org/traccar/events/CommandResultEventHandlerTest.java
@@ -3,7 +3,7 @@ package org.traccar.events;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import java.util.Collection;
+import java.util.Map;
 
 import org.junit.Test;
 import org.traccar.BaseTest;
@@ -19,9 +19,9 @@ public class CommandResultEventHandlerTest extends BaseTest {
         
         Position position = new Position();
         position.set(Position.KEY_RESULT, "Test Result");
-        Collection<Event> events = commandResultEventHandler.analyzePosition(position);
+        Map<Event, Position> events = commandResultEventHandler.analyzePosition(position);
         assertNotNull(events);
-        Event event = (Event) events.toArray()[0];
+        Event event = events.keySet().iterator().next();
         assertEquals(Event.TYPE_COMMAND_RESULT, event.getType());
     }
 

--- a/test/org/traccar/events/IgnitionEventHandlerTest.java
+++ b/test/org/traccar/events/IgnitionEventHandlerTest.java
@@ -2,7 +2,7 @@ package org.traccar.events;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Collection;
+import java.util.Map;
 
 import org.junit.Test;
 import org.traccar.BaseTest;
@@ -19,7 +19,7 @@ public class IgnitionEventHandlerTest extends BaseTest {
         Position position = new Position();
         position.set(Position.KEY_IGNITION, true);
         position.setValid(true);
-        Collection<Event> events = ignitionEventHandler.analyzePosition(position);
+        Map<Event, Position> events = ignitionEventHandler.analyzePosition(position);
         assertEquals(events, null);
     }
 

--- a/test/org/traccar/events/MotionEventHandlerTest.java
+++ b/test/org/traccar/events/MotionEventHandlerTest.java
@@ -10,6 +10,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Map;
 import java.util.TimeZone;
 
 import org.junit.Test;
@@ -45,12 +46,13 @@ public class MotionEventHandlerTest extends BaseTest {
         nextPosition.set(Position.KEY_MOTION, true);
         nextPosition.set(Position.KEY_TOTAL_DISTANCE, 200);
 
-        Event event = motionEventHandler.updateMotionState(deviceState, nextPosition);
-        assertNull(event);
+        Map<Event, Position> events = motionEventHandler.updateMotionState(deviceState, nextPosition);
+        assertNull(events);
 
         nextPosition.set(Position.KEY_TOTAL_DISTANCE, 600);
-        event = motionEventHandler.updateMotionState(deviceState, nextPosition);        
-        assertNotNull(event);
+        events = motionEventHandler.updateMotionState(deviceState, nextPosition);        
+        assertNotNull(events);
+        Event event = events.keySet().iterator().next();
         assertEquals(Event.TYPE_DEVICE_MOVING, event.getType());
         assertTrue(deviceState.getMotionState());
         assertNull(deviceState.getMotionPosition());
@@ -59,8 +61,9 @@ public class MotionEventHandlerTest extends BaseTest {
         deviceState.setMotionPosition(position);
         nextPosition.setTime(date("2017-01-01 00:06:00"));
         nextPosition.set(Position.KEY_TOTAL_DISTANCE, 200);
-        event = motionEventHandler.updateMotionState(deviceState, nextPosition);
+        events = motionEventHandler.updateMotionState(deviceState, nextPosition);
         assertNotNull(event);
+        event = events.keySet().iterator().next();
         assertEquals(Event.TYPE_DEVICE_MOVING, event.getType());
         assertTrue(deviceState.getMotionState());
         assertNull(deviceState.getMotionPosition());
@@ -78,9 +81,10 @@ public class MotionEventHandlerTest extends BaseTest {
         deviceState.setMotionState(false);
         deviceState.setMotionPosition(position);
 
-        Event event = motionEventHandler.updateMotionState(deviceState);
+        Map<Event, Position> events = motionEventHandler.updateMotionState(deviceState);
 
-        assertNotNull(event);
+        assertNotNull(events);
+        Event event = events.keySet().iterator().next();
         assertEquals(Event.TYPE_DEVICE_MOVING, event.getType());
         assertTrue(deviceState.getMotionState());
         assertNull(deviceState.getMotionPosition());
@@ -104,8 +108,9 @@ public class MotionEventHandlerTest extends BaseTest {
         nextPosition.set(Position.KEY_MOTION, false);
         nextPosition.set(Position.KEY_IGNITION, false);
 
-        Event event = motionEventHandler.updateMotionState(deviceState, nextPosition);
-        assertNotNull(event);
+        Map<Event, Position> events = motionEventHandler.updateMotionState(deviceState, nextPosition);
+        assertNotNull(events);
+        Event event = events.keySet().iterator().next();
         assertEquals(Event.TYPE_DEVICE_STOPPED, event.getType());
         assertFalse(deviceState.getMotionState());
         assertNull(deviceState.getMotionPosition());

--- a/test/org/traccar/events/OverspeedEventHandlerTest.java
+++ b/test/org/traccar/events/OverspeedEventHandlerTest.java
@@ -9,6 +9,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Map;
 import java.util.TimeZone;
 
 import org.junit.Test;
@@ -34,8 +35,8 @@ public class OverspeedEventHandlerTest  extends BaseTest {
         DeviceState deviceState = new DeviceState();
         deviceState.setOverspeedState(false);
 
-        Event event = overspeedEventHandler.updateOverspeedState(deviceState, position, 40);
-        assertNull(event);
+        Map<Event, Position> events = overspeedEventHandler.updateOverspeedState(deviceState, position, 40);
+        assertNull(events);
         assertFalse(deviceState.getOverspeedState());
         assertEquals(position, deviceState.getOverspeedPosition());
 
@@ -43,13 +44,14 @@ public class OverspeedEventHandlerTest  extends BaseTest {
         nextPosition.setTime(date("2017-01-01 00:00:10"));
         nextPosition.setSpeed(55);
 
-        event = overspeedEventHandler.updateOverspeedState(deviceState, nextPosition, 40);
-        assertNull(event);
+        events = overspeedEventHandler.updateOverspeedState(deviceState, nextPosition, 40);
+        assertNull(events);
 
         nextPosition.setTime(date("2017-01-01 00:00:20"));
 
-        event = overspeedEventHandler.updateOverspeedState(deviceState, nextPosition, 40);
-        assertNotNull(event);
+        events = overspeedEventHandler.updateOverspeedState(deviceState, nextPosition, 40);
+        assertNotNull(events);
+        Event event = events.keySet().iterator().next();
         assertEquals(Event.TYPE_DEVICE_OVERSPEED, event.getType());
         assertEquals(50, event.getDouble("speed"), 0.1);
         assertEquals(40, event.getDouble(OverspeedEventHandler.ATTRIBUTE_SPEED_LIMIT), 0.1);
@@ -58,8 +60,8 @@ public class OverspeedEventHandlerTest  extends BaseTest {
         assertNull(deviceState.getOverspeedPosition());
 
         nextPosition.setTime(date("2017-01-01 00:00:30"));
-        event = overspeedEventHandler.updateOverspeedState(deviceState, nextPosition, 40);
-        assertNull(event);
+        events = overspeedEventHandler.updateOverspeedState(deviceState, nextPosition, 40);
+        assertNull(events);
         assertEquals(notRepeat, deviceState.getOverspeedState());
 
         if (notRepeat) {
@@ -71,8 +73,8 @@ public class OverspeedEventHandlerTest  extends BaseTest {
         nextPosition.setTime(date("2017-01-01 00:00:40"));
         nextPosition.setSpeed(30);
 
-        event = overspeedEventHandler.updateOverspeedState(deviceState, nextPosition, 40);
-        assertNull(event);
+        events = overspeedEventHandler.updateOverspeedState(deviceState, nextPosition, 40);
+        assertNull(events);
         assertFalse(deviceState.getOverspeedState());
         assertNull(deviceState.getOverspeedPosition());
     }
@@ -87,9 +89,10 @@ public class OverspeedEventHandlerTest  extends BaseTest {
         deviceState.setOverspeedState(false);
         deviceState.setOverspeedPosition(position);
 
-        Event event = overspeedEventHandler.updateOverspeedState(deviceState, 40);
+        Map<Event, Position> events = overspeedEventHandler.updateOverspeedState(deviceState, 40);
 
-        assertNotNull(event);
+        assertNotNull(events);
+        Event event = events.keySet().iterator().next();
         assertEquals(Event.TYPE_DEVICE_OVERSPEED, event.getType());
         assertEquals(notRepeat, deviceState.getOverspeedState());
     }


### PR DESCRIPTION
Totally slip out of mind, we also have to load old position to map it to notification like we do on web side.

It might be looking like quickfix, if you are totally against requesting DB here I have a couple of ideas:
- Simply cache such delayed positions (map `positionId`->`Position` but I do not know when cleanup them, some positions might be related more than one event)
- Rethink how we call event handlers, now, they basically inside separate pipeline handlers. We can implement common pipeline handler to call all event handlers, collect results and call notification once. Because `DeviceState` has cached related position we can pass them to notification and avoid additional DB requests.

Also fixed nested condition