### PR TITLE
Implement skipping filtering by list of attributes

### DIFF
--- a/test/org/traccar/BaseTest.java
+++ b/test/org/traccar/BaseTest.java
@@ -40,25 +40,25 @@ public class BaseTest {
             @Override
             public boolean lookupAttributeBoolean(
                     long deviceId, String attributeName, boolean defaultValue, boolean lookupConfig) {
-                return false;
+                return defaultValue;
             }
 
             @Override
             public String lookupAttributeString(
                     long deviceId, String attributeName, String defaultValue, boolean lookupConfig) {
-                return null;
+                return defaultValue;
             }
 
             @Override
             public int lookupAttributeInteger(
                     long deviceId, String attributeName, int defaultValue, boolean lookupConfig) {
-                return 0;
+                return defaultValue;
             }
 
             @Override
             public long lookupAttributeLong(
                     long deviceId, String attributeName, long defaultValue, boolean lookupConfig) {
-                return 0;
+                return defaultValue;
             }
 
         });

--- a/test/org/traccar/FilterHandlerTest.java
+++ b/test/org/traccar/FilterHandlerTest.java
@@ -3,6 +3,8 @@ package org.traccar;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.traccar.database.IdentityManager;
+import org.traccar.model.Device;
 import org.traccar.model.Position;
 
 import java.util.Date;
@@ -10,7 +12,65 @@ import java.util.Date;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-public class FilterHandlerTest extends BaseTest {
+public class FilterHandlerTest {
+
+    static {
+        Context.init(new IdentityManager() {
+
+            private Device createDevice() {
+                Device device = new Device();
+                device.setId(1);
+                device.setName("test");
+                device.setUniqueId("123456789012345");
+                return device;
+            }
+
+            @Override
+            public Device getById(long id) {
+                return createDevice();
+            }
+
+            @Override
+            public Device getByUniqueId(String uniqueId) {
+                return createDevice();
+            }
+            
+            @Override
+            public Position getLastPosition(long deviceId) {
+                return null;
+            }
+            
+            @Override
+            public boolean isLatestPosition(Position position) {
+                return true;
+            }
+
+            @Override
+            public boolean lookupAttributeBoolean(
+                    long deviceId, String attributeName, boolean defaultValue, boolean lookupConfig) {
+                return defaultValue;
+            }
+
+            @Override
+            public String lookupAttributeString(
+                    long deviceId, String attributeName, String defaultValue, boolean lookupConfig) {
+                return "alarm,result";
+            }
+
+            @Override
+            public int lookupAttributeInteger(
+                    long deviceId, String attributeName, int defaultValue, boolean lookupConfig) {
+                return defaultValue;
+            }
+
+            @Override
+            public long lookupAttributeLong(
+                    long deviceId, String attributeName, long defaultValue, boolean lookupConfig) {
+                return defaultValue;
+            }
+
+        });
+    }
 
     private FilterHandler filtingHandler;
     private FilterHandler passingHandler;
@@ -77,7 +137,7 @@ public class FilterHandlerTest extends BaseTest {
         assertNotNull(passingHandler.decode(null, null, position));
 
         position.set(Position.KEY_ALARM, Position.ALARM_GENERAL);
-        filtingHandler.setSkipAlarms(true);
+        filtingHandler.setSkipAttributes(true);
         assertNotNull(filtingHandler.decode(null, null, position));
     }
 


### PR DESCRIPTION
Main switch is `filter.skipAttributes.enable` because lookup might costs a lot.
Attributes list should be in `filter.skipAttributes`

fix #3513 

More comments in code