### PR TITLE
Retry geocoding for trips/stops

### DIFF
--- a/src/org/traccar/BasePipelineFactory.java
+++ b/src/org/traccar/BasePipelineFactory.java
@@ -141,7 +141,7 @@ public abstract class BasePipelineFactory implements ChannelPipelineFactory {
             filterHandler = new FilterHandler();
         }
 
-        if (Context.getConfig().getBoolean("geocoder.enable")) {
+        if (Context.getGeocoder() != null && !Context.getConfig().getBoolean("geocoder.ignorePositions")) {
             geocoderHandler = new GeocoderHandler(
                     Context.getGeocoder(),
                     Context.getConfig().getBoolean("geocoder.processInvalidPositions"));

--- a/src/org/traccar/BasePipelineFactory.java
+++ b/src/org/traccar/BasePipelineFactory.java
@@ -141,7 +141,7 @@ public abstract class BasePipelineFactory implements ChannelPipelineFactory {
             filterHandler = new FilterHandler();
         }
 
-        if (Context.getGeocoder() != null) {
+        if (Context.getConfig().getBoolean("geocoder.enable")) {
             geocoderHandler = new GeocoderHandler(
                     Context.getGeocoder(),
                     Context.getConfig().getBoolean("geocoder.processInvalidPositions"));

--- a/src/org/traccar/Context.java
+++ b/src/org/traccar/Context.java
@@ -333,7 +333,7 @@ public final class Context {
 
         identityManager = deviceManager;
 
-        if (config.getBoolean("geocoder.enable") || config.getBoolean("report.retryGeocoding")) {
+        if (config.getBoolean("geocoder.enable")) {
             geocoder = initGeocoder();
         }
 

--- a/src/org/traccar/Context.java
+++ b/src/org/traccar/Context.java
@@ -43,6 +43,7 @@ import org.traccar.database.StatisticsManager;
 import org.traccar.database.UsersManager;
 import org.traccar.events.MotionEventHandler;
 import org.traccar.events.OverspeedEventHandler;
+import org.traccar.geocoder.AddressFormat;
 import org.traccar.geocoder.BingMapsGeocoder;
 import org.traccar.geocoder.FactualGeocoder;
 import org.traccar.geocoder.GeocodeFarmGeocoder;
@@ -263,6 +264,41 @@ public final class Context {
                 config.getDouble("event.motion.speedThreshold", 0.01));
     }
 
+    public static Geocoder initGeocoder() {
+        String type = config.getString("geocoder.type", "google");
+        String url = config.getString("geocoder.url");
+        String key = config.getString("geocoder.key");
+        String language = config.getString("geocoder.language");
+
+        String formatString = config.getString("geocoder.format");
+        AddressFormat addressFormat;
+        if (formatString != null) {
+            addressFormat = new AddressFormat(formatString);
+        } else {
+            addressFormat = new AddressFormat();
+        }
+
+        int cacheSize = config.getInteger("geocoder.cacheSize");
+        switch (type) {
+            case "nominatim":
+                return new NominatimGeocoder(url, key, language, cacheSize, addressFormat);
+            case "gisgraphy":
+                return new GisgraphyGeocoder(url, cacheSize, addressFormat);
+            case "mapquest":
+                return new MapQuestGeocoder(url, key, cacheSize, addressFormat);
+            case "opencage":
+                return new OpenCageGeocoder(url, key, cacheSize, addressFormat);
+            case "bingmaps":
+                return new BingMapsGeocoder(url, key, cacheSize, addressFormat);
+            case "factual":
+                return new FactualGeocoder(url, key, cacheSize, addressFormat);
+            case "geocodefarm":
+                return new GeocodeFarmGeocoder(key, language, cacheSize, addressFormat);
+            default:
+                return new GoogleGeocoder(key, language, cacheSize, addressFormat);
+        }
+    }
+
     public static void init(String[] arguments) throws Exception {
 
         config = new Config();
@@ -297,39 +333,8 @@ public final class Context {
 
         identityManager = deviceManager;
 
-        if (config.getBoolean("geocoder.enable")) {
-            String type = config.getString("geocoder.type", "google");
-            String url = config.getString("geocoder.url");
-            String key = config.getString("geocoder.key");
-            String language = config.getString("geocoder.language");
-
-            int cacheSize = config.getInteger("geocoder.cacheSize");
-            switch (type) {
-                case "nominatim":
-                    geocoder = new NominatimGeocoder(url, key, language, cacheSize);
-                    break;
-                case "gisgraphy":
-                    geocoder = new GisgraphyGeocoder(url, cacheSize);
-                    break;
-                case "mapquest":
-                    geocoder = new MapQuestGeocoder(url, key, cacheSize);
-                    break;
-                case "opencage":
-                    geocoder = new OpenCageGeocoder(url, key, cacheSize);
-                    break;
-                case "bingmaps":
-                    geocoder = new BingMapsGeocoder(url, key, cacheSize);
-                    break;
-                case "factual":
-                    geocoder = new FactualGeocoder(url, key, cacheSize);
-                    break;
-                case "geocodefarm":
-                    geocoder = new GeocodeFarmGeocoder(key, language, cacheSize);
-                    break;
-                default:
-                    geocoder = new GoogleGeocoder(key, language, cacheSize);
-                    break;
-            }
+        if (config.getBoolean("geocoder.enable") || config.getBoolean("report.retryGeocoding")) {
+            geocoder = initGeocoder();
         }
 
         if (config.getBoolean("geolocation.enable")) {

--- a/src/org/traccar/GeocoderHandler.java
+++ b/src/org/traccar/GeocoderHandler.java
@@ -20,7 +20,6 @@ import org.jboss.netty.channel.ChannelHandlerContext;
 import org.jboss.netty.channel.ChannelUpstreamHandler;
 import org.jboss.netty.channel.Channels;
 import org.jboss.netty.channel.MessageEvent;
-import org.traccar.geocoder.AddressFormat;
 import org.traccar.geocoder.Geocoder;
 import org.traccar.helper.Log;
 import org.traccar.model.Position;
@@ -29,19 +28,11 @@ public class GeocoderHandler implements ChannelUpstreamHandler {
 
     private final Geocoder geocoder;
     private final boolean processInvalidPositions;
-    private final AddressFormat addressFormat;
     private final int geocoderReuseDistance;
 
     public GeocoderHandler(Geocoder geocoder, boolean processInvalidPositions) {
         this.geocoder = geocoder;
         this.processInvalidPositions = processInvalidPositions;
-
-        String formatString = Context.getConfig().getString("geocoder.format");
-        if (formatString != null) {
-            addressFormat = new AddressFormat(formatString);
-        } else {
-            addressFormat = new AddressFormat();
-        }
 
         geocoderReuseDistance = Context.getConfig().getInteger("geocoder.reuseDistance", 0);
     }
@@ -70,7 +61,7 @@ public class GeocoderHandler implements ChannelUpstreamHandler {
 
                 Context.getStatisticsManager().registerGeocoderRequest();
 
-                geocoder.getAddress(addressFormat, position.getLatitude(), position.getLongitude(),
+                geocoder.getAddress(position.getLatitude(), position.getLongitude(),
                         new Geocoder.ReverseGeocoderCallback() {
                     @Override
                     public void onSuccess(String address) {

--- a/src/org/traccar/api/resource/ServerResource.java
+++ b/src/org/traccar/api/resource/ServerResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Anton Tananaev (anton@traccar.org)
+ * Copyright 2015 - 2017 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.sql.SQLException;
@@ -45,6 +46,12 @@ public class ServerResource extends BaseResource {
         Context.getPermissionsManager().checkAdmin(getUserId());
         Context.getPermissionsManager().updateServer(entity);
         return Response.ok(entity).build();
+    }
+
+    @Path("geocoding")
+    @GET
+    public String geocode(@QueryParam("latitude") double latitude, @QueryParam("longitude") double longitude) {
+        return Context.getGeocoder().getAddress(latitude, longitude);
     }
 
 }

--- a/src/org/traccar/api/resource/ServerResource.java
+++ b/src/org/traccar/api/resource/ServerResource.java
@@ -48,10 +48,10 @@ public class ServerResource extends BaseResource {
         return Response.ok(entity).build();
     }
 
-    @Path("geocoding")
+    @Path("geocode")
     @GET
     public String geocode(@QueryParam("latitude") double latitude, @QueryParam("longitude") double longitude) {
-        return Context.getGeocoder().getAddress(latitude, longitude);
+        return Context.getGeocoder().getAddress(latitude, longitude, null);
     }
 
 }

--- a/src/org/traccar/geocoder/BingMapsGeocoder.java
+++ b/src/org/traccar/geocoder/BingMapsGeocoder.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2014 - 2015 Stefaan Van Dooren (stefaan.vandooren@gmail.com)
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +21,8 @@ import javax.json.JsonObject;
 
 public class BingMapsGeocoder extends JsonGeocoder {
 
-    public BingMapsGeocoder(String url, String key, int cacheSize) {
-        super(url + "/Locations/%f,%f?key=" + key + "&include=ciso2", cacheSize);
+    public BingMapsGeocoder(String url, String key, int cacheSize, AddressFormat addressFormat) {
+        super(url + "/Locations/%f,%f?key=" + key + "&include=ciso2", cacheSize, addressFormat);
     }
 
     @Override

--- a/src/org/traccar/geocoder/FactualGeocoder.java
+++ b/src/org/traccar/geocoder/FactualGeocoder.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2014 - 2015 Stefaan Van Dooren (stefaan.vandooren@gmail.com)
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +20,8 @@ import javax.json.JsonObject;
 
 public class FactualGeocoder extends JsonGeocoder {
 
-    public FactualGeocoder(String url, String key, int cacheSize) {
-        super(url + "?latitude=%f&longitude=%f&KEY=" + key, cacheSize);
+    public FactualGeocoder(String url, String key, int cacheSize, AddressFormat addressFormat) {
+        super(url + "?latitude=%f&longitude=%f&KEY=" + key, cacheSize, addressFormat);
     }
 
     @Override

--- a/src/org/traccar/geocoder/GeocodeFarmGeocoder.java
+++ b/src/org/traccar/geocoder/GeocodeFarmGeocoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2016 - 2017 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,8 +30,8 @@ public class GeocodeFarmGeocoder extends JsonGeocoder {
         }
         return url;
     }
-    public GeocodeFarmGeocoder(String key, String language, int cacheSize) {
-        super(formatUrl(key, language), cacheSize);
+    public GeocodeFarmGeocoder(String key, String language, int cacheSize, AddressFormat addressFormat) {
+        super(formatUrl(key, language), cacheSize, addressFormat);
     }
 
     @Override

--- a/src/org/traccar/geocoder/Geocoder.java
+++ b/src/org/traccar/geocoder/Geocoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 - 2013 Anton Tananaev (anton@traccar.org)
+ * Copyright 2012 - 2017 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,8 @@ public interface Geocoder {
 
     }
 
-    void getAddress(AddressFormat format, double latitude, double longitude, ReverseGeocoderCallback callback);
+    void getAddress(double latitude, double longitude, ReverseGeocoderCallback callback);
+
+    String getAddress(double latitude, double longitude);
 
 }

--- a/src/org/traccar/geocoder/Geocoder.java
+++ b/src/org/traccar/geocoder/Geocoder.java
@@ -25,8 +25,6 @@ public interface Geocoder {
 
     }
 
-    void getAddress(double latitude, double longitude, ReverseGeocoderCallback callback);
-
-    String getAddress(double latitude, double longitude);
+    String getAddress(double latitude, double longitude, ReverseGeocoderCallback callback);
 
 }

--- a/src/org/traccar/geocoder/GisgraphyGeocoder.java
+++ b/src/org/traccar/geocoder/GisgraphyGeocoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 - 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2015 - 2017 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,12 @@ import javax.json.JsonObject;
 
 public class GisgraphyGeocoder extends JsonGeocoder {
 
-    public GisgraphyGeocoder() {
-        this("http://services.gisgraphy.com/reversegeocoding/search", 0);
+    public GisgraphyGeocoder(AddressFormat addressFormat) {
+        this("http://services.gisgraphy.com/reversegeocoding/search", 0, addressFormat);
     }
 
-    public GisgraphyGeocoder(String url, int cacheSize) {
-        super(url + "?format=json&lat=%f&lng=%f&from=1&to=1", cacheSize);
+    public GisgraphyGeocoder(String url, int cacheSize, AddressFormat addressFormat) {
+        super(url + "?format=json&lat=%f&lng=%f&from=1&to=1", cacheSize, addressFormat);
     }
 
     @Override

--- a/src/org/traccar/geocoder/GoogleGeocoder.java
+++ b/src/org/traccar/geocoder/GoogleGeocoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 - 2015 Anton Tananaev (anton@traccar.org)
+ * Copyright 2012 - 2017 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,8 +32,8 @@ public class GoogleGeocoder extends JsonGeocoder {
         return url;
     }
 
-    public GoogleGeocoder(String key, String language, int cacheSize) {
-        super(formatUrl(key, language), cacheSize);
+    public GoogleGeocoder(String key, String language, int cacheSize, AddressFormat addressFormat) {
+        super(formatUrl(key, language), cacheSize, addressFormat);
     }
 
     @Override

--- a/src/org/traccar/geocoder/MapQuestGeocoder.java
+++ b/src/org/traccar/geocoder/MapQuestGeocoder.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2014 - 2015 Stefaan Van Dooren (stefaan.vandooren@gmail.com)
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +21,8 @@ import javax.json.JsonObject;
 
 public class MapQuestGeocoder extends JsonGeocoder {
 
-    public MapQuestGeocoder(String url, String key, int cacheSize) {
-        super(url + "?key=" + key + "&location=%f,%f", cacheSize);
+    public MapQuestGeocoder(String url, String key, int cacheSize, AddressFormat addressFormat) {
+        super(url + "?key=" + key + "&location=%f,%f", cacheSize, addressFormat);
     }
 
     @Override

--- a/src/org/traccar/geocoder/NominatimGeocoder.java
+++ b/src/org/traccar/geocoder/NominatimGeocoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2015 Anton Tananaev (anton@traccar.org)
+ * Copyright 2014 - 2017 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,8 +33,8 @@ public class NominatimGeocoder extends JsonGeocoder {
         return url;
     }
 
-    public NominatimGeocoder(String url, String key, String language, int cacheSize) {
-        super(formatUrl(url, key, language), cacheSize);
+    public NominatimGeocoder(String url, String key, String language, int cacheSize, AddressFormat addressFormat) {
+        super(formatUrl(url, key, language), cacheSize, addressFormat);
     }
 
     @Override

--- a/src/org/traccar/geocoder/OpenCageGeocoder.java
+++ b/src/org/traccar/geocoder/OpenCageGeocoder.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2014 - 2015 Stefaan Van Dooren (stefaan.vandooren@gmail.com)
- * Copyright 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,8 @@ import javax.json.JsonObject;
 
 public class OpenCageGeocoder extends JsonGeocoder {
 
-    public OpenCageGeocoder(String url, String key, int cacheSize) {
-        super(url + "/json?q=%f,%f&key=" + key, cacheSize);
+    public OpenCageGeocoder(String url, String key, int cacheSize, AddressFormat addressFormat) {
+        super(url + "/json?q=%f,%f&key=" + key, cacheSize, addressFormat);
     }
 
     @Override

--- a/src/org/traccar/reports/ReportUtils.java
+++ b/src/org/traccar/reports/ReportUtils.java
@@ -191,8 +191,9 @@ public final class ReportUtils {
         trip.setStartLon(startTrip.getLongitude());
         trip.setStartTime(startTrip.getFixTime());
         String startAddress = startTrip.getAddress();
-        if (startAddress == null && Context.getConfig().getBoolean("report.retryGeocoding")) {
-            startAddress = Context.getGeocoder().getAddress(startTrip.getLatitude(), startTrip.getLongitude());
+        if (startAddress == null && Context.getGeocoder() != null
+                && Context.getConfig().getBoolean("geocoder.onRequest")) {
+            startAddress = Context.getGeocoder().getAddress(startTrip.getLatitude(), startTrip.getLongitude(), null);
         }
         trip.setStartAddress(startAddress);
 
@@ -201,8 +202,9 @@ public final class ReportUtils {
         trip.setEndLon(endTrip.getLongitude());
         trip.setEndTime(endTrip.getFixTime());
         String endAddress = endTrip.getAddress();
-        if (endAddress == null && Context.getConfig().getBoolean("report.retryGeocoding")) {
-            endAddress = Context.getGeocoder().getAddress(startTrip.getLatitude(), startTrip.getLongitude());
+        if (endAddress == null && Context.getGeocoder() != null
+                && Context.getConfig().getBoolean("geocoder.onRequest")) {
+            endAddress = Context.getGeocoder().getAddress(endTrip.getLatitude(), endTrip.getLongitude(), null);
         }
         trip.setEndAddress(endAddress);
 
@@ -233,8 +235,9 @@ public final class ReportUtils {
         stop.setLongitude(startStop.getLongitude());
         stop.setStartTime(startStop.getFixTime());
         String address = startStop.getAddress();
-        if (address == null && Context.getConfig().getBoolean("report.retryGeocoding")) {
-            address = Context.getGeocoder().getAddress(stop.getLatitude(), stop.getLongitude());
+        if (address == null && Context.getGeocoder() != null
+                && Context.getConfig().getBoolean("geocoder.onRequest")) {
+            address = Context.getGeocoder().getAddress(stop.getLatitude(), stop.getLongitude(), null);
         }
         stop.setAddress(address);
 

--- a/src/org/traccar/reports/ReportUtils.java
+++ b/src/org/traccar/reports/ReportUtils.java
@@ -190,13 +190,21 @@ public final class ReportUtils {
         trip.setStartLat(startTrip.getLatitude());
         trip.setStartLon(startTrip.getLongitude());
         trip.setStartTime(startTrip.getFixTime());
-        trip.setStartAddress(startTrip.getAddress());
+        String startAddress = startTrip.getAddress();
+        if (startAddress == null && Context.getConfig().getBoolean("report.retryGeocoding")) {
+            startAddress = Context.getGeocoder().getAddress(startTrip.getLatitude(), startTrip.getLongitude());
+        }
+        trip.setStartAddress(startAddress);
 
         trip.setEndPositionId(endTrip.getId());
         trip.setEndLat(endTrip.getLatitude());
         trip.setEndLon(endTrip.getLongitude());
         trip.setEndTime(endTrip.getFixTime());
-        trip.setEndAddress(endTrip.getAddress());
+        String endAddress = endTrip.getAddress();
+        if (endAddress == null && Context.getConfig().getBoolean("report.retryGeocoding")) {
+            endAddress = Context.getGeocoder().getAddress(startTrip.getLatitude(), startTrip.getLongitude());
+        }
+        trip.setEndAddress(endAddress);
 
         trip.setDistance(calculateDistance(startTrip, endTrip, !ignoreOdometer));
         trip.setDuration(tripDuration);
@@ -224,7 +232,12 @@ public final class ReportUtils {
         stop.setLatitude(startStop.getLatitude());
         stop.setLongitude(startStop.getLongitude());
         stop.setStartTime(startStop.getFixTime());
-        stop.setAddress(startStop.getAddress());
+        String address = startStop.getAddress();
+        if (address == null && Context.getConfig().getBoolean("report.retryGeocoding")) {
+            address = Context.getGeocoder().getAddress(stop.getLatitude(), stop.getLongitude());
+        }
+        stop.setAddress(address);
+
         stop.setEndTime(endStop.getFixTime());
 
         long stopDuration = endStop.getFixTime().getTime() - startStop.getFixTime().getTime();

--- a/test/org/traccar/geocoder/GeocoderTest.java
+++ b/test/org/traccar/geocoder/GeocoderTest.java
@@ -1,5 +1,7 @@
 package org.traccar.geocoder;
 
+import java.util.Locale;
+
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -9,6 +11,7 @@ public class GeocoderTest {
     @Ignore
     @Test
     public void test() throws InterruptedException {
+        Locale.setDefault(Locale.US);
         testGoogle();
     }
 
@@ -38,12 +41,13 @@ public class GeocoderTest {
             }
 
             @Override
-            public void onFailure(Throwable e) {
+            public void onFailure(final Throwable e) {
             }
         });
         Assert.assertEquals("1 Ibn Shaprut St, Jerusalem, Jerusalem District, IL", waitAddress());
 
-        Assert.assertEquals("1 Ibn Shaprut St, Jerusalem, Jerusalem District, IL", geocoder.getAddress(31.776797, 35.211489));
+        Assert.assertEquals("1 Ibn Shaprut St, Jerusalem, Jerusalem District, IL",
+                geocoder.getAddress(31.776797, 35.211489, null));
     }
 
     public void testNominatim() throws InterruptedException {
@@ -59,9 +63,10 @@ public class GeocoderTest {
             public void onFailure(Throwable e) {
             }
         });
-        Assert.assertEquals("35 West 9th Street, NYC, New York, US",  waitAddress());
+        Assert.assertEquals("35 West 9th Street, NYC, New York, US", waitAddress());
 
-        Assert.assertEquals("35 West 9th Street, NYC, New York, US",  geocoder.getAddress(40.7337807, -73.9974401));
+        Assert.assertEquals("35 West 9th Street, NYC, New York, US",
+                geocoder.getAddress(40.7337807, -73.9974401, null));
     }
 
     public void testGisgraphy() throws InterruptedException {
@@ -77,9 +82,9 @@ public class GeocoderTest {
             public void onFailure(Throwable e) {
             }
         });
-        Assert.assertEquals("Rue du Jardinet, Paris, FR",  waitAddress());
+        Assert.assertEquals("Rue du Jardinet, Paris, FR", waitAddress());
 
-        Assert.assertEquals("Rue du Jardinet, Paris, FR",  geocoder.getAddress(48.8530000, 2.3400000));
+        Assert.assertEquals("Rue du Jardinet, Paris, FR", geocoder.getAddress(48.8530000, 2.3400000, null));
     }
 
     public void testOpenCage() throws InterruptedException {
@@ -96,9 +101,9 @@ public class GeocoderTest {
             public void onFailure(Throwable e) {
             }
         });
-        Assert.assertEquals("Charleston Road, California, US",  waitAddress());
+        Assert.assertEquals("Charleston Road, California, US", waitAddress());
 
-        Assert.assertEquals("Charleston Road, California, US",  geocoder.getAddress(34.116302, -118.051519));
+        Assert.assertEquals("Charleston Road, California, US", geocoder.getAddress(34.116302, -118.051519, null));
     }
 
     public void testGeocodeFarm() throws InterruptedException {
@@ -114,9 +119,10 @@ public class GeocoderTest {
             public void onFailure(Throwable e) {
             }
         });
-        Assert.assertEquals("Estrella Avenue, Arcadia, California, United States",  waitAddress());
+        Assert.assertEquals("Estrella Avenue, Arcadia, California, United States", waitAddress());
 
-        Assert.assertEquals("Estrella Avenue, Arcadia, California, United States",  geocoder.getAddress(34.116302, -118.051519));
+        Assert.assertEquals("Estrella Avenue, Arcadia, California, United States",
+                geocoder.getAddress(34.116302, -118.051519, null));
     }
 
 }

--- a/test/org/traccar/geocoder/GeocoderTest.java
+++ b/test/org/traccar/geocoder/GeocoderTest.java
@@ -29,9 +29,9 @@ public class GeocoderTest {
     }
 
     public void testGoogle() throws InterruptedException {
-        Geocoder geocoder = new GoogleGeocoder(null, null, 0);
+        Geocoder geocoder = new GoogleGeocoder(null, null, 0, new AddressFormat());
 
-        geocoder.getAddress(new AddressFormat(), 31.776797, 35.211489, new Geocoder.ReverseGeocoderCallback() {
+        geocoder.getAddress(31.776797, 35.211489, new Geocoder.ReverseGeocoderCallback() {
             @Override
             public void onSuccess(String address) {
                 setAddress(address);
@@ -42,12 +42,14 @@ public class GeocoderTest {
             }
         });
         Assert.assertEquals("1 Ibn Shaprut St, Jerusalem, Jerusalem District, IL", waitAddress());
+
+        Assert.assertEquals("1 Ibn Shaprut St, Jerusalem, Jerusalem District, IL", geocoder.getAddress(31.776797, 35.211489));
     }
 
     public void testNominatim() throws InterruptedException {
-        Geocoder geocoder = new NominatimGeocoder(null, null, null, 0);
+        Geocoder geocoder = new NominatimGeocoder(null, null, null, 0, new AddressFormat());
 
-        geocoder.getAddress(new AddressFormat(), 40.7337807, -73.9974401, new Geocoder.ReverseGeocoderCallback() {
+        geocoder.getAddress(40.7337807, -73.9974401, new Geocoder.ReverseGeocoderCallback() {
             @Override
             public void onSuccess(String address) {
                 setAddress(address);
@@ -58,12 +60,14 @@ public class GeocoderTest {
             }
         });
         Assert.assertEquals("35 West 9th Street, NYC, New York, US",  waitAddress());
+
+        Assert.assertEquals("35 West 9th Street, NYC, New York, US",  geocoder.getAddress(40.7337807, -73.9974401));
     }
 
     public void testGisgraphy() throws InterruptedException {
-        Geocoder geocoder = new GisgraphyGeocoder();
+        Geocoder geocoder = new GisgraphyGeocoder(new AddressFormat());
 
-        geocoder.getAddress(new AddressFormat(), 48.8530000, 2.3400000, new Geocoder.ReverseGeocoderCallback() {
+        geocoder.getAddress(48.8530000, 2.3400000, new Geocoder.ReverseGeocoderCallback() {
             @Override
             public void onSuccess(String address) {
                 setAddress(address);
@@ -74,13 +78,15 @@ public class GeocoderTest {
             }
         });
         Assert.assertEquals("Rue du Jardinet, Paris, FR",  waitAddress());
+
+        Assert.assertEquals("Rue du Jardinet, Paris, FR",  geocoder.getAddress(48.8530000, 2.3400000));
     }
 
     public void testOpenCage() throws InterruptedException {
         Geocoder geocoder = new OpenCageGeocoder(
-                "http://api.opencagedata.com/geocode/v1", "SECRET", 0);
+                "http://api.opencagedata.com/geocode/v1", "SECRET", 0, new AddressFormat());
 
-        geocoder.getAddress(new AddressFormat(), 34.116302, -118.051519, new Geocoder.ReverseGeocoderCallback() {
+        geocoder.getAddress(34.116302, -118.051519, new Geocoder.ReverseGeocoderCallback() {
             @Override
             public void onSuccess(String address) {
                 setAddress(address);
@@ -91,12 +97,14 @@ public class GeocoderTest {
             }
         });
         Assert.assertEquals("Charleston Road, California, US",  waitAddress());
+
+        Assert.assertEquals("Charleston Road, California, US",  geocoder.getAddress(34.116302, -118.051519));
     }
 
     public void testGeocodeFarm() throws InterruptedException {
-        Geocoder geocoder = new GeocodeFarmGeocoder(null, null, 0);
+        Geocoder geocoder = new GeocodeFarmGeocoder(null, null, 0, new AddressFormat());
 
-        geocoder.getAddress(new AddressFormat(), 34.116302, -118.051519, new Geocoder.ReverseGeocoderCallback() {
+        geocoder.getAddress(34.116302, -118.051519, new Geocoder.ReverseGeocoderCallback() {
             @Override
             public void onSuccess(String address) {
                 setAddress(address);
@@ -107,6 +115,8 @@ public class GeocoderTest {
             }
         });
         Assert.assertEquals("Estrella Avenue, Arcadia, California, United States",  waitAddress());
+
+        Assert.assertEquals("Estrella Avenue, Arcadia, California, United States",  geocoder.getAddress(34.116302, -118.051519));
     }
 
 }


### PR DESCRIPTION
In some cases it is not necessary to revers geocoding every position. It might be enough find out addresses of trips endpoints for reports and allow user check address on demand from web client.

- Moved `AddressFormat` inside `Geocoder`
- Implement synchronous geocoding
- Implement retry geocoding for trips/stops reports
- Implement API for revers geocoding

if `geocoder.enable` - `true` - it will try for all positions, if `report.retryGeocoding` - `true` it will retry find out addresses of trips and stops. If both are false, geocoder is disabled.

I have an initial implementation for web client 
![image](https://user-images.githubusercontent.com/5688080/32545805-a8a8e90a-c49e-11e7-88a4-8c9588998b38.png)

![image](https://user-images.githubusercontent.com/5688080/32545818-b8aa2d28-c49e-11e7-8e1c-f0aa412c6ce6.png)

more comments in code...
