### PR TITLE
Do not filter alarms

### DIFF
--- a/src/org/traccar/FilterHandler.java
+++ b/src/org/traccar/FilterHandler.java
@@ -147,10 +147,6 @@ public class FilterHandler extends BaseDataHandler {
 
     private boolean filter(Position position) {
 
-        if (keepAlarms && position.getAttributes().containsKey(Position.KEY_ALARM)) {
-            return false;
-        }
-
         StringBuilder filterType = new StringBuilder();
 
         Position last = null;
@@ -158,9 +154,10 @@ public class FilterHandler extends BaseDataHandler {
             last = Context.getIdentityManager().getLastPosition(position.getDeviceId());
         }
 
-        if (filterLimit(position, last)) {
-            filterType.append("Limit ");
+        if (filterLimit(position, last) || keepAlarms && position.getAttributes().containsKey(Position.KEY_ALARM)) {
+            return false;
         }
+
         if (filterInvalid(position)) {
             filterType.append("Invalid ");
         }

--- a/src/org/traccar/FilterHandler.java
+++ b/src/org/traccar/FilterHandler.java
@@ -138,11 +138,15 @@ public class FilterHandler extends BaseDataHandler {
         return false;
     }
 
-    private boolean filterLimit(Position position, Position last) {
+    private boolean skipLimit(Position position, Position last) {
         if (filterLimit != 0 && last != null) {
             return (position.getFixTime().getTime() - last.getFixTime().getTime()) > filterLimit;
         }
         return false;
+    }
+
+    private boolean skipAlarms(Position position) {
+        return keepAlarms && position.getAttributes().containsKey(Position.KEY_ALARM);
     }
 
     private boolean filter(Position position) {
@@ -154,7 +158,7 @@ public class FilterHandler extends BaseDataHandler {
             last = Context.getIdentityManager().getLastPosition(position.getDeviceId());
         }
 
-        if (filterLimit(position, last) || keepAlarms && position.getAttributes().containsKey(Position.KEY_ALARM)) {
+        if (skipLimit(position, last) || skipAlarms(position)) {
             return false;
         }
 

--- a/src/org/traccar/FilterHandler.java
+++ b/src/org/traccar/FilterHandler.java
@@ -29,8 +29,8 @@ public class FilterHandler extends BaseDataHandler {
     private boolean filterStatic;
     private int filterDistance;
     private int filterMaxSpeed;
-    private long filterLimit;
-    private boolean keepAlarms;
+    private long skipLimit;
+    private boolean skipAlarms;
 
     public void setFilterInvalid(boolean filterInvalid) {
         this.filterInvalid = filterInvalid;
@@ -64,12 +64,12 @@ public class FilterHandler extends BaseDataHandler {
         this.filterMaxSpeed = filterMaxSpeed;
     }
 
-    public void setFilterLimit(long filterLimit) {
-        this.filterLimit = filterLimit;
+    public void setSkipLimit(long skipLimit) {
+        this.skipLimit = skipLimit;
     }
 
-    public void setKeepAlarms(boolean keepAlarms) {
-        this.keepAlarms = keepAlarms;
+    public void setSkipAlarms(boolean skipAlarms) {
+        this.skipAlarms = skipAlarms;
     }
 
     public FilterHandler() {
@@ -83,8 +83,8 @@ public class FilterHandler extends BaseDataHandler {
             filterStatic = config.getBoolean("filter.static");
             filterDistance = config.getInteger("filter.distance");
             filterMaxSpeed = config.getInteger("filter.maxSpeed");
-            filterLimit = config.getLong("filter.limit") * 1000;
-            keepAlarms = config.getBoolean("filter.keepAlarms");
+            skipLimit = config.getLong("filter.skipLimit") * 1000;
+            skipAlarms = config.getBoolean("filter.skipAlarms");
         }
     }
 
@@ -139,14 +139,14 @@ public class FilterHandler extends BaseDataHandler {
     }
 
     private boolean skipLimit(Position position, Position last) {
-        if (filterLimit != 0 && last != null) {
-            return (position.getFixTime().getTime() - last.getFixTime().getTime()) > filterLimit;
+        if (skipLimit != 0 && last != null) {
+            return (position.getFixTime().getTime() - last.getFixTime().getTime()) > skipLimit;
         }
         return false;
     }
 
     private boolean skipAlarms(Position position) {
-        return keepAlarms && position.getAttributes().containsKey(Position.KEY_ALARM);
+        return skipAlarms && position.getAttributes().containsKey(Position.KEY_ALARM);
     }
 
     private boolean filter(Position position) {

--- a/src/org/traccar/FilterHandler.java
+++ b/src/org/traccar/FilterHandler.java
@@ -30,6 +30,7 @@ public class FilterHandler extends BaseDataHandler {
     private int filterDistance;
     private int filterMaxSpeed;
     private long filterLimit;
+    private boolean allowAlarms;
 
     public void setFilterInvalid(boolean filterInvalid) {
         this.filterInvalid = filterInvalid;
@@ -67,6 +68,10 @@ public class FilterHandler extends BaseDataHandler {
         this.filterLimit = filterLimit;
     }
 
+    public void setAllowAlarms(boolean allowAlarms) {
+        this.allowAlarms = allowAlarms;
+    }
+
     public FilterHandler() {
         Config config = Context.getConfig();
         if (config != null) {
@@ -79,6 +84,7 @@ public class FilterHandler extends BaseDataHandler {
             filterDistance = config.getInteger("filter.distance");
             filterMaxSpeed = config.getInteger("filter.maxSpeed");
             filterLimit = config.getLong("filter.limit") * 1000;
+            allowAlarms = config.getBoolean("filter.allowAlarms");
         }
     }
 
@@ -127,7 +133,7 @@ public class FilterHandler extends BaseDataHandler {
         if (filterMaxSpeed != 0 && last != null) {
             double distance = position.getDouble(Position.KEY_DISTANCE);
             long time = position.getFixTime().getTime() - last.getFixTime().getTime();
-            return UnitsConverter.knotsFromMps(distance / (time / 1000)) > filterMaxSpeed;
+            return UnitsConverter.knotsFromMps(distance / (time / 1000.0)) > filterMaxSpeed;
         }
         return false;
     }
@@ -145,6 +151,10 @@ public class FilterHandler extends BaseDataHandler {
     }
 
     private boolean filter(Position position) {
+
+        if (allowAlarms && position.getAttributes().containsKey(Position.KEY_ALARM)) {
+            return false;
+        }
 
         StringBuilder filterType = new StringBuilder();
 

--- a/test/org/traccar/FilterHandlerTest.java
+++ b/test/org/traccar/FilterHandlerTest.java
@@ -77,7 +77,7 @@ public class FilterHandlerTest extends BaseTest {
         assertNotNull(passingHandler.decode(null, null, position));
 
         position.set(Position.KEY_ALARM, Position.ALARM_GENERAL);
-        filtingHandler.setAllowAlarms(true);
+        filtingHandler.setKeepAlarms(true);
         assertNotNull(filtingHandler.decode(null, null, position));
     }
 

--- a/test/org/traccar/FilterHandlerTest.java
+++ b/test/org/traccar/FilterHandlerTest.java
@@ -27,7 +27,7 @@ public class FilterHandlerTest extends BaseTest {
         filtingHandler.setFilterStatic(true);
         filtingHandler.setFilterDistance(10);
         filtingHandler.setFilterMaxSpeed(500);
-        filtingHandler.setFilterLimit(10);
+        filtingHandler.setSkipLimit(10);
     }
 
     @After
@@ -77,7 +77,7 @@ public class FilterHandlerTest extends BaseTest {
         assertNotNull(passingHandler.decode(null, null, position));
 
         position.set(Position.KEY_ALARM, Position.ALARM_GENERAL);
-        filtingHandler.setKeepAlarms(true);
+        filtingHandler.setSkipAlarms(true);
         assertNotNull(filtingHandler.decode(null, null, position));
     }
 

--- a/test/org/traccar/FilterHandlerTest.java
+++ b/test/org/traccar/FilterHandlerTest.java
@@ -75,6 +75,10 @@ public class FilterHandlerTest extends BaseTest {
 
         assertNull(filtingHandler.decode(null, null, position));
         assertNotNull(passingHandler.decode(null, null, position));
+
+        position.set(Position.KEY_ALARM, Position.ALARM_GENERAL);
+        filtingHandler.setAllowAlarms(true);
+        assertNotNull(filtingHandler.decode(null, null, position));
     }
 
 }


### PR DESCRIPTION
Some protocols report alarms without coordinates, we use last position to construct new one. Such position very likely will be filtered (if filter enabled)

Implemented configuration parameter to skip such positions (not filter)

Parameter name is controversial.


Also fixed http://findbugs.sourceforge.net/bugDescriptions.html#ICAST_IDIV_CAST_TO_DOUBLE