### PR TITLE
Map "Math" to Computed Attributes context

### DIFF
--- a/src/org/traccar/processing/ComputedAttributesHandler.java
+++ b/src/org/traccar/processing/ComputedAttributesHandler.java
@@ -20,6 +20,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -43,6 +44,7 @@ public class ComputedAttributesHandler extends BaseDataHandler {
     public ComputedAttributesHandler() {
         engine = new JexlEngine();
         engine.setStrict(true);
+        engine.setFunctions(Collections.singletonMap("math", (Object) Math.class));
         if (Context.getConfig() != null) {
             mapDeviceAttributes = Context.getConfig().getBoolean("processing.computedAttributes.deviceAttributes");
         }

--- a/test/org/traccar/processing/ComputedAttributesTest.java
+++ b/test/org/traccar/processing/ComputedAttributesTest.java
@@ -8,7 +8,7 @@ import org.traccar.model.Attribute;
 import org.traccar.model.Position;
 
 public class ComputedAttributesTest {
-    
+
     @Test
     public void testComputedAttributes() {
         Position position = new Position();
@@ -39,26 +39,29 @@ public class ComputedAttributesTest {
 
         attribute.setExpression("if (event == 42) \"lowBattery\"");
         Assert.assertEquals("lowBattery", computedAttributesHandler.computeAttribute(attribute, position));
-        
+
         attribute.setExpression("speed > 5 && valid");
         Assert.assertEquals(false, computedAttributesHandler.computeAttribute(attribute, position));
-        
+
         attribute.setExpression("fixTime");
         Assert.assertEquals(date, computedAttributesHandler.computeAttribute(attribute, position));
-        
+
+        attribute.setExpression("math:pow(adc1, 2)");
+        Assert.assertEquals(16384.0, computedAttributesHandler.computeAttribute(attribute, position));
+
         // modification tests
         attribute.setExpression("adc1 = 256");
         computedAttributesHandler.computeAttribute(attribute, position);
         Assert.assertEquals(128, position.getInteger("adc1"));
-        
+
         attribute.setExpression("result = \"fail\"");
         computedAttributesHandler.computeAttribute(attribute, position);
         Assert.assertEquals("success", position.getString("result"));
-        
+
         attribute.setExpression("fixTime = \"2017-10-18 10:00:01\"");
         computedAttributesHandler.computeAttribute(attribute, position);
         Assert.assertEquals(date, position.getFixTime());
-        
+
     }
 
 }


### PR DESCRIPTION
It would be useful to have `Math` functions in Computed Attributes. Class registered as function namespaces http://commons.apache.org/proper/commons-jexl/reference/syntax.html#Functions

https://www.traccar.org/forums/topic/power-math-operation-in-computed-attributes/