### PR TITLE
Implement scheduled notifications

### DIFF
--- a/schema/changelog-3.16.xml
+++ b/schema/changelog-3.16.xml
@@ -24,7 +24,7 @@
       <column name="calendarid" type="INT" />
     </addColumn>
 
-    <addForeignKeyConstraint baseColumnNames="calendarid" baseTableName="notifications" constraintName="fk_notification_calendar_calendarid" onDelete="SET NULL" onUpdate="RESTRICT" referencedColumnNames="id" referencedTableName="calendars"/>
+    <addForeignKeyConstraint baseColumnNames="calendarid" baseTableName="notifications" constraintName="fk_notification_calendar_calendarid" onDelete="SET NULL" onUpdate="RESTRICT" referencedColumnNames="id" referencedTableName="calendars" />
 
   </changeSet>
 </databaseChangeLog>

--- a/schema/changelog-3.16.xml
+++ b/schema/changelog-3.16.xml
@@ -20,5 +20,11 @@
         <column name="poilayer" type="VARCHAR(512)" />
     </addColumn>
 
+    <addColumn tableName="notifications">
+      <column name="calendarid" type="INT" />
+    </addColumn>
+
+    <addForeignKeyConstraint baseColumnNames="calendarid" baseTableName="notifications" constraintName="fk_notification_calendar_calendarid" onDelete="SET NULL" onUpdate="RESTRICT" referencedColumnNames="id" referencedTableName="calendars"/>
+
   </changeSet>
 </databaseChangeLog>

--- a/src/org/traccar/api/BaseObjectResource.java
+++ b/src/org/traccar/api/BaseObjectResource.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2017 Anton Tananaev (anton@traccar.org)
- * Copyright 2017 Andrey Kunitsyn (andrey@traccar.org)
+ * Copyright 2017 - 2018 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 - 2018 Andrey Kunitsyn (andrey@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,9 +33,11 @@ import org.traccar.database.ManagableObjects;
 import org.traccar.database.SimpleObjectManager;
 import org.traccar.helper.LogAction;
 import org.traccar.model.BaseModel;
+import org.traccar.model.Calendar;
 import org.traccar.model.Command;
 import org.traccar.model.Device;
 import org.traccar.model.Group;
+import org.traccar.model.ScheduledModel;
 import org.traccar.model.User;
 
 public abstract class BaseObjectResource<T extends BaseModel> extends BaseResource {
@@ -77,6 +79,9 @@ public abstract class BaseObjectResource<T extends BaseModel> extends BaseResour
             Context.getPermissionsManager().checkDeviceLimit(getUserId());
         } else if (baseClass.equals(Command.class)) {
             Context.getPermissionsManager().checkLimitCommands(getUserId());
+        } else if (entity instanceof ScheduledModel) {
+            Context.getPermissionsManager().checkPermission(Calendar.class, getUserId(),
+                    ((ScheduledModel) entity).getCalendarId());
         }
 
         BaseObjectManager<T> manager = Context.getManager(baseClass);
@@ -106,6 +111,9 @@ public abstract class BaseObjectResource<T extends BaseModel> extends BaseResour
             Context.getPermissionsManager().checkUserUpdate(getUserId(), before, (User) entity);
         } else if (baseClass.equals(Command.class)) {
             Context.getPermissionsManager().checkLimitCommands(getUserId());
+        } else if (entity instanceof ScheduledModel) {
+            Context.getPermissionsManager().checkPermission(Calendar.class, getUserId(),
+                    ((ScheduledModel) entity).getCalendarId());
         }
         Context.getPermissionsManager().checkPermission(baseClass, getUserId(), entity.getId());
 
@@ -151,6 +159,9 @@ public abstract class BaseObjectResource<T extends BaseModel> extends BaseResour
             } else {
                 Context.getPermissionsManager().refreshAllExtendedPermissions();
             }
+        } else if (baseClass.equals(Calendar.class)) {
+            Context.getGeofenceManager().refreshItems();
+            Context.getNotificationManager().refreshItems();
         }
         return Response.noContent().build();
     }

--- a/src/org/traccar/database/NotificationManager.java
+++ b/src/org/traccar/database/NotificationManager.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2016 - 2017 Anton Tananaev (anton@traccar.org)
- * Copyright 2016 - 2017 Andrey Kunitsyn (andrey@traccar.org)
+ * Copyright 2016 - 2018 Anton Tananaev (anton@traccar.org)
+ * Copyright 2016 - 2018 Andrey Kunitsyn (andrey@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.traccar.database;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.sql.SQLException;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -26,6 +27,7 @@ import java.util.Set;
 
 import org.traccar.Context;
 import org.traccar.helper.Log;
+import org.traccar.model.Calendar;
 import org.traccar.model.Event;
 import org.traccar.model.Notification;
 import org.traccar.model.Position;
@@ -42,12 +44,16 @@ public class NotificationManager extends ExtendedObjectManager<Notification> {
         geocodeOnRequest = Context.getConfig().getBoolean("geocoder.onRequest");
     }
 
-    private Set<Long> getEffectiveNotifications(long userId, long deviceId) {
+    private Set<Long> getEffectiveNotifications(long userId, long deviceId, Date date) {
         Set<Long> result = new HashSet<>();
         Set<Long> deviceNotifications = getAllDeviceItems(deviceId);
         for (long itemId : getUserItems(userId)) {
             if (getById(itemId).getAlways() || deviceNotifications.contains(itemId)) {
-                result.add(itemId);
+                long calendarId = getById(itemId).getCalendarId();
+                Calendar calendar = calendarId != 0 ? Context.getCalendarManager().getById(calendarId) : null;
+                if (calendar == null || calendar.checkMoment(date)) {
+                    result.add(itemId);
+                }
             }
         }
         return result;
@@ -73,7 +79,7 @@ public class NotificationManager extends ExtendedObjectManager<Notification> {
                 boolean sentWeb = false;
                 boolean sentMail = false;
                 boolean sentSms = Context.getSmppManager() == null;
-                for (long notificationId : getEffectiveNotifications(userId, deviceId)) {
+                for (long notificationId : getEffectiveNotifications(userId, deviceId, event.getServerTime())) {
                     Notification notification = getById(notificationId);
                     if (getById(notificationId).getType().equals(event.getType())) {
                         if (!sentWeb && notification.getWeb()) {

--- a/src/org/traccar/database/NotificationManager.java
+++ b/src/org/traccar/database/NotificationManager.java
@@ -44,14 +44,14 @@ public class NotificationManager extends ExtendedObjectManager<Notification> {
         geocodeOnRequest = Context.getConfig().getBoolean("geocoder.onRequest");
     }
 
-    private Set<Long> getEffectiveNotifications(long userId, long deviceId, Date date) {
+    private Set<Long> getEffectiveNotifications(long userId, long deviceId, Date time) {
         Set<Long> result = new HashSet<>();
         Set<Long> deviceNotifications = getAllDeviceItems(deviceId);
         for (long itemId : getUserItems(userId)) {
             if (getById(itemId).getAlways() || deviceNotifications.contains(itemId)) {
                 long calendarId = getById(itemId).getCalendarId();
                 Calendar calendar = calendarId != 0 ? Context.getCalendarManager().getById(calendarId) : null;
-                if (calendar == null || calendar.checkMoment(date)) {
+                if (calendar == null || calendar.checkMoment(time)) {
                     result.add(itemId);
                 }
             }

--- a/src/org/traccar/model/Geofence.java
+++ b/src/org/traccar/model/Geofence.java
@@ -26,7 +26,7 @@ import org.traccar.geofence.GeofencePolyline;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-public class Geofence extends ExtendedModel {
+public class Geofence extends ScheduledModel {
 
     public static final String TYPE_GEOFENCE_CILCLE = "geofenceCircle";
     public static final String TYPE_GEOFENCE_POLYGON = "geofencePolygon";
@@ -86,15 +86,5 @@ public class Geofence extends ExtendedModel {
     public void setGeometry(GeofenceGeometry geometry) {
         area = geometry.toWkt();
         this.geometry = geometry;
-    }
-
-    private long calendarId;
-
-    public long getCalendarId() {
-        return calendarId;
-    }
-
-    public void setCalendarId(long calendarId) {
-        this.calendarId = calendarId;
     }
 }

--- a/src/org/traccar/model/Notification.java
+++ b/src/org/traccar/model/Notification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2016 - 2018 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.traccar.model;
 
-public class Notification extends ExtendedModel {
+public class Notification extends ScheduledModel {
 
     private boolean always;
 

--- a/src/org/traccar/model/ScheduledModel.java
+++ b/src/org/traccar/model/ScheduledModel.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Anton Tananaev (anton@traccar.org)
+ * Copyright 2018 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.model;
+
+public class ScheduledModel extends ExtendedModel {
+
+    private long calendarId;
+
+    public long getCalendarId() {
+        return calendarId;
+    }
+
+    public void setCalendarId(long calendarId) {
+        this.calendarId = calendarId;
+    }
+}


### PR DESCRIPTION
A calendar can be selected for a notification now. If it is selected, notification will be sent only in calendar period.

- Introduced `ScheduledModel` for objects with `calendarId` field
- Filter "effective" notifications by calendar
- Added permission check when add or update `ScheduledModel` objects (User should not be able select calendar he do not have access)
- Removing calendar can cause cascade clear of `calendarId` fields we should refresh geofences and notifications.