### PR TITLE
NPE bug fix for the Position's serverTime

### DIFF
--- a/src/org/traccar/model/Position.java
+++ b/src/org/traccar/model/Position.java
@@ -131,6 +131,10 @@ public class Position extends Message {
     public static final String ALARM_TAMPERING = "tampering";
     public static final String ALARM_REMOVING = "removing";
 
+    public Position() {
+        this.serverTime = new Date();
+    }
+
     private String protocol;
 
     public String getProtocol() {


### PR DESCRIPTION
I was not aware about the initialization of serverTime and didn't found any better way than this.

Pull Request:
https://github.com/tananaev/traccar/pull/3721
 