### PR TITLE
Device disable

### DIFF
--- a/schema/changelog-3.16.xml
+++ b/schema/changelog-3.16.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd"
+  logicalFilePath="changelog-3.16">
+
+  <changeSet author="author" id="changelog-3.16">
+
+    <addColumn tableName="devices">
+      <column name="disabled" type="BOOLEAN" defaultValueBoolean="false" />
+    </addColumn>
+
+  </changeSet>
+</databaseChangeLog>

--- a/schema/changelog-master.xml
+++ b/schema/changelog-master.xml
@@ -16,4 +16,5 @@
   <include file="changelog-3.12.xml" relativeToChangelogFile="true" />
   <include file="changelog-3.14.xml" relativeToChangelogFile="true" />
   <include file="changelog-3.15.xml" relativeToChangelogFile="true" />
+  <include file="changelog-3.16.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/src/org/traccar/api/BaseObjectResource.java
+++ b/src/org/traccar/api/BaseObjectResource.java
@@ -101,6 +101,8 @@ public abstract class BaseObjectResource<T extends BaseModel> extends BaseResour
         Context.getPermissionsManager().checkReadonly(getUserId());
         if (baseClass.equals(Device.class)) {
             Context.getPermissionsManager().checkDeviceReadonly(getUserId());
+            Device before = Context.getIdentityManager().getById(entity.getId());
+            Context.getPermissionsManager().checkDeviceUpdate(getUserId(), before, (Device) entity);
         } else if (baseClass.equals(User.class)) {
             User before = Context.getPermissionsManager().getUser(entity.getId());
             Context.getPermissionsManager().checkUserUpdate(getUserId(), before, (User) entity);

--- a/src/org/traccar/database/ConnectionManager.java
+++ b/src/org/traccar/database/ConnectionManager.java
@@ -171,7 +171,7 @@ public class ConnectionManager {
         long deviceId = position.getDeviceId();
 
         for (long userId : Context.getPermissionsManager().getDeviceUsers(deviceId)) {
-            if (listeners.containsKey(userId)) {
+            if (listeners.containsKey(userId) && !Context.getPermissionsManager().getDeviceDisabled(userId, deviceId)) {
                 for (UpdateListener listener : listeners.get(userId)) {
                     listener.onUpdatePosition(position);
                 }

--- a/src/org/traccar/database/DeviceManager.java
+++ b/src/org/traccar/database/DeviceManager.java
@@ -160,6 +160,7 @@ public class DeviceManager extends BaseObjectManager<Device> implements Identity
         cachedDevice.setCategory(device.getCategory());
         cachedDevice.setContact(device.getContact());
         cachedDevice.setModel(device.getModel());
+        cachedDevice.setDisabled(device.getDisabled());
         cachedDevice.setAttributes(device.getAttributes());
         if (!device.getUniqueId().equals(cachedDevice.getUniqueId())) {
             devicesByUniqueId.remove(cachedDevice.getUniqueId());
@@ -244,7 +245,8 @@ public class DeviceManager extends BaseObjectManager<Device> implements Identity
 
         if (Context.getPermissionsManager() != null) {
             for (long deviceId : getUserItems(userId)) {
-                if (positions.containsKey(deviceId)) {
+                if (positions.containsKey(deviceId)
+                        && !Context.getPermissionsManager().getDeviceDisabled(userId, deviceId)) {
                     result.add(positions.get(deviceId));
                 }
             }

--- a/src/org/traccar/database/NotificationManager.java
+++ b/src/org/traccar/database/NotificationManager.java
@@ -68,7 +68,8 @@ public class NotificationManager extends ExtendedObjectManager<Notification> {
         long deviceId = event.getDeviceId();
         Set<Long> users = Context.getPermissionsManager().getDeviceUsers(deviceId);
         for (long userId : users) {
-            if (event.getGeofenceId() == 0 || Context.getGeofenceManager() != null
+            if (!Context.getPermissionsManager().getDeviceDisabled(userId, deviceId)
+                    && event.getGeofenceId() == 0 || Context.getGeofenceManager() != null
                     && Context.getGeofenceManager().checkItemPermission(userId, event.getGeofenceId())) {
                 boolean sentWeb = false;
                 boolean sentMail = false;

--- a/src/org/traccar/database/PermissionsManager.java
+++ b/src/org/traccar/database/PermissionsManager.java
@@ -199,6 +199,11 @@ public class PermissionsManager {
         return user != null && user.getDeviceReadonly();
     }
 
+    public boolean getDeviceDisabled(long userId, long deviceId) {
+        Device device = Context.getIdentityManager().getById(deviceId);
+        return !getUserAdmin(userId) && device != null && device.getDisabled();
+    }
+
     public boolean getUserLimitCommands(long userId) {
         User user = getUser(userId);
         return user != null && user.getLimitCommands();
@@ -263,6 +268,12 @@ public class PermissionsManager {
             if (!getUserAdmin(userId)) {
                 checkManager(userId);
             }
+        }
+    }
+
+    public void checkDeviceUpdate(long userId, Device before, Device after) throws SecurityException {
+        if (before.getDisabled() && !after.getDisabled()) {
+            checkAdmin(userId);
         }
     }
 

--- a/src/org/traccar/model/Device.java
+++ b/src/org/traccar/model/Device.java
@@ -149,4 +149,14 @@ public class Device extends ExtendedModel {
         this.category = category;
     }
 
+    private boolean disabled;
+
+    public boolean getDisabled() {
+        return disabled;
+    }
+
+    public void setDisabled(boolean disabled) {
+        this.disabled = disabled;
+    }
+
 }

--- a/src/org/traccar/reports/Route.java
+++ b/src/org/traccar/reports/Route.java
@@ -43,7 +43,9 @@ public final class Route {
         ArrayList<Position> result = new ArrayList<>();
         for (long deviceId: ReportUtils.getDeviceList(deviceIds, groupIds)) {
             Context.getPermissionsManager().checkDevice(userId, deviceId);
-            result.addAll(Context.getDataManager().getPositions(deviceId, from, to));
+            if (!Context.getPermissionsManager().getDeviceDisabled(userId, deviceId)) {
+                result.addAll(Context.getDataManager().getPositions(deviceId, from, to));
+            }
         }
         return result;
     }
@@ -56,20 +58,22 @@ public final class Route {
         ArrayList<String> sheetNames = new ArrayList<>();
         for (long deviceId: ReportUtils.getDeviceList(deviceIds, groupIds)) {
             Context.getPermissionsManager().checkDevice(userId, deviceId);
-            Collection<Position> positions = Context.getDataManager()
-                    .getPositions(deviceId, from, to);
-            DeviceReport deviceRoutes = new DeviceReport();
-            Device device = Context.getIdentityManager().getById(deviceId);
-            deviceRoutes.setDeviceName(device.getName());
-            sheetNames.add(WorkbookUtil.createSafeSheetName(deviceRoutes.getDeviceName()));
-            if (device.getGroupId() != 0) {
-                Group group = Context.getGroupsManager().getById(device.getGroupId());
-                if (group != null) {
-                    deviceRoutes.setGroupName(group.getName());
+            if (!Context.getPermissionsManager().getDeviceDisabled(userId, deviceId)) {
+                Collection<Position> positions = Context.getDataManager()
+                        .getPositions(deviceId, from, to);
+                DeviceReport deviceRoutes = new DeviceReport();
+                Device device = Context.getIdentityManager().getById(deviceId);
+                deviceRoutes.setDeviceName(device.getName());
+                sheetNames.add(WorkbookUtil.createSafeSheetName(deviceRoutes.getDeviceName()));
+                if (device.getGroupId() != 0) {
+                    Group group = Context.getGroupsManager().getById(device.getGroupId());
+                    if (group != null) {
+                        deviceRoutes.setGroupName(group.getName());
+                    }
                 }
+                deviceRoutes.setObjects(positions);
+                devicesRoutes.add(deviceRoutes);
             }
-            deviceRoutes.setObjects(positions);
-            devicesRoutes.add(deviceRoutes);
         }
         String templatePath = Context.getConfig().getString("report.templatesPath",
                 "templates/export/");

--- a/src/org/traccar/reports/Stops.java
+++ b/src/org/traccar/reports/Stops.java
@@ -56,7 +56,9 @@ public final class Stops {
         ArrayList<StopReport> result = new ArrayList<>();
         for (long deviceId: ReportUtils.getDeviceList(deviceIds, groupIds)) {
             Context.getPermissionsManager().checkDevice(userId, deviceId);
-            result.addAll(detectStops(deviceId, from, to));
+            if (!Context.getPermissionsManager().getDeviceDisabled(userId, deviceId)) {
+                result.addAll(detectStops(deviceId, from, to));
+            }
         }
         return result;
     }
@@ -69,19 +71,21 @@ public final class Stops {
         ArrayList<String> sheetNames = new ArrayList<>();
         for (long deviceId: ReportUtils.getDeviceList(deviceIds, groupIds)) {
             Context.getPermissionsManager().checkDevice(userId, deviceId);
-            Collection<StopReport> stops = detectStops(deviceId, from, to);
-            DeviceReport deviceStops = new DeviceReport();
-            Device device = Context.getIdentityManager().getById(deviceId);
-            deviceStops.setDeviceName(device.getName());
-            sheetNames.add(WorkbookUtil.createSafeSheetName(deviceStops.getDeviceName()));
-            if (device.getGroupId() != 0) {
-                Group group = Context.getGroupsManager().getById(device.getGroupId());
-                if (group != null) {
-                    deviceStops.setGroupName(group.getName());
+            if (!Context.getPermissionsManager().getDeviceDisabled(userId, deviceId)) {
+                Collection<StopReport> stops = detectStops(deviceId, from, to);
+                DeviceReport deviceStops = new DeviceReport();
+                Device device = Context.getIdentityManager().getById(deviceId);
+                deviceStops.setDeviceName(device.getName());
+                sheetNames.add(WorkbookUtil.createSafeSheetName(deviceStops.getDeviceName()));
+                if (device.getGroupId() != 0) {
+                    Group group = Context.getGroupsManager().getById(device.getGroupId());
+                    if (group != null) {
+                        deviceStops.setGroupName(group.getName());
+                    }
                 }
+                deviceStops.setObjects(stops);
+                devicesStops.add(deviceStops);
             }
-            deviceStops.setObjects(stops);
-            devicesStops.add(deviceStops);
         }
         String templatePath = Context.getConfig().getString("report.templatesPath",
                 "templates/export/");

--- a/src/org/traccar/reports/Summary.java
+++ b/src/org/traccar/reports/Summary.java
@@ -72,7 +72,9 @@ public final class Summary {
         ArrayList<SummaryReport> result = new ArrayList<>();
         for (long deviceId: ReportUtils.getDeviceList(deviceIds, groupIds)) {
             Context.getPermissionsManager().checkDevice(userId, deviceId);
-            result.add(calculateSummaryResult(deviceId, from, to));
+            if (!Context.getPermissionsManager().getDeviceDisabled(userId, deviceId)) {
+                result.add(calculateSummaryResult(deviceId, from, to));
+            }
         }
         return result;
     }

--- a/src/org/traccar/reports/Trips.java
+++ b/src/org/traccar/reports/Trips.java
@@ -54,7 +54,9 @@ public final class Trips {
         ArrayList<TripReport> result = new ArrayList<>();
         for (long deviceId: ReportUtils.getDeviceList(deviceIds, groupIds)) {
             Context.getPermissionsManager().checkDevice(userId, deviceId);
-            result.addAll(detectTrips(deviceId, from, to));
+            if (!Context.getPermissionsManager().getDeviceDisabled(userId, deviceId)) {
+                result.addAll(detectTrips(deviceId, from, to));
+            }
         }
         return result;
     }
@@ -67,19 +69,21 @@ public final class Trips {
         ArrayList<String> sheetNames = new ArrayList<>();
         for (long deviceId: ReportUtils.getDeviceList(deviceIds, groupIds)) {
             Context.getPermissionsManager().checkDevice(userId, deviceId);
-            Collection<TripReport> trips = detectTrips(deviceId, from, to);
-            DeviceReport deviceTrips = new DeviceReport();
-            Device device = Context.getIdentityManager().getById(deviceId);
-            deviceTrips.setDeviceName(device.getName());
-            sheetNames.add(WorkbookUtil.createSafeSheetName(deviceTrips.getDeviceName()));
-            if (device.getGroupId() != 0) {
-                Group group = Context.getGroupsManager().getById(device.getGroupId());
-                if (group != null) {
-                    deviceTrips.setGroupName(group.getName());
+            if (!Context.getPermissionsManager().getDeviceDisabled(userId, deviceId)) {
+                Collection<TripReport> trips = detectTrips(deviceId, from, to);
+                DeviceReport deviceTrips = new DeviceReport();
+                Device device = Context.getIdentityManager().getById(deviceId);
+                deviceTrips.setDeviceName(device.getName());
+                sheetNames.add(WorkbookUtil.createSafeSheetName(deviceTrips.getDeviceName()));
+                if (device.getGroupId() != 0) {
+                    Group group = Context.getGroupsManager().getById(device.getGroupId());
+                    if (group != null) {
+                        deviceTrips.setGroupName(group.getName());
+                    }
                 }
+                deviceTrips.setObjects(trips);
+                devicesTrips.add(deviceTrips);
             }
-            deviceTrips.setObjects(trips);
-            devicesTrips.add(deviceTrips);
         }
         String templatePath = Context.getConfig().getString("report.templatesPath",
                 "templates/export/");


### PR DESCRIPTION
Here is implementation discussed in #3683

Disabled device excluded from reports of ordinary users and managers and from events notifications (via all transports).
Current device position is not updated via websocket for ordinary user, but device object is still updated.
Theoretically user can understand where device is placed now by `device.geofenceIds[]` but I do not think it is big leakage.

Only admin can enable device back.

There is switch `database.storeDisabled` to store or not store data from disabled device.

Also It is easy to add device expiration in future.

Frankly I'm not very satisfied with changes, some constructions/checks become rather complex. I have some thoughts about permission optimizations, but it is need to be discussed.

fix #3683