### PR TITLE
Log user actions

### DIFF
--- a/src/org/traccar/api/BaseObjectResource.java
+++ b/src/org/traccar/api/BaseObjectResource.java
@@ -31,6 +31,7 @@ import org.traccar.database.BaseObjectManager;
 import org.traccar.database.ExtendedObjectManager;
 import org.traccar.database.ManagableObjects;
 import org.traccar.database.SimpleObjectManager;
+import org.traccar.helper.LogAction;
 import org.traccar.model.BaseModel;
 import org.traccar.model.Command;
 import org.traccar.model.Device;
@@ -80,8 +81,10 @@ public abstract class BaseObjectResource<T extends BaseModel> extends BaseResour
 
         BaseObjectManager<T> manager = Context.getManager(baseClass);
         manager.addItem(entity);
+        LogAction.create(getUserId(), entity);
 
         Context.getDataManager().linkObject(User.class, getUserId(), baseClass, entity.getId(), true);
+        LogAction.link(getUserId(), User.class, getUserId(), baseClass, entity.getId());
 
         if (manager instanceof SimpleObjectManager) {
             ((SimpleObjectManager<T>) manager).refreshUserItems();
@@ -107,6 +110,7 @@ public abstract class BaseObjectResource<T extends BaseModel> extends BaseResour
         Context.getPermissionsManager().checkPermission(baseClass, getUserId(), entity.getId());
 
         Context.getManager(baseClass).updateItem(entity);
+        LogAction.edit(getUserId(), entity);
 
         if (baseClass.equals(Group.class) || baseClass.equals(Device.class)) {
             Context.getPermissionsManager().refreshDeviceAndGroupPermissions();
@@ -128,6 +132,7 @@ public abstract class BaseObjectResource<T extends BaseModel> extends BaseResour
 
         BaseObjectManager<T> manager = Context.getManager(baseClass);
         manager.removeItem(id);
+        LogAction.remove(getUserId(), baseClass, id);
 
         if (manager instanceof SimpleObjectManager) {
             ((SimpleObjectManager<T>) manager).refreshUserItems();

--- a/src/org/traccar/api/resource/DeviceResource.java
+++ b/src/org/traccar/api/resource/DeviceResource.java
@@ -18,6 +18,7 @@ package org.traccar.api.resource;
 import org.traccar.Context;
 import org.traccar.api.BaseObjectResource;
 import org.traccar.database.DeviceManager;
+import org.traccar.helper.LogAction;
 import org.traccar.model.Device;
 import org.traccar.model.DeviceTotalDistance;
 
@@ -85,6 +86,7 @@ public class DeviceResource extends BaseObjectResource<Device> {
     public Response updateTotalDistance(DeviceTotalDistance entity) throws SQLException {
         Context.getPermissionsManager().checkAdmin(getUserId());
         Context.getDeviceManager().resetTotalDistance(entity);
+        LogAction.resetTotalDistance(getUserId(), entity.getDeviceId());
         return Response.noContent().build();
     }
 

--- a/src/org/traccar/api/resource/PermissionsResource.java
+++ b/src/org/traccar/api/resource/PermissionsResource.java
@@ -29,6 +29,7 @@ import javax.ws.rs.core.Response;
 
 import org.traccar.Context;
 import org.traccar.api.BaseResource;
+import org.traccar.helper.LogAction;
 import org.traccar.model.Device;
 import org.traccar.model.Permission;
 import org.traccar.model.User;
@@ -61,6 +62,8 @@ public class PermissionsResource  extends BaseResource {
         checkPermission(permission, true);
         Context.getDataManager().linkObject(permission.getOwnerClass(), permission.getOwnerId(),
                 permission.getPropertyClass(), permission.getPropertyId(), true);
+        LogAction.link(getUserId(), permission.getOwnerClass(), permission.getOwnerId(),
+                permission.getPropertyClass(), permission.getPropertyId());
         Context.getPermissionsManager().refreshPermissions(permission);
         return Response.noContent().build();
     }
@@ -72,6 +75,8 @@ public class PermissionsResource  extends BaseResource {
         checkPermission(permission, false);
         Context.getDataManager().linkObject(permission.getOwnerClass(), permission.getOwnerId(),
                 permission.getPropertyClass(), permission.getPropertyId(), false);
+        LogAction.unlink(getUserId(), permission.getOwnerClass(), permission.getOwnerId(),
+                permission.getPropertyClass(), permission.getPropertyId());
         Context.getPermissionsManager().refreshPermissions(permission);
         return Response.noContent().build();
     }

--- a/src/org/traccar/api/resource/ServerResource.java
+++ b/src/org/traccar/api/resource/ServerResource.java
@@ -17,6 +17,7 @@ package org.traccar.api.resource;
 
 import org.traccar.Context;
 import org.traccar.api.BaseResource;
+import org.traccar.helper.LogAction;
 import org.traccar.model.Server;
 
 import javax.annotation.security.PermitAll;
@@ -45,6 +46,7 @@ public class ServerResource extends BaseResource {
     public Response update(Server entity) throws SQLException {
         Context.getPermissionsManager().checkAdmin(getUserId());
         Context.getPermissionsManager().updateServer(entity);
+        LogAction.edit(getUserId(), entity);
         return Response.ok(entity).build();
     }
 

--- a/src/org/traccar/api/resource/SessionResource.java
+++ b/src/org/traccar/api/resource/SessionResource.java
@@ -17,6 +17,7 @@ package org.traccar.api.resource;
 
 import org.traccar.Context;
 import org.traccar.api.BaseResource;
+import org.traccar.helper.LogAction;
 import org.traccar.model.User;
 
 import javax.annotation.security.PermitAll;
@@ -103,6 +104,7 @@ public class SessionResource extends BaseResource {
         User user = Context.getPermissionsManager().login(email, password);
         if (user != null) {
             request.getSession().setAttribute(USER_ID_KEY, user.getId());
+            LogAction.login(user.getId());
             return user;
         } else {
             throw new WebApplicationException(Response.status(Response.Status.UNAUTHORIZED).build());
@@ -111,6 +113,7 @@ public class SessionResource extends BaseResource {
 
     @DELETE
     public Response remove() {
+        LogAction.logout(getUserId());
         request.getSession().removeAttribute(USER_ID_KEY);
         return Response.noContent().build();
     }

--- a/src/org/traccar/api/resource/UserResource.java
+++ b/src/org/traccar/api/resource/UserResource.java
@@ -18,6 +18,7 @@ package org.traccar.api.resource;
 import org.traccar.Context;
 import org.traccar.api.BaseObjectResource;
 import org.traccar.database.UsersManager;
+import org.traccar.helper.LogAction;
 import org.traccar.model.ManagedUser;
 import org.traccar.model.User;
 
@@ -81,8 +82,10 @@ public class UserResource extends BaseObjectResource<User> {
             }
         }
         Context.getUsersManager().addItem(entity);
+        LogAction.create(getUserId(), entity);
         if (Context.getPermissionsManager().getUserManager(getUserId())) {
             Context.getDataManager().linkObject(User.class, getUserId(), ManagedUser.class, entity.getId(), true);
+            LogAction.link(getUserId(), User.class, getUserId(), ManagedUser.class, entity.getId());
         }
         Context.getUsersManager().refreshUserItems();
         return Response.ok(entity).build();

--- a/src/org/traccar/helper/LogAction.java
+++ b/src/org/traccar/helper/LogAction.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.helper;
+
+import org.traccar.model.BaseModel;
+
+public final class LogAction {
+
+    private LogAction() {
+    }
+
+    private static final String ACTION_CREATE = "create";
+    private static final String ACTION_EDIT = "edit";
+    private static final String ACTION_REMOVE = "remove";
+
+    private static final String ACTION_LINK = "link";
+    private static final String ACTION_UNLINK = "unlink";
+
+    private static final String ACTION_LOGIN = "login";
+    private static final String ACTION_LOGOUT = "logout";
+
+    private static final String ACTION_TOTAL_DISTANCE = "resetTotalDistance";
+
+    private static final String PATTERN_OBJECT = "User: %d, Action: %s, Object: %s, Id: %d";
+    private static final String PATTERN_LINK = "User: %d, Action: %s, Owner: %s, Id: %d, Property: %s, Id: %d";
+    private static final String PATTERN_LOGIN = "User: %d, Action: %s";
+    private static final String PATTERN_TOTAL_DISTANCE = "User: %d, Action: %s, DeviceId: %d";
+
+    public static void create(long userId, BaseModel object) {
+        logObjectAction(ACTION_CREATE, userId, object.getClass(), object.getId());
+    }
+
+    public static void edit(long userId, BaseModel object) {
+        logObjectAction(ACTION_EDIT, userId, object.getClass(), object.getId());
+    }
+
+    public static void remove(long userId, Class<?> clazz, long objectId) {
+        logObjectAction(ACTION_REMOVE, userId, clazz, objectId);
+    }
+
+    public static void link(long userId, Class<?> owner, long ownerId, Class<?> property, long propertyId) {
+        logLinkAction(ACTION_LINK, userId, owner, ownerId, property, propertyId);
+    }
+
+    public static void unlink(long userId, Class<?> owner, long ownerId, Class<?> property, long propertyId) {
+        logLinkAction(ACTION_UNLINK, userId, owner, ownerId, property, propertyId);
+    }
+
+    public static void login(long userId) {
+        logLoginAction(ACTION_LOGIN, userId);
+    }
+
+    public static void logout(long userId) {
+        logLoginAction(ACTION_LOGOUT, userId);
+    }
+
+    public static void resetTotalDistance(long userId, long deviceId) {
+        log(String.format(PATTERN_TOTAL_DISTANCE, userId, ACTION_TOTAL_DISTANCE, deviceId));
+    }
+
+    private static void logObjectAction(String action, long userId, Class<?> clazz, long objectId) {
+        log(String.format(PATTERN_OBJECT, userId, action, clazz.getSimpleName(), objectId));
+    }
+
+    private static void logLinkAction(String action, long userId,
+            Class<?> owner, long ownerId, Class<?> property, long propertyId) {
+        log(String.format(PATTERN_LINK, userId, action,
+                owner.getSimpleName(), ownerId, property.getSimpleName(), propertyId));
+    }
+
+    private static void logLoginAction(String action, long userId) {
+        log(String.format(PATTERN_LOGIN, userId, action));
+    }
+
+    private static void log(String msg) {
+        Log.info(msg);
+    }
+
+}

--- a/src/org/traccar/helper/LogAction.java
+++ b/src/org/traccar/helper/LogAction.java
@@ -16,6 +16,8 @@
  */
 package org.traccar.helper;
 
+import java.beans.Introspector;
+
 import org.traccar.model.BaseModel;
 
 public final class LogAction {
@@ -35,10 +37,10 @@ public final class LogAction {
 
     private static final String ACTION_TOTAL_DISTANCE = "resetTotalDistance";
 
-    private static final String PATTERN_OBJECT = "User: %d, Action: %s, Object: %s, Id: %d";
-    private static final String PATTERN_LINK = "User: %d, Action: %s, Owner: %s, Id: %d, Property: %s, Id: %d";
-    private static final String PATTERN_LOGIN = "User: %d, Action: %s";
-    private static final String PATTERN_TOTAL_DISTANCE = "User: %d, Action: %s, DeviceId: %d";
+    private static final String PATTERN_OBJECT = "user: %d, action: %s, object: %s, id: %d";
+    private static final String PATTERN_LINK = "user: %d, action: %s, owner: %s, id: %d, property: %s, id: %d";
+    private static final String PATTERN_LOGIN = "user: %d, action: %s";
+    private static final String PATTERN_TOTAL_DISTANCE = "user: %d, action: %s, deviceId: %d";
 
     public static void create(long userId, BaseModel object) {
         logObjectAction(ACTION_CREATE, userId, object.getClass(), object.getId());
@@ -73,13 +75,14 @@ public final class LogAction {
     }
 
     private static void logObjectAction(String action, long userId, Class<?> clazz, long objectId) {
-        log(String.format(PATTERN_OBJECT, userId, action, clazz.getSimpleName(), objectId));
+        log(String.format(PATTERN_OBJECT, userId, action, Introspector.decapitalize(clazz.getSimpleName()), objectId));
     }
 
     private static void logLinkAction(String action, long userId,
             Class<?> owner, long ownerId, Class<?> property, long propertyId) {
         log(String.format(PATTERN_LINK, userId, action,
-                owner.getSimpleName(), ownerId, property.getSimpleName(), propertyId));
+                Introspector.decapitalize(owner.getSimpleName()), ownerId,
+                Introspector.decapitalize(property.getSimpleName()), propertyId));
     }
 
     private static void logLoginAction(String action, long userId) {


### PR DESCRIPTION
Here is implementation of logging user actions:
- Object create/edit/remove
- Objects link/unlink
- User login/logout
- Reset device total distance

Made it non-switchable, only with global log. I do not think log size will grow dramatically in comparing with device communications debug.

Example:
```
2017-12-13 14:48:21  INFO: User: 1, Action: login
2017-12-13 12:05:53  INFO: User: 1, Action: edit, Object: User, Id: 18
2017-12-13 12:06:27  INFO: User: 1, Action: link, Owner: User, Id: 18, Property: Group, Id: 11
2017-12-13 12:06:28  INFO: User: 1, Action: link, Owner: User, Id: 18, Property: Group, Id: 5
2017-12-13 12:06:30  INFO: User: 1, Action: unlink, Owner: User, Id: 18, Property: Group, Id: 11
2017-12-13 14:48:23  INFO: User: 1, Action: logout
2017-12-13 14:48:21  INFO: User: 2, Action: login
2017-12-13 12:07:29  INFO: User: 2, Action: create, Object: Device, Id: 52
2017-12-13 12:07:29  INFO: User: 2, Action: link, Owner: User, Id: 2, Property: Device, Id: 52
2017-12-13 12:16:13  INFO: User: 2, Action: remove, Object: Device, Id: 52
2017-12-13 14:48:21  INFO: User: 2, Action: login
2017-12-13 14:48:23  INFO: User: 2, Action: logout
2017-12-18 16:40:11  INFO: User: 1, Action: login
2017-12-18 16:40:34  INFO: User: 1, Action: resetTotalDistance, DeviceId: 8
```

fix #3528 