### PR TITLE
Fix trips and stops detector

### DIFF
--- a/src/org/traccar/reports/ReportUtils.java
+++ b/src/org/traccar/reports/ReportUtils.java
@@ -284,17 +284,21 @@ public final class ReportUtils {
             for (int i = 0; i < positions.size(); i++) {
                 Map<Event, Position> event = motionHandler.updateMotionState(deviceState, positions.get(i),
                         isMoving(positions, i, tripsConfig, speedThreshold));
-                if (deviceState.getMotionPosition() != null && startEventIndex == -1
-                        && trips != deviceState.getMotionState()) {
+                if (startEventIndex == -1
+                        && (trips != deviceState.getMotionState() && deviceState.getMotionPosition() != null
+                        || trips == deviceState.getMotionState() && event != null)) {
                     startEventIndex = i;
                     startNoEventIndex = -1;
+                } else if (trips != deviceState.getMotionState() && startEventIndex != -1
+                        && deviceState.getMotionPosition() == null && event == null) {
+                    startEventIndex = -1;
                 }
-                if (trips == deviceState.getMotionState()) {
-                    if (startNoEventIndex == -1) {
-                        startNoEventIndex = i;
-                    } else if (deviceState.getMotionPosition() == null) {
-                        startNoEventIndex = -1;
-                    }
+                if (startNoEventIndex == -1
+                        && (trips == deviceState.getMotionState() && deviceState.getMotionPosition() != null
+                        || trips != deviceState.getMotionState() && event != null)) {
+                    startNoEventIndex = i;
+                } else if (startNoEventIndex != -1 && deviceState.getMotionPosition() == null && event == null) {
+                    startNoEventIndex = -1;
                 }
                 if (startEventIndex != -1 && startNoEventIndex != -1 && event != null
                         && trips != deviceState.getMotionState()) {

--- a/test/org/traccar/reports/ReportUtilsTest.java
+++ b/test/org/traccar/reports/ReportUtilsTest.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
+import java.util.List;
 import java.util.TimeZone;
 
 import org.junit.Assert;
@@ -69,7 +70,7 @@ public class ReportUtilsTest extends BaseTest {
     @Test
     public void testDetectTripsSimple() throws ParseException {
 
-        Collection<Position> data = Arrays.asList(
+        List<Position> data = Arrays.asList(
                 position("2016-01-01 00:00:00.000", 0, 0),
                 position("2016-01-01 00:01:00.000", 0, 0),
                 position("2016-01-01 00:02:00.000", 10, 0),
@@ -112,6 +113,126 @@ public class ReportUtilsTest extends BaseTest {
 
         assertEquals(date("2016-01-01 00:05:00.000"), itemStop.getStartTime());
         assertEquals(date("2016-01-01 00:07:00.000"), itemStop.getEndTime());
+        assertEquals(120000, itemStop.getDuration());
+
+    }
+
+    @Test
+    public void testDetectTripsSimpleWithIgnition() throws ParseException {
+
+        List<Position> data = Arrays.asList(
+                position("2016-01-01 00:00:00.000", 0, 0),
+                position("2016-01-01 00:01:00.000", 0, 0),
+                position("2016-01-01 00:02:00.000", 10, 0),
+                position("2016-01-01 00:03:00.000", 10, 1000),
+                position("2016-01-01 00:04:00.000", 10, 2000),
+                position("2016-01-01 00:05:00.000", 0, 3000),
+                position("2016-01-01 00:06:00.000", 0, 3000),
+                position("2016-01-01 00:07:00.000", 0, 3000));
+
+        data.get(5).set(Position.KEY_IGNITION, false);
+
+        TripsConfig tripsConfig = new TripsConfig(500, 300000, 180000, 900000, true);
+
+        Collection<TripReport> trips = ReportUtils.detectTripsAndStops(data, tripsConfig, false, 0.01, TripReport.class);
+
+        assertNotNull(trips);
+        assertFalse(trips.isEmpty());
+
+        TripReport itemTrip = trips.iterator().next();
+
+        assertEquals(date("2016-01-01 00:02:00.000"), itemTrip.getStartTime());
+        assertEquals(date("2016-01-01 00:05:00.000"), itemTrip.getEndTime());
+        assertEquals(180000, itemTrip.getDuration());
+        assertEquals(10, itemTrip.getAverageSpeed(), 0.01);
+        assertEquals(10, itemTrip.getMaxSpeed(), 0.01);
+        assertEquals(3000, itemTrip.getDistance(), 0.01);
+
+        trips = ReportUtils.detectTripsAndStops(data, tripsConfig, false, 0.01, TripReport.class);
+
+        assertNotNull(trips);
+        assertFalse(trips.isEmpty());
+
+        itemTrip = trips.iterator().next();
+
+        assertEquals(date("2016-01-01 00:02:00.000"), itemTrip.getStartTime());
+        assertEquals(date("2016-01-01 00:05:00.000"), itemTrip.getEndTime());
+        assertEquals(180000, itemTrip.getDuration());
+        assertEquals(10, itemTrip.getAverageSpeed(), 0.01);
+        assertEquals(10, itemTrip.getMaxSpeed(), 0.01);
+        assertEquals(3000, itemTrip.getDistance(), 0.01);
+
+        Collection<StopReport> stops = ReportUtils.detectTripsAndStops(data, tripsConfig, false, 0.01, StopReport.class);
+
+        assertNotNull(stops);
+        assertFalse(stops.isEmpty());
+
+        Iterator<StopReport> iterator = stops.iterator();
+
+        StopReport itemStop = iterator.next();
+
+        assertEquals(date("2016-01-01 00:00:00.000"), itemStop.getStartTime());
+        assertEquals(date("2016-01-01 00:02:00.000"), itemStop.getEndTime());
+        assertEquals(120000, itemStop.getDuration());
+
+        itemStop = iterator.next();
+
+        assertEquals(date("2016-01-01 00:05:00.000"), itemStop.getStartTime());
+        assertEquals(date("2016-01-01 00:07:00.000"), itemStop.getEndTime());
+        assertEquals(120000, itemStop.getDuration());
+
+    }
+
+    @Test
+    public void testDetectTripsWithFluctuation() throws ParseException {
+
+        List<Position> data = Arrays.asList(
+                position("2016-01-01 00:00:00.000", 0, 0),
+                position("2016-01-01 00:01:00.000", 0, 0),
+                position("2016-01-01 00:02:00.000", 10, 0),
+                position("2016-01-01 00:03:00.000", 10, 1000),
+                position("2016-01-01 00:04:00.000", 10, 2000),
+                position("2016-01-01 00:05:00.000", 10, 3000),
+                position("2016-01-01 00:06:00.000", 10, 4000),
+                position("2016-01-01 00:07:00.000", 0, 5000),
+                position("2016-01-01 00:08:00.000", 10, 6000),
+                position("2016-01-01 00:09:00.000", 0, 7000),
+                position("2016-01-01 00:10:00.000", 0, 7000),
+                position("2016-01-01 00:11:00.000", 0, 7000));
+
+        TripsConfig tripsConfig = new TripsConfig(500, 300000, 180000, 900000, false);
+
+        Collection<TripReport> trips = ReportUtils.detectTripsAndStops(data, tripsConfig, false, 0.01, TripReport.class);
+
+        assertNotNull(trips);
+        assertFalse(trips.isEmpty());
+
+        TripReport itemTrip = trips.iterator().next();
+
+        assertEquals(date("2016-01-01 00:02:00.000"), itemTrip.getStartTime());
+        assertEquals(date("2016-01-01 00:09:00.000"), itemTrip.getEndTime());
+        assertEquals(420000, itemTrip.getDuration());
+        assertEquals(8.57, itemTrip.getAverageSpeed(), 0.01);
+        assertEquals(10, itemTrip.getMaxSpeed(), 0.01);
+        assertEquals(7000, itemTrip.getDistance(), 0.01);
+
+        Collection<StopReport> stops = ReportUtils.detectTripsAndStops(data, tripsConfig, false, 0.01, StopReport.class);
+
+        assertNotNull(stops);
+        assertFalse(stops.isEmpty());
+
+        Iterator<StopReport> iterator = stops.iterator();
+
+        StopReport itemStop = iterator.next();
+
+        assertEquals(date("2016-01-01 00:00:00.000"), itemStop.getStartTime());
+        assertEquals(date("2016-01-01 00:02:00.000"), itemStop.getEndTime());
+        assertEquals(120000, itemStop.getDuration());
+
+        itemStop = iterator.next();
+
+        assertEquals(date("2016-01-01 00:09:00.000"), itemStop.getStartTime());
+        assertEquals(date("2016-01-01 00:11:00.000"), itemStop.getEndTime());
         assertEquals(120000, itemStop.getDuration());
 
     }
@@ -251,8 +372,8 @@ public class ReportUtilsTest extends BaseTest {
         StopReport itemStop = stops.iterator().next();
 
         assertEquals(date("2016-01-01 00:04:00.000"), itemStop.getStartTime());
-        assertEquals(date("2016-01-01 00:23:00.000"), itemStop.getEndTime());
-        assertEquals(1140000, itemStop.getDuration());
+        assertEquals(date("2016-01-01 00:24:00.000"), itemStop.getEndTime());
+        assertEquals(1200000, itemStop.getDuration());
     }
 
 }


### PR DESCRIPTION
Testing trips detector on real data noticed a couple of problems:
- In case `deviceState` switched instantly in one position (stopped and switched ignition off) we missed it
- Fluctuations of opposite state incorrectly handled (did not reset `startEventIndex`)

Added appropriate tests 