### PR TITLE
GT06 alarm packet issue

### DIFF
--- a/src/org/traccar/protocol/Gt06ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gt06ProtocolDecoder.java
@@ -182,6 +182,9 @@ public class Gt06ProtocolDecoder extends BaseProtocolDecoder {
         }
 
         if (length > 0) {
+            if (length > 12) {
+                length = 12;
+            }
             buf.skipBytes(length - 12); // skip reserved
         }
 
@@ -202,7 +205,11 @@ public class Gt06ProtocolDecoder extends BaseProtocolDecoder {
                 buf.readUnsignedShort(), buf.readUnsignedByte(), buf.readUnsignedShort(), buf.readUnsignedMedium())));
 
         if (length > 0) {
-            buf.skipBytes(length - 8);
+            if (hasLength) {
+                buf.skipBytes(length - 9);
+            } else {
+                buf.skipBytes(length - 8);
+            }
         }
 
         return true;

--- a/src/org/traccar/protocol/Gt06ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gt06ProtocolDecoder.java
@@ -191,7 +191,7 @@ public class Gt06ProtocolDecoder extends BaseProtocolDecoder {
         return true;
     }
 
-    private boolean decodeLbs(Position position, ChannelBuffer buf, boolean hasLength) {
+    private boolean decodeLbs(Position position, ChannelBuffer buf, boolean hasLength, boolean isExtended) {
 
         int length = 0;
         if (hasLength) {
@@ -205,7 +205,7 @@ public class Gt06ProtocolDecoder extends BaseProtocolDecoder {
                 buf.readUnsignedShort(), buf.readUnsignedByte(), buf.readUnsignedShort(), buf.readUnsignedMedium())));
 
         if (length > 0) {
-            if (hasLength) {
+            if (hasLength && !isExtended) {
                 buf.skipBytes(length - 9);
             } else {
                 buf.skipBytes(length - 8);
@@ -468,7 +468,7 @@ public class Gt06ProtocolDecoder extends BaseProtocolDecoder {
             }
 
             if (hasLbs(type)) {
-                decodeLbs(position, buf, hasStatus(type));
+                decodeLbs(position, buf, hasStatus(type), false);
             }
 
             if (hasStatus(type)) {
@@ -580,7 +580,7 @@ public class Gt06ProtocolDecoder extends BaseProtocolDecoder {
                 getLastLocation(position, position.getDeviceTime());
             }
 
-            decodeLbs(position, buf, true);
+            decodeLbs(position, buf, true, true);
 
             buf.skipBytes(buf.readUnsignedByte()); // additional cell towers
             buf.skipBytes(buf.readUnsignedByte()); // wifi access point

--- a/test/org/traccar/protocol/Gt06ProtocolDecoderTest.java
+++ b/test/org/traccar/protocol/Gt06ProtocolDecoderTest.java
@@ -161,6 +161,13 @@ public class Gt06ProtocolDecoderTest extends ProtocolTest {
         verifyNull(decoder, binary(
                 "78780d1f000000000000000200b196a20d0a"));
 
+        verifyPosition(decoder, binary(
+                "78781f12110819110216d402f250340828924055d4c801944600d300c09501429c830d0a"));
+
+        verifyPosition(decoder, binary(
+                "78782516110819110208d402f264dc08289a4058d4c70901944600d300c0954606040600014057e90d0a"));
+
+
     }
 
 }


### PR DESCRIPTION
Skipbyte 8 is correct for location data. But for alarm packet it is 9. Also alarm data is after LBS, due to which it is giving wrong alarms and it needs to be changed to skipbyte 9 as it was previously.

Also, some gt06 devices sending GPS information length 13 instead of 12, so I have added length to maximum 12 incase it is greater than 12.

Status packet is sending 13 length for GPS information. But as per protocol document, it cannot be greater than 12.
Example Login Packet
```
78780d01035873507021706101314f600d0a
```
Status Packet
```
78782516110819110208d402f264dc08289a4058d4c70901944600d300c0954606040600014057e90d0a
```
Due to above issue, it is sending alarm power cut as LBS data is skipping one extra value due to which it is taking language which is 02 and 02 is also for power cut.

Location data :- Please check table 5.2.1. page no 12 for lbs data with 8 bytes.
Alarm Data :- Please check table 5.3.1. page no 16 for lbs data with 9 bytes.
PFA document for the same.
[new protocol gt06n.pdf](https://github.com/tananaev/traccar/files/1255225/new.protocol.gt06n.pdf)

Please check and let me know if you think there is any issue with this change.