### PR TITLE
Teltonika: store command response as KEY_RESULT

### DIFF
--- a/src/org/traccar/protocol/TeltonikaProtocolDecoder.java
+++ b/src/org/traccar/protocol/TeltonikaProtocolDecoder.java
@@ -76,7 +76,7 @@ public class TeltonikaProtocolDecoder extends BaseProtocolDecoder {
 
         position.set(Position.KEY_TYPE, buf.readUnsignedByte());
 
-        position.set(Position.KEY_COMMAND, buf.readBytes(buf.readInt()).toString(StandardCharsets.US_ASCII));
+        position.set(Position.KEY_RESULT, buf.readBytes(buf.readInt()).toString(StandardCharsets.US_ASCII));
 
     }
 


### PR DESCRIPTION
Looks like it was implemented before we started handle command responses in modern way
https://github.com/tananaev/traccar/commit/17744264e2938cf8c87346c175e458cd89a1f3c6#diff-1fcc7f951825555b40d62ec37802158f

I've checked on real device, send command "getparam 800" and got this:

![image](https://user-images.githubusercontent.com/5688080/30692027-326af32c-9ee3-11e7-884f-9975006844d4.png)
