### PR TITLE
Added new Parser.DateTimeFormat, HMSno0

### DIFF
--- a/src/org/traccar/helper/Parser.java
+++ b/src/org/traccar/helper/Parser.java
@@ -212,6 +212,7 @@ public class Parser {
     }
 
     public enum DateTimeFormat {
+        HMSno0,
         HMS,
         SMH,
         HMS_YMD,
@@ -226,9 +227,16 @@ public class Parser {
 
     public Date nextDateTime(DateTimeFormat format, String timeZone) {
         int year = 0, month = 0, day = 0;
-        int hour = 0, minute = 0, second = 0, millisecond = 0;
+        int hour, minute, second, millisecond = 0;
+        int time;
 
         switch (format) {
+            case HMSno0:  // d{1-6} with no leading zeros
+                time = nextInt(0);
+                hour = time / 100 / 100;
+                minute = time / 100 % 100;
+                second = time % 100;
+                break;
             case HMS:
                 hour = nextInt(0);
                 minute = nextInt(0);

--- a/src/org/traccar/protocol/CradlepointProtocolDecoder.java
+++ b/src/org/traccar/protocol/CradlepointProtocolDecoder.java
@@ -18,13 +18,11 @@ package org.traccar.protocol;
 import org.jboss.netty.channel.Channel;
 import org.traccar.BaseProtocolDecoder;
 import org.traccar.DeviceSession;
-import org.traccar.helper.DateBuilder;
 import org.traccar.helper.Parser;
 import org.traccar.helper.PatternBuilder;
 import org.traccar.model.Position;
 
 import java.net.SocketAddress;
-import java.util.Date;
 import java.util.regex.Pattern;
 
 public class CradlepointProtocolDecoder extends BaseProtocolDecoder {
@@ -35,7 +33,7 @@ public class CradlepointProtocolDecoder extends BaseProtocolDecoder {
 
     private static final Pattern PATTERN = new PatternBuilder()
             .expression("([^,]+),")              // id
-            .number("(d{1,6}),")                 // time (hhmmss)
+            .number("(d{1,6}),")                 // time (hhmmss), no leading zeros
             .number("(d+)(dd.d+),")              // latitude
             .expression("([NS]),")
             .number("(d+)(dd.d+),")              // longitude
@@ -69,12 +67,7 @@ public class CradlepointProtocolDecoder extends BaseProtocolDecoder {
         position.setProtocol(getProtocolName());
         position.setDeviceId(deviceSession.getDeviceId());
 
-        int time = parser.nextInt();
-        DateBuilder dateBuilder = new DateBuilder(new Date());
-        dateBuilder.setHour(time / 100 / 100);
-        dateBuilder.setMinute(time / 100 % 100);
-        dateBuilder.setSecond(time % 100);
-        position.setTime(dateBuilder.getDate());
+        position.setTime(parser.nextDateTime(Parser.DateTimeFormat.HMSno0));
 
         position.setValid(true);
         position.setLatitude(parser.nextCoordinate());


### PR DESCRIPTION
I added a new date/time format to deal with the fact that the Cradlepoint protocol provides time with no leading zeros.  I didn't like having the special case in the protocol decoder.

Even though there is only one case that does this, no doubt another protocol may do the same thing in the future and it is best to have all the date/time logic in one place so the protocol decoders can look similar.
