### PR TITLE
Update group and device cache on group delete.

### DIFF
--- a/src/org/traccar/api/BaseObjectResource.java
+++ b/src/org/traccar/api/BaseObjectResource.java
@@ -141,6 +141,10 @@ public abstract class BaseObjectResource<T extends BaseModel> extends BaseResour
             }
         }
         if (baseClass.equals(Group.class) || baseClass.equals(Device.class) || baseClass.equals(User.class)) {
+            if (baseClass.equals(Group.class)) {
+                Context.getGroupsManager().updateGroupCache(true);
+                Context.getDeviceManager().updateDeviceCache(true);
+            }
             Context.getPermissionsManager().refreshDeviceAndGroupPermissions();
             if (baseClass.equals(User.class)) {
                 Context.getPermissionsManager().refreshAllUsersPermissions();

--- a/src/org/traccar/database/DeviceManager.java
+++ b/src/org/traccar/database/DeviceManager.java
@@ -65,7 +65,7 @@ public class DeviceManager extends BaseObjectManager<Device> implements Identity
         refreshLastPositions();
     }
 
-    private void updateDeviceCache(boolean force) throws SQLException {
+    public void updateDeviceCache(boolean force) throws SQLException {
         long lastUpdate = devicesLastUpdate.get();
         if ((force || System.currentTimeMillis() - lastUpdate > dataRefreshDelay)
                 && devicesLastUpdate.compareAndSet(lastUpdate, System.currentTimeMillis())) {

--- a/src/org/traccar/database/GroupsManager.java
+++ b/src/org/traccar/database/GroupsManager.java
@@ -47,7 +47,7 @@ public class GroupsManager extends BaseObjectManager<Group> implements Managable
         }
     }
 
-    private void updateGroupCache(boolean force) throws SQLException {
+    public void updateGroupCache(boolean force) throws SQLException {
         long lastUpdate = groupsLastUpdate.get();
         if ((force || System.currentTimeMillis() - lastUpdate > dataRefreshDelay)
                 && groupsLastUpdate.compareAndSet(lastUpdate, System.currentTimeMillis())) {


### PR DESCRIPTION
Deleting group may cause cascade clear `groupId` fields in `groups` and `devices` DB tables. We need refresh cached objects.

https://www.traccar.org/forums/topic/group-delete-issue/