### PR TITLE
Accept timezone id instead of offset in commands

### DIFF
--- a/src/org/traccar/protocol/CityeasyProtocolEncoder.java
+++ b/src/org/traccar/protocol/CityeasyProtocolEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Anton Tananaev (anton@traccar.org)
+ * Copyright 2015 - 2017 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package org.traccar.protocol;
+
+import java.util.TimeZone;
 
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBuffers;
@@ -56,13 +58,13 @@ public class CityeasyProtocolEncoder extends BaseProtocolEncoder {
                 content.writeShort(0);
                 return encodeContent(CityeasyProtocolDecoder.MSG_LOCATION_INTERVAL, content);
             case Command.TYPE_SET_TIMEZONE:
-                int timezone = command.getInteger(Command.KEY_TIMEZONE);
+                int timezone = TimeZone.getTimeZone(command.getString(Command.KEY_TIMEZONE)).getRawOffset() / 60000;
                 if (timezone < 0) {
                     content.writeByte(1);
                 } else {
                     content.writeByte(0);
                 }
-                content.writeShort(Math.abs(timezone) / 60);
+                content.writeShort(Math.abs(timezone));
                 return encodeContent(CityeasyProtocolDecoder.MSG_TIMEZONE, content);
             default:
                 Log.warning(new UnsupportedOperationException(command.getType()));

--- a/src/org/traccar/protocol/Jt600ProtocolEncoder.java
+++ b/src/org/traccar/protocol/Jt600ProtocolEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2016 - 2017 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package org.traccar.protocol;
 
+import java.util.TimeZone;
+
 import org.traccar.StringProtocolEncoder;
 import org.traccar.helper.Log;
 import org.traccar.model.Command;
@@ -29,7 +31,7 @@ public class Jt600ProtocolEncoder extends StringProtocolEncoder {
             case Command.TYPE_ENGINE_RESUME:
                 return "(S07,1)";
             case Command.TYPE_SET_TIMEZONE:
-                int offset = command.getInteger(Command.KEY_TIMEZONE) / 60;
+                int offset = TimeZone.getTimeZone(command.getString(Command.KEY_TIMEZONE)).getRawOffset() / 60000;
                 return "(S09,1," + offset + ")";
             case Command.TYPE_REBOOT_DEVICE:
                 return "(S17)";

--- a/src/org/traccar/protocol/MeiligaoProtocolEncoder.java
+++ b/src/org/traccar/protocol/MeiligaoProtocolEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Anton Tananaev (anton@traccar.org)
+ * Copyright 2015 - 2017 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.traccar.model.Command;
 
 import javax.xml.bind.DatatypeConverter;
 import java.nio.charset.StandardCharsets;
+import java.util.TimeZone;
 
 public class MeiligaoProtocolEncoder extends BaseProtocolEncoder {
 
@@ -78,7 +79,7 @@ public class MeiligaoProtocolEncoder extends BaseProtocolEncoder {
                 content.writeShort(command.getInteger(Command.KEY_RADIUS));
                 return encodeContent(command.getDeviceId(), MSG_MOVEMENT_ALARM, content);
             case Command.TYPE_SET_TIMEZONE:
-                int offset = command.getInteger(Command.KEY_TIMEZONE) / 60;
+                int offset = TimeZone.getTimeZone(command.getString(Command.KEY_TIMEZONE)).getRawOffset() / 60000;
                 content.writeBytes(String.valueOf(offset).getBytes(StandardCharsets.US_ASCII));
                 return encodeContent(command.getDeviceId(), MSG_TIME_ZONE, content);
             case Command.TYPE_REBOOT_DEVICE:

--- a/src/org/traccar/protocol/MiniFinderProtocolEncoder.java
+++ b/src/org/traccar/protocol/MiniFinderProtocolEncoder.java
@@ -29,7 +29,7 @@ public class MiniFinderProtocolEncoder extends StringProtocolEncoder implements 
         if (key.equals(Command.KEY_ENABLE)) {
             return (Boolean) value ? "1" : "0";
         } else if (key.equals(Command.KEY_TIMEZONE)) {
-            return String.format("%+03d", TimeZone.getTimeZone(value.toString()).getRawOffset() / 3600000);
+            return String.format("%+03d", TimeZone.getTimeZone((String) value).getRawOffset() / 3600000);
         } else if (key.equals(Command.KEY_INDEX)) {
             switch (((Number) value).intValue()) {
                 case 0:

--- a/src/org/traccar/protocol/MiniFinderProtocolEncoder.java
+++ b/src/org/traccar/protocol/MiniFinderProtocolEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2016 - 2017 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package org.traccar.protocol;
 
+import java.util.TimeZone;
+
 import org.traccar.StringProtocolEncoder;
 import org.traccar.helper.Log;
 import org.traccar.model.Command;
@@ -27,7 +29,7 @@ public class MiniFinderProtocolEncoder extends StringProtocolEncoder implements 
         if (key.equals(Command.KEY_ENABLE)) {
             return (Boolean) value ? "1" : "0";
         } else if (key.equals(Command.KEY_TIMEZONE)) {
-            return String.format("%+03d", ((Number) value).longValue() / 3600);
+            return String.format("%+03d", TimeZone.getTimeZone(value.toString()).getRawOffset() / 3600000);
         } else if (key.equals(Command.KEY_INDEX)) {
             switch (((Number) value).intValue()) {
                 case 0:

--- a/src/org/traccar/protocol/Pt502ProtocolEncoder.java
+++ b/src/org/traccar/protocol/Pt502ProtocolEncoder.java
@@ -26,7 +26,7 @@ public class Pt502ProtocolEncoder extends StringProtocolEncoder implements Strin
     @Override
     public String formatValue(String key, Object value) {
         if (key.equals(Command.KEY_TIMEZONE)) {
-            return String.valueOf(TimeZone.getTimeZone(value.toString()).getRawOffset() / 3600000);
+            return String.valueOf(TimeZone.getTimeZone((String) value).getRawOffset() / 3600000);
         }
 
         return null;
@@ -34,7 +34,7 @@ public class Pt502ProtocolEncoder extends StringProtocolEncoder implements Strin
 
     @Override
     protected String formatCommand(Command command, String format, String... keys) {
-        return super.formatCommand(command, format, this, keys);
+        return formatCommand(command, format, this, keys);
     }
 
     @Override

--- a/src/org/traccar/protocol/Pt502ProtocolEncoder.java
+++ b/src/org/traccar/protocol/Pt502ProtocolEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2016 - 2017 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,27 @@
  */
 package org.traccar.protocol;
 
+import java.util.TimeZone;
+
 import org.traccar.StringProtocolEncoder;
 import org.traccar.helper.Log;
 import org.traccar.model.Command;
 
-public class Pt502ProtocolEncoder extends StringProtocolEncoder {
+public class Pt502ProtocolEncoder extends StringProtocolEncoder implements StringProtocolEncoder.ValueFormatter {
+
+    @Override
+    public String formatValue(String key, Object value) {
+        if (key.equals(Command.KEY_TIMEZONE)) {
+            return String.valueOf(TimeZone.getTimeZone(value.toString()).getRawOffset() / 3600000);
+        }
+
+        return null;
+    }
+
+    @Override
+    protected String formatCommand(Command command, String format, String... keys) {
+        return super.formatCommand(command, format, this, keys);
+    }
 
     @Override
     protected Object encodeCommand(Command command) {

--- a/src/org/traccar/protocol/WatchProtocolEncoder.java
+++ b/src/org/traccar/protocol/WatchProtocolEncoder.java
@@ -33,7 +33,7 @@ public class WatchProtocolEncoder extends StringProtocolEncoder implements Strin
     @Override
     public String formatValue(String key, Object value) {
         if (key.equals(Command.KEY_TIMEZONE)) {
-            double offset = TimeZone.getTimeZone(value.toString()).getRawOffset() / 3600000.0;
+            double offset = TimeZone.getTimeZone((String) value).getRawOffset() / 3600000.0;
             DecimalFormat fmt = new DecimalFormat("+#.##;-#.##", DecimalFormatSymbols.getInstance(Locale.US));
             return fmt.format(offset);
         }
@@ -44,7 +44,7 @@ public class WatchProtocolEncoder extends StringProtocolEncoder implements Strin
 
     @Override
     protected String formatCommand(Command command, String format, String... keys) {
-        String content = super.formatCommand(command, format, this, keys);
+        String content = formatCommand(command, format, this, keys);
         return String.format("[CS*%s*%04x*%s]",
                 getUniqueId(command.getDeviceId()), content.length(), content);
     }

--- a/src/org/traccar/protocol/WatchProtocolEncoder.java
+++ b/src/org/traccar/protocol/WatchProtocolEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2016 - 2017 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,13 +26,14 @@ import java.text.DecimalFormatSymbols;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.TimeZone;
 
 public class WatchProtocolEncoder extends StringProtocolEncoder implements StringProtocolEncoder.ValueFormatter {
 
     @Override
     public String formatValue(String key, Object value) {
         if (key.equals(Command.KEY_TIMEZONE)) {
-            double offset = ((Number) value).longValue() / 3600.0;
+            double offset = TimeZone.getTimeZone(value.toString()).getRawOffset() / 3600000.0;
             DecimalFormat fmt = new DecimalFormat("+#.##;-#.##", DecimalFormatSymbols.getInstance(Locale.US));
             return fmt.format(offset);
         }
@@ -41,6 +42,7 @@ public class WatchProtocolEncoder extends StringProtocolEncoder implements Strin
     }
 
 
+    @Override
     protected String formatCommand(Command command, String format, String... keys) {
         String content = super.formatCommand(command, format, this, keys);
         return String.format("[CS*%s*%04x*%s]",

--- a/test/org/traccar/protocol/CityeasyProtocolEncoderTest.java
+++ b/test/org/traccar/protocol/CityeasyProtocolEncoderTest.java
@@ -10,11 +10,11 @@ public class CityeasyProtocolEncoderTest extends ProtocolTest {
     public void testEncode() throws Exception {
 
         CityeasyProtocolEncoder encoder = new CityeasyProtocolEncoder();
-        
+
         Command command = new Command();
         command.setDeviceId(1);
         command.setType(Command.TYPE_SET_TIMEZONE);
-        command.set(Command.KEY_TIMEZONE, 6 * 3600);
+        command.set(Command.KEY_TIMEZONE, "GMT+6");
 
         verifyCommand(encoder, command, binary("5353001100080001680000000B60820D0A"));
 

--- a/test/org/traccar/protocol/Jt600ProtocolEncoderTest.java
+++ b/test/org/traccar/protocol/Jt600ProtocolEncoderTest.java
@@ -25,7 +25,7 @@ public class Jt600ProtocolEncoderTest extends ProtocolTest {
     @Test
     public void testSetTimezone() throws Exception {
         command.setType(Command.TYPE_SET_TIMEZONE);
-        command.set(Command.KEY_TIMEZONE, 240 * 60);
+        command.set(Command.KEY_TIMEZONE, "GMT+4");
         assertEquals("(S09,1,240)", encoder.encodeCommand(command));
     }
 

--- a/test/org/traccar/protocol/MeiligaoProtocolEncoderTest.java
+++ b/test/org/traccar/protocol/MeiligaoProtocolEncoderTest.java
@@ -10,7 +10,7 @@ public class MeiligaoProtocolEncoderTest extends ProtocolTest {
     public void testEncode() throws Exception {
 
         MeiligaoProtocolEncoder encoder = new MeiligaoProtocolEncoder();
-        
+
         Command command = new Command();
         command.setDeviceId(1);
         command.setType(Command.TYPE_POSITION_SINGLE);
@@ -23,7 +23,7 @@ public class MeiligaoProtocolEncoderTest extends ProtocolTest {
         verifyCommand(encoder, command, binary("40400013123456789012344102000a2f4f0d0a"));
 
         command.setType(Command.TYPE_SET_TIMEZONE);
-        command.set(Command.KEY_TIMEZONE, 480 * 60);
+        command.set(Command.KEY_TIMEZONE, "GMT+8");
 
         verifyCommand(encoder, command, binary("4040001412345678901234413234383030ad0d0a"));
 

--- a/test/org/traccar/protocol/MiniFinderProtocolEncoderTest.java
+++ b/test/org/traccar/protocol/MiniFinderProtocolEncoderTest.java
@@ -11,12 +11,12 @@ public class MiniFinderProtocolEncoderTest extends ProtocolTest {
     public void testEncode() throws Exception {
 
         MiniFinderProtocolEncoder encoder = new MiniFinderProtocolEncoder();
-        
+
         Command command = new Command();
         command.setDeviceId(1);
         command.setType(Command.TYPE_SET_TIMEZONE);
-        command.set(Command.KEY_TIMEZONE, 3600);
-        
+        command.set(Command.KEY_TIMEZONE, "GMT+1");
+
         Assert.assertEquals("123456L+01", encoder.encodeCommand(command));
 
         command = new Command();

--- a/test/org/traccar/protocol/Pt502ProtocolEncoderTest.java
+++ b/test/org/traccar/protocol/Pt502ProtocolEncoderTest.java
@@ -30,7 +30,7 @@ public class Pt502ProtocolEncoderTest extends ProtocolTest {
         Command command = new Command();
         command.setDeviceId(1);
         command.setType(Command.TYPE_SET_TIMEZONE);
-        command.set(Command.KEY_TIMEZONE, 8);
+        command.set(Command.KEY_TIMEZONE, "GMT+8");
 
         Assert.assertEquals("#TMZ8\r\n", encoder.encodeCommand(command));
 

--- a/test/org/traccar/protocol/WatchProtocolEncoderTest.java
+++ b/test/org/traccar/protocol/WatchProtocolEncoderTest.java
@@ -41,16 +41,16 @@ public class WatchProtocolEncoderTest extends ProtocolTest {
         command = new Command();
         command.setDeviceId(1);
         command.setType(Command.TYPE_SET_TIMEZONE);
-        command.set(Command.KEY_TIMEZONE, 60 * 60);
+        command.set(Command.KEY_TIMEZONE, "Europe/Amsterdam");
         Assert.assertEquals("[CS*123456789012345*0006*LZ,,+1]", encoder.encodeCommand(command));
 
-        command.set(Command.KEY_TIMEZONE, 90 * 60);
+        command.set(Command.KEY_TIMEZONE, "GMT+01:30");
         Assert.assertEquals("[CS*123456789012345*0008*LZ,,+1.5]", encoder.encodeCommand(command));
 
-        command.set(Command.KEY_TIMEZONE, -60 * 60);
+        command.set(Command.KEY_TIMEZONE, "Atlantic/Azores");
         Assert.assertEquals("[CS*123456789012345*0006*LZ,,-1]", encoder.encodeCommand(command));
 
-        command.set(Command.KEY_TIMEZONE, -11 * 60 * 60 - 30 * 60);
+        command.set(Command.KEY_TIMEZONE, "GMT-11:30");
         Assert.assertEquals("[CS*123456789012345*0009*LZ,,-11.5]", encoder.encodeCommand(command));
 
     }


### PR DESCRIPTION
In continuous #3496  
Decided to replace how we treat `Command.KEY_TIMEZONE`. Now it is timezone id (like user/server timezone)
As about backward compatibility, i think it will be easy convert seconds to "GMT+XX:XX" if somebody use this API.

Unfortunately `TimeZone.getTimeZone()` return "GMT" not exception if passed unknown/incorrect id but I thing it is OK.

PS: Pt502 does not have any Timezone formatting, and worked incorrectly.