### PR TITLE
Do geocoding for every events related position

### DIFF
--- a/src/org/traccar/database/LdapProvider.java
+++ b/src/org/traccar/database/LdapProvider.java
@@ -78,7 +78,7 @@ public class LdapProvider {
         if (this.adminFilter != null) {
             try {
                 InitialDirContext context = initContext();
-                String searchString = new String(adminFilter).replace(":login", accountName);
+                String searchString = adminFilter.replace(":login", accountName);
                 SearchControls searchControls = new SearchControls();
                 searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);
                 NamingEnumeration<SearchResult> results = context.search(searchBase, searchString, searchControls);
@@ -104,7 +104,7 @@ public class LdapProvider {
     private SearchResult lookupUser(String accountName) throws NamingException {
         InitialDirContext context = initContext();
 
-        String searchString = new String(searchFilter).replace(":login", accountName);
+        String searchString = searchFilter.replace(":login", accountName);
 
         SearchControls searchControls = new SearchControls();
         String[] attributeFilter = {idAttribute, nameAttribute, mailAttribute};

--- a/src/org/traccar/database/NotificationManager.java
+++ b/src/org/traccar/database/NotificationManager.java
@@ -35,8 +35,11 @@ import org.traccar.notification.NotificationSms;
 
 public class NotificationManager extends ExtendedObjectManager<Notification> {
 
+    private boolean geocodeOnRequest;
+
     public NotificationManager(DataManager dataManager) {
         super(dataManager, Notification.class);
+        geocodeOnRequest = Context.getConfig().getBoolean("geocoder.onRequest");
     }
 
     private Set<Long> getEffectiveNotifications(long userId, long deviceId) {
@@ -55,6 +58,11 @@ public class NotificationManager extends ExtendedObjectManager<Notification> {
             getDataManager().addObject(event);
         } catch (SQLException error) {
             Log.warning(error);
+        }
+
+        if (position != null && geocodeOnRequest && Context.getGeocoder() != null && position.getAddress() == null) {
+            position.setAddress(Context.getGeocoder()
+                    .getAddress(position.getLatitude(), position.getLongitude(), null));
         }
 
         long deviceId = event.getDeviceId();


### PR DESCRIPTION
If `geocoder.onRequest` enabled retry to geocode event related position before sending notification.

Also fixed unnecessary String creation in `LdapProvider`