### PR TITLE
Handle correct and incorrect attribute types

### DIFF
--- a/src/org/traccar/database/DeviceManager.java
+++ b/src/org/traccar/database/DeviceManager.java
@@ -262,59 +262,44 @@ public class DeviceManager extends BaseObjectManager<Device> implements Identity
 
     public boolean lookupAttributeBoolean(
             long deviceId, String attributeName, boolean defaultValue, boolean lookupConfig) {
-        String result = lookupAttribute(deviceId, attributeName, lookupConfig);
-        if (result != null) {
-            return Boolean.parseBoolean(result);
-        }
-        return defaultValue;
+        Object result = lookupAttribute(deviceId, attributeName, lookupConfig);
+        return result != null ? Boolean.parseBoolean(result.toString()) : defaultValue;
     }
 
     public String lookupAttributeString(
             long deviceId, String attributeName, String defaultValue, boolean lookupConfig) {
-        String result = lookupAttribute(deviceId, attributeName, lookupConfig);
-        if (result != null) {
-            return result;
-        }
-        return defaultValue;
+        Object result = lookupAttribute(deviceId, attributeName, lookupConfig);
+        return result != null ? result.toString() : defaultValue;
     }
 
     public int lookupAttributeInteger(long deviceId, String attributeName, int defaultValue, boolean lookupConfig) {
-        String result = lookupAttribute(deviceId, attributeName, lookupConfig);
-        if (result != null) {
-            return Integer.parseInt(result);
-        }
-        return defaultValue;
+        Object result = lookupAttribute(deviceId, attributeName, lookupConfig);
+        return result != null ? Integer.parseInt(result.toString()) : defaultValue;
     }
 
     public long lookupAttributeLong(
             long deviceId, String attributeName, long defaultValue, boolean lookupConfig) {
-        String result = lookupAttribute(deviceId, attributeName, lookupConfig);
-        if (result != null) {
-            return Long.parseLong(result);
-        }
-        return defaultValue;
+        Object result = lookupAttribute(deviceId, attributeName, lookupConfig);
+        return result != null ? Long.parseLong(result.toString()) : defaultValue;
     }
 
     public double lookupAttributeDouble(
             long deviceId, String attributeName, double defaultValue, boolean lookupConfig) {
-        String result = lookupAttribute(deviceId, attributeName, lookupConfig);
-        if (result != null) {
-            return Double.parseDouble(result);
-        }
-        return defaultValue;
+        Object result = lookupAttribute(deviceId, attributeName, lookupConfig);
+        return result != null ? Double.parseDouble(result.toString()) : defaultValue;
     }
 
-    private String lookupAttribute(long deviceId, String attributeName, boolean lookupConfig) {
-        String result = null;
+    private Object lookupAttribute(long deviceId, String attributeName, boolean lookupConfig) {
+        Object result = null;
         Device device = getById(deviceId);
         if (device != null) {
-            result = device.getString(attributeName);
+            result = device.getAttributes().get(attributeName);
             if (result == null && lookupGroupsAttribute) {
                 long groupId = device.getGroupId();
                 while (groupId != 0) {
                     Group group = Context.getGroupsManager().getById(groupId);
                     if (group != null) {
-                        result = group.getString(attributeName);
+                        result = group.getAttributes().get(attributeName);
                         if (result != null) {
                             break;
                         }
@@ -329,7 +314,7 @@ public class DeviceManager extends BaseObjectManager<Device> implements Identity
                     result = Context.getConfig().getString(attributeName);
                 } else {
                     Server server = Context.getPermissionsManager().getServer();
-                    result = server.getString(attributeName);
+                    result = server.getAttributes().get(attributeName);
                 }
             }
         }

--- a/src/org/traccar/database/DeviceManager.java
+++ b/src/org/traccar/database/DeviceManager.java
@@ -263,30 +263,42 @@ public class DeviceManager extends BaseObjectManager<Device> implements Identity
     public boolean lookupAttributeBoolean(
             long deviceId, String attributeName, boolean defaultValue, boolean lookupConfig) {
         Object result = lookupAttribute(deviceId, attributeName, lookupConfig);
-        return result != null ? Boolean.parseBoolean(result.toString()) : defaultValue;
+        if (result != null) {
+            return result instanceof String ? Boolean.parseBoolean((String) result) : (Boolean) result;
+        }
+        return defaultValue;
     }
 
     public String lookupAttributeString(
             long deviceId, String attributeName, String defaultValue, boolean lookupConfig) {
         Object result = lookupAttribute(deviceId, attributeName, lookupConfig);
-        return result != null ? result.toString() : defaultValue;
+        return result != null ? (String) result : defaultValue;
     }
 
     public int lookupAttributeInteger(long deviceId, String attributeName, int defaultValue, boolean lookupConfig) {
         Object result = lookupAttribute(deviceId, attributeName, lookupConfig);
-        return result != null ? Integer.parseInt(result.toString()) : defaultValue;
+        if (result != null) {
+            return result instanceof String ? Integer.parseInt((String) result) : ((Number) result).intValue();
+        }
+        return defaultValue;
     }
 
     public long lookupAttributeLong(
             long deviceId, String attributeName, long defaultValue, boolean lookupConfig) {
         Object result = lookupAttribute(deviceId, attributeName, lookupConfig);
-        return result != null ? Long.parseLong(result.toString()) : defaultValue;
+        if (result != null) {
+            return result instanceof String ? Long.parseLong((String) result) : ((Number) result).longValue();
+        }
+        return defaultValue;
     }
 
     public double lookupAttributeDouble(
             long deviceId, String attributeName, double defaultValue, boolean lookupConfig) {
         Object result = lookupAttribute(deviceId, attributeName, lookupConfig);
-        return result != null ? Double.parseDouble(result.toString()) : defaultValue;
+        if (result != null) {
+            return result instanceof String ? Double.parseDouble((String) result) : ((Number) result).doubleValue();
+        }
+        return defaultValue;
     }
 
     private Object lookupAttribute(long deviceId, String attributeName, boolean lookupConfig) {

--- a/src/org/traccar/model/ExtendedModel.java
+++ b/src/org/traccar/model/ExtendedModel.java
@@ -100,7 +100,7 @@ public class ExtendedModel extends BaseModel {
 
     public boolean getBoolean(String key) {
         if (attributes.containsKey(key)) {
-            return Boolean.parseBoolean(attributes.get(key).toString());
+            return (Boolean) attributes.get(key);
         } else {
             return false;
         }

--- a/src/org/traccar/notification/NotificationMail.java
+++ b/src/org/traccar/notification/NotificationMail.java
@@ -43,7 +43,7 @@ public final class NotificationMail {
         if (host != null) {
             properties.put("mail.transport.protocol", provider.getString("mail.transport.protocol", "smtp"));
             properties.put("mail.smtp.host", host);
-            properties.put("mail.smtp.port", provider.getString("mail.smtp.port", "25"));
+            properties.put("mail.smtp.port", String.valueOf(provider.getInteger("mail.smtp.port", 25)));
 
             String starttlsEnable = provider.getString("mail.smtp.starttls.enable");
             if (starttlsEnable != null) {

--- a/src/org/traccar/notification/PropertiesProvider.java
+++ b/src/org/traccar/notification/PropertiesProvider.java
@@ -51,10 +51,13 @@ public class PropertiesProvider {
     public int getInteger(String key, int defaultValue) {
         if (config != null) {
             return config.getInteger(key, defaultValue);
-        } else if (extendedModel.getAttributes().containsKey(key)) {
-            return Integer.parseInt(extendedModel.getAttributes().get(key).toString());
         } else {
-            return defaultValue;
+            Object result = extendedModel.getAttributes().get(key);
+            if (result != null) {
+                return result instanceof String ? Integer.parseInt((String) result) : (Integer) result;
+            } else {
+                return defaultValue;
+            }
         }
     }
 

--- a/src/org/traccar/notification/PropertiesProvider.java
+++ b/src/org/traccar/notification/PropertiesProvider.java
@@ -48,4 +48,14 @@ public class PropertiesProvider {
         return value;
     }
 
+    public int getInteger(String key, int defaultValue) {
+        if (config != null) {
+            return config.getInteger(key, defaultValue);
+        } else if (extendedModel.getAttributes().containsKey(key)) {
+            return Integer.parseInt(extendedModel.getAttributes().get(key).toString());
+        } else {
+            return defaultValue;
+        }
+    }
+
 }

--- a/src/org/traccar/protocol/OsmAndProtocolDecoder.java
+++ b/src/org/traccar/protocol/OsmAndProtocolDecoder.java
@@ -135,7 +135,17 @@ public class OsmAndProtocolDecoder extends BaseProtocolDecoder {
                     try {
                         position.set(entry.getKey(), Double.parseDouble(value));
                     } catch (NumberFormatException e) {
-                        position.set(entry.getKey(), value);
+                        switch (value) {
+                            case "true":
+                                position.set(entry.getKey(), true);
+                                break;
+                            case "false":
+                                position.set(entry.getKey(), false);
+                                break;
+                            default:
+                                position.set(entry.getKey(), value);
+                                break;
+                        }
                     }
                     break;
             }

--- a/test/org/traccar/ProtocolTest.java
+++ b/test/org/traccar/ProtocolTest.java
@@ -241,6 +241,10 @@ public class ProtocolTest extends BaseTest {
             Assert.assertTrue(attributes.get(Position.KEY_CHARGE) instanceof Boolean);
         }
 
+        if (attributes.containsKey(Position.KEY_IGNITION)) {
+            Assert.assertTrue(attributes.get(Position.KEY_IGNITION) instanceof Boolean);
+        }
+
         if (attributes.containsKey(Position.KEY_MOTION)) {
             Assert.assertTrue(attributes.get(Position.KEY_MOTION) instanceof Boolean);
         }

--- a/test/org/traccar/protocol/OsmAndProtocolDecoderTest.java
+++ b/test/org/traccar/protocol/OsmAndProtocolDecoderTest.java
@@ -37,6 +37,9 @@ public class OsmAndProtocolDecoderTest extends ProtocolTest {
         verifyPosition(decoder, request(
                 "/?id=123456&timestamp=1377177267&location=60.0,30.0"));
 
+        verifyPosition(decoder, request(
+                "/?id=123456789012345&timestamp=1504763810&lat=40.7232948571&lon=-74.0061408571&bearing=7.19889788244&speed=40&ignition=true&rpm=933&fuel=24"));
+
     }
 
 }


### PR DESCRIPTION
- Moved Boolean workaround outside the `ExtendedModel`. I think it should be clean.
- Adapted `DeviceManager.lookupAttributeXxx` to handle correct and incorrect types (temporary solution, for year or so)
- Handle boolean attributes in `OsmAndProtocol`
- Handle `mail.smtp.port` as integer

Some comments in code