### PR TITLE
Set deviceId in Saved Command before sending

### DIFF
--- a/src/org/traccar/api/resource/CommandResource.java
+++ b/src/org/traccar/api/resource/CommandResource.java
@@ -69,8 +69,7 @@ public class CommandResource extends ExtendedObjectResource<Command> {
         } else {
             Context.getPermissionsManager().checkLimitCommands(getUserId());
         }
-        boolean sent = Context.getCommandsManager().sendCommand(entity);
-        if (!sent) {
+        if (!Context.getCommandsManager().sendCommand(entity)) {
             return Response.accepted(entity).build();
         }
         return Response.ok(entity).build();

--- a/src/org/traccar/api/resource/CommandResource.java
+++ b/src/org/traccar/api/resource/CommandResource.java
@@ -62,17 +62,14 @@ public class CommandResource extends ExtendedObjectResource<Command> {
         Context.getPermissionsManager().checkReadonly(getUserId());
         long deviceId = entity.getDeviceId();
         long id = entity.getId();
-        boolean sent;
-        if (deviceId != 0 && id != 0) {
+        Context.getPermissionsManager().checkDevice(getUserId(), deviceId);
+        if (id != 0) {
             Context.getPermissionsManager().checkPermission(Command.class, getUserId(), id);
-            Context.getPermissionsManager().checkDevice(getUserId(), deviceId);
             Context.getPermissionsManager().checkUserDeviceCommand(getUserId(), deviceId, id);
-            sent = Context.getCommandsManager().sendCommand(id, deviceId);
         } else {
             Context.getPermissionsManager().checkLimitCommands(getUserId());
-            Context.getPermissionsManager().checkDevice(getUserId(), deviceId);
-            sent = Context.getCommandsManager().sendCommand(entity, deviceId);
         }
+        boolean sent = Context.getCommandsManager().sendCommand(entity);
         if (!sent) {
             return Response.accepted(entity).build();
         }

--- a/src/org/traccar/database/CommandsManager.java
+++ b/src/org/traccar/database/CommandsManager.java
@@ -45,11 +45,15 @@ public class CommandsManager  extends ExtendedObjectManager<Command> {
         return !getAllDeviceItems(deviceId).contains(commandId);
     }
 
-    public boolean sendCommand(long commandId, long deviceId) throws Exception {
-        return sendCommand(getById(commandId), deviceId);
-    }
-
-    public boolean sendCommand(Command command, long deviceId) throws Exception {
+    public boolean sendCommand(Command command) throws Exception {
+        long deviceId = command.getDeviceId();
+        if (command.getId() != 0) {
+            Command savedCommand = getById(command.getId());
+            command.setTextChannel(savedCommand.getTextChannel());
+            command.setType(savedCommand.getType());
+            command.setAttributes(savedCommand.getAttributes());
+            command.setDescription(savedCommand.getDescription());
+        }
         boolean sent = true;
         if (command.getTextChannel()) {
             Position lastPosition = Context.getIdentityManager().getLastPosition(deviceId);

--- a/src/org/traccar/database/CommandsManager.java
+++ b/src/org/traccar/database/CommandsManager.java
@@ -48,13 +48,9 @@ public class CommandsManager  extends ExtendedObjectManager<Command> {
     public boolean sendCommand(Command command) throws Exception {
         long deviceId = command.getDeviceId();
         if (command.getId() != 0) {
-            Command savedCommand = getById(command.getId());
-            command.setTextChannel(savedCommand.getTextChannel());
-            command.setType(savedCommand.getType());
-            command.setAttributes(savedCommand.getAttributes());
-            command.setDescription(savedCommand.getDescription());
+            command = getById(command.getId()).clone();
+            command.setDeviceId(deviceId);
         }
-        boolean sent = true;
         if (command.getTextChannel()) {
             Position lastPosition = Context.getIdentityManager().getLastPosition(deviceId);
             String phone = Context.getIdentityManager().getById(deviceId).getPhone();
@@ -75,10 +71,11 @@ public class CommandsManager  extends ExtendedObjectManager<Command> {
             if (activeDevice != null) {
                 activeDevice.sendCommand(command);
             } else {
-                sent = !getDeviceQueue(deviceId).add(command);
+                getDeviceQueue(deviceId).add(command);
+                return false;
             }
         }
-        return sent;
+        return true;
     }
 
     public Collection<Long> getSupportedCommands(long deviceId) {

--- a/src/org/traccar/model/Command.java
+++ b/src/org/traccar/model/Command.java
@@ -20,7 +20,7 @@ import org.traccar.database.QueryIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class Command extends Message {
+public class Command extends Message implements Cloneable {
 
     public static final String TYPE_CUSTOM = "custom";
     public static final String TYPE_IDENTIFICATION = "deviceIdentification";
@@ -76,6 +76,11 @@ public class Command extends Message {
     public static final String KEY_PHONE = "phone";
     public static final String KEY_SERVER = "server";
     public static final String KEY_PORT = "port";
+
+    @Override
+    public Command clone() throws CloneNotSupportedException {
+      return (Command) super.clone();
+    }
 
     private boolean textChannel;
 

--- a/src/org/traccar/model/Command.java
+++ b/src/org/traccar/model/Command.java
@@ -79,7 +79,7 @@ public class Command extends Message implements Cloneable {
 
     @Override
     public Command clone() throws CloneNotSupportedException {
-      return (Command) super.clone();
+        return (Command) super.clone();
     }
 
     private boolean textChannel;


### PR DESCRIPTION
We can't send bare Saved Command, we need to set `deviceId` in it before sending to log working correctly. Also we can't set `deviceId` in Saved Command to not change cached instance.

I decided just override incoming entity with cached Saved Command

Also optimized resource a bit.

fix #3592 

PS: tested with a real device