### PR TITLE
Make OsmAnd speed units configurable

### DIFF
--- a/src/org/traccar/BaseProtocolDecoder.java
+++ b/src/org/traccar/BaseProtocolDecoder.java
@@ -19,6 +19,7 @@ import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.socket.DatagramChannel;
 import org.jboss.netty.handler.codec.http.HttpRequestDecoder;
 import org.traccar.helper.Log;
+import org.traccar.helper.UnitsConverter;
 import org.traccar.model.Device;
 import org.traccar.model.Position;
 
@@ -64,6 +65,20 @@ public abstract class BaseProtocolDecoder extends ExtendedObjectDecoder {
 
     public String getProtocolName() {
         return protocol.getName();
+    }
+
+    protected double convertSpeed(double value, String defaultUnits) {
+        switch (Context.getConfig().getString(getProtocolName() + ".speed", defaultUnits)) {
+            case "kmh":
+                return UnitsConverter.knotsFromKph(value);
+            case "mps":
+                return UnitsConverter.knotsFromMps(value);
+            case "mph":
+                return UnitsConverter.knotsFromMph(value);
+            case "kn":
+            default:
+                return value;
+        }
     }
 
     private DeviceSession channelDeviceSession; // connection-based protocols

--- a/src/org/traccar/protocol/OsmAndProtocolDecoder.java
+++ b/src/org/traccar/protocol/OsmAndProtocolDecoder.java
@@ -25,9 +25,7 @@ import org.jboss.netty.handler.codec.http.HttpVersion;
 import org.jboss.netty.handler.codec.http.QueryStringDecoder;
 import org.joda.time.format.ISODateTimeFormat;
 import org.traccar.BaseProtocolDecoder;
-import org.traccar.Context;
 import org.traccar.DeviceSession;
-import org.traccar.helper.UnitsConverter;
 import org.traccar.model.Position;
 
 import java.net.SocketAddress;
@@ -40,11 +38,8 @@ import java.util.Map;
 
 public class OsmAndProtocolDecoder extends BaseProtocolDecoder {
 
-    private String speedUnits;
-
     public OsmAndProtocolDecoder(OsmAndProtocol protocol) {
         super(protocol);
-        speedUnits = Context.getConfig().getString("osmand.speedUnits", "kn");
     }
 
     private void sendResponse(Channel channel, HttpResponseStatus status) {
@@ -115,19 +110,7 @@ public class OsmAndProtocolDecoder extends BaseProtocolDecoder {
                     position.setLongitude(Double.parseDouble(location[1]));
                     break;
                 case "speed":
-                    switch (speedUnits) {
-                        case "kph":
-                            position.setSpeed(UnitsConverter.knotsFromKph(Double.parseDouble(value)));
-                            break;
-                        case "mps":
-                            position.setSpeed(UnitsConverter.knotsFromMps(Double.parseDouble(value)));
-                            break;
-                        case "mph":
-                            position.setSpeed(UnitsConverter.knotsFromMph(Double.parseDouble(value)));
-                            break;
-                        default:
-                            position.setSpeed(Double.parseDouble(value));
-                    }
+                    position.setSpeed(convertSpeed(Double.parseDouble(value), "kn"));
                     break;
                 case "bearing":
                 case "heading":

--- a/src/org/traccar/protocol/OsmAndProtocolDecoder.java
+++ b/src/org/traccar/protocol/OsmAndProtocolDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 - 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2013 - 2017 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,9 @@ import org.jboss.netty.handler.codec.http.HttpVersion;
 import org.jboss.netty.handler.codec.http.QueryStringDecoder;
 import org.joda.time.format.ISODateTimeFormat;
 import org.traccar.BaseProtocolDecoder;
+import org.traccar.Context;
 import org.traccar.DeviceSession;
+import org.traccar.helper.UnitsConverter;
 import org.traccar.model.Position;
 
 import java.net.SocketAddress;
@@ -38,8 +40,11 @@ import java.util.Map;
 
 public class OsmAndProtocolDecoder extends BaseProtocolDecoder {
 
+    private String speedUnits;
+
     public OsmAndProtocolDecoder(OsmAndProtocol protocol) {
         super(protocol);
+        speedUnits = Context.getConfig().getString("osmand.speedUnits", "kn");
     }
 
     private void sendResponse(Channel channel, HttpResponseStatus status) {
@@ -110,7 +115,19 @@ public class OsmAndProtocolDecoder extends BaseProtocolDecoder {
                     position.setLongitude(Double.parseDouble(location[1]));
                     break;
                 case "speed":
-                    position.setSpeed(Double.parseDouble(value));
+                    switch (speedUnits) {
+                        case "kph":
+                            position.setSpeed(UnitsConverter.knotsFromKph(Double.parseDouble(value)));
+                            break;
+                        case "mps":
+                            position.setSpeed(UnitsConverter.knotsFromMps(Double.parseDouble(value)));
+                            break;
+                        case "mph":
+                            position.setSpeed(UnitsConverter.knotsFromMph(Double.parseDouble(value)));
+                            break;
+                        default:
+                            position.setSpeed(Double.parseDouble(value));
+                    }
                     break;
                 case "bearing":
                 case "heading":

--- a/src/org/traccar/protocol/Tk103ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Tk103ProtocolDecoder.java
@@ -23,7 +23,6 @@ import org.traccar.helper.BitUtil;
 import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
-import org.traccar.helper.UnitsConverter;
 import org.traccar.model.CellTower;
 import org.traccar.model.Network;
 import org.traccar.model.Position;
@@ -253,17 +252,7 @@ public class Tk103ProtocolDecoder extends BaseProtocolDecoder {
         position.setLatitude(parser.nextCoordinate());
         position.setLongitude(parser.nextCoordinate());
 
-        switch (Context.getConfig().getString(getProtocolName() + ".speed", "kmh")) {
-            case "kn":
-                position.setSpeed(parser.nextDouble(0));
-                break;
-            case "mph":
-                position.setSpeed(UnitsConverter.knotsFromMph(parser.nextDouble(0)));
-                break;
-            default:
-                position.setSpeed(UnitsConverter.knotsFromKph(parser.nextDouble(0)));
-                break;
-        }
+        position.setSpeed(convertSpeed(parser.nextDouble(0), "kmh"));
 
         dateBuilder.setTime(parser.nextInt(0), parser.nextInt(0), parser.nextInt(0));
         position.setTime(dateBuilder.getDate());

--- a/src/org/traccar/protocol/XexunProtocolDecoder.java
+++ b/src/org/traccar/protocol/XexunProtocolDecoder.java
@@ -17,13 +17,11 @@ package org.traccar.protocol;
 
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
-import org.traccar.Context;
 import org.traccar.DeviceSession;
 import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.Position;
-import org.traccar.helper.UnitsConverter;
 
 import java.net.SocketAddress;
 import java.util.regex.Pattern;
@@ -121,14 +119,7 @@ public class XexunProtocolDecoder extends BaseProtocolDecoder {
         position.setLatitude(parser.nextCoordinate());
         position.setLongitude(parser.nextCoordinate());
 
-        switch (Context.getConfig().getString(getProtocolName() + ".speed", "kn")) {
-            case "kmh":
-                position.setSpeed(UnitsConverter.knotsFromKph(parser.nextDouble(0)));
-                break;
-            default:
-                position.setSpeed(parser.nextDouble(0));
-                break;
-        }
+        position.setSpeed(convertSpeed(parser.nextDouble(0), "kn"));
 
         position.setCourse(parser.nextDouble(0));
 


### PR DESCRIPTION
It is not obvious but looks like OsmAnd application post speed in m/s units http://osmand.net/features?id=trip-recording-plugin#Online_tracking , but Traccar Client uses knots.

I think it is good idea to make it configurable, at least server wide.

Also fix #3487 