### PR TITLE
Improve incoming SMS handling

### DIFF
--- a/src/org/traccar/smpp/ClientSmppSessionHandler.java
+++ b/src/org/traccar/smpp/ClientSmppSessionHandler.java
@@ -25,6 +25,7 @@ import com.cloudhopper.smpp.impl.DefaultSmppSessionHandler;
 import com.cloudhopper.smpp.pdu.DeliverSm;
 import com.cloudhopper.smpp.pdu.PduRequest;
 import com.cloudhopper.smpp.pdu.PduResponse;
+import com.cloudhopper.smpp.util.SmppUtil;
 
 public class ClientSmppSessionHandler extends DefaultSmppSessionHandler {
 
@@ -44,16 +45,12 @@ public class ClientSmppSessionHandler extends DefaultSmppSessionHandler {
         PduResponse response = null;
         try {
             if (request instanceof DeliverSm) {
-                if (request.getOptionalParameters() != null) {
-                    Log.debug("SMS Message Delivered: "
-                            + request.getOptionalParameter(SmppConstants.TAG_RECEIPTED_MSG_ID).getValueAsString()
-                            + ", State: "
-                            + request.getOptionalParameter(SmppConstants.TAG_MSG_STATE).getValueAsByte());
-                } else {
-                    String sourceAddress = ((DeliverSm) request).getSourceAddress().getAddress();
-                    String message = CharsetUtil.decode(((DeliverSm) request).getShortMessage(),
-                            smppClient.mapDataCodingToCharset(((DeliverSm) request).getDataCoding()));
-                    Log.debug("SMS Message Received: " + message.trim() + ", Source Address: " + sourceAddress);
+                String sourceAddress = ((DeliverSm) request).getSourceAddress().getAddress();
+                String message = CharsetUtil.decode(((DeliverSm) request).getShortMessage(),
+                        smppClient.mapDataCodingToCharset(((DeliverSm) request).getDataCoding()));
+                Log.debug("SMS Message Received: " + message.trim() + ", Source Address: " + sourceAddress);
+
+                if (!SmppUtil.isMessageTypeAnyDeliveryReceipt(((DeliverSm) request).getEsmClass())) {
                     TextMessageEventHandler.handleTextMessage(sourceAddress, message);
                 }
             }

--- a/src/org/traccar/smpp/SmppClient.java
+++ b/src/org/traccar/smpp/SmppClient.java
@@ -61,6 +61,7 @@ public class SmppClient {
     private String sourceAddress;
     private String commandSourceAddress;
     private int submitTimeout;
+    private boolean requestDrl;
     private String notificationsCharsetName;
     private byte notificationsDataCoding;
     private String commandsCharsetName;
@@ -89,6 +90,8 @@ public class SmppClient {
         sourceAddress = Context.getConfig().getString("sms.smpp.sourceAddress", "");
         commandSourceAddress = Context.getConfig().getString("sms.smpp.commandSourceAddress", sourceAddress);
         submitTimeout = Context.getConfig().getInteger("sms.smpp.submitTimeout", 10000);
+
+        requestDrl = Context.getConfig().getBoolean("sms.smpp.requestDrl");
 
         notificationsCharsetName = Context.getConfig().getString("sms.smpp.notificationsCharset",
                 CharsetUtil.NAME_UCS_2);
@@ -209,6 +212,9 @@ public class SmppClient {
             byte[] textBytes;
             textBytes = CharsetUtil.encode(message, command ? commandsCharsetName : notificationsCharsetName);
             submit.setDataCoding(command ? commandsDataCoding : notificationsDataCoding);
+            if (requestDrl) {
+                submit.setRegisteredDelivery(SmppConstants.REGISTERED_DELIVERY_SMSC_RECEIPT_REQUESTED);
+            }
             submit.setShortMessage(textBytes);
             submit.setSourceAddress(command ? new Address(commandSourceTon, commandSourceNpi, commandSourceAddress)
                     : new Address(sourceTon, sourceNpi, sourceAddress));


### PR DESCRIPTION
- More correctly distinguish delivery reports from incoming messages
Inspired https://www.traccar.org/forums/topic/sms-receiving-problem-brazil/, looks like that SMSC reports some optional parameters with ordinary messages.
- Added optional `sms.smpp.requestDrl` parameter to enable request delivery reports for all outgoing SMS

Delivery reports contain all information as text, we can log it as other messages, just not fire event. Log example:
```
2018-01-24 12:38:55 DEBUG: SMS submitted, message id: f27322e5-6f88-49e5-8c4c-2ae9dedd8dfe
2018-01-24 12:39:29 DEBUG: SMS Message Received: id:f27322e5-6f88-49e5-8c4c-2ae9dedd8dfe sub:001 dlvrd:001 submit date:1801241238 done date:1801241239 stat:DELIVRD err:000 text:     Success, Source Address: +7922xxxxxxx
2018-01-24 12:41:33 DEBUG: SMS Message Received: Test incoming, Source Address: +7922xxxxxxx
```