### PR TITLE
Provide web access to media files received from devices

### DIFF
--- a/src/org/traccar/api/MediaFilter.java
+++ b/src/org/traccar/api/MediaFilter.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 Anton Tananaev (anton@traccar.org)
+ * Copyright 2018 Andrey Kunitsyn (andrey@traccar.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.traccar.api;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import javax.ws.rs.NotAuthorizedException;
+
+import org.traccar.Context;
+import org.traccar.api.resource.SessionResource;
+import org.traccar.helper.Log;
+import org.traccar.model.Device;
+
+public class MediaFilter implements Filter {
+
+    private boolean dirAllowed;
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        dirAllowed = Context.getConfig().getBoolean("media.dirAllowed");
+    }
+
+    private static void formatError(HttpServletResponse response, Exception e) throws IOException {
+        if (e instanceof SecurityException) {
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        } else if (e instanceof IllegalArgumentException) {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+        } else if (e instanceof NotAuthorizedException) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        } else {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        }
+        response.getWriter().println(Log.exceptionStack(e));
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        try {
+            HttpSession session = ((HttpServletRequest) request).getSession(false);
+            Long userId = null;
+            if (session != null) {
+                userId = (Long) session.getAttribute(SessionResource.USER_ID_KEY);
+                if (userId != null) {
+                    Context.getPermissionsManager().checkUserEnabled(userId);
+                    Context.getStatisticsManager().registerRequest(userId);
+                }
+            }
+            if (userId == null) {
+                throw new NotAuthorizedException("Not authorized");
+            }
+
+            String[] parts = ((HttpServletRequest) request).getPathInfo().split("/");
+            if (parts.length < 2) {
+                if (dirAllowed) {
+                    Context.getPermissionsManager().checkAdmin(userId);
+                } else {
+                    throw new SecurityException("Wrong path");
+                }
+            } else if (parts.length == 2 && !dirAllowed) {
+                throw new SecurityException("Wrong path");
+            } else {
+                Device device = Context.getIdentityManager().getByUniqueId(parts[1]);
+                if (device != null) {
+                    Context.getPermissionsManager().checkDevice(userId, device.getId());
+                } else {
+                    throw new IllegalArgumentException("Device not found");
+                }
+            }
+
+            chain.doFilter(request, response);
+        } catch (Exception e) {
+            formatError((HttpServletResponse) response, e);
+        }
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+}

--- a/src/org/traccar/api/MediaFilter.java
+++ b/src/org/traccar/api/MediaFilter.java
@@ -43,6 +43,7 @@ public class MediaFilter implements Filter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
+        HttpServletResponse httpResponse = ((HttpServletResponse) response);
         try {
             HttpSession session = ((HttpServletRequest) request).getSession(false);
             Long userId = null;
@@ -54,8 +55,7 @@ public class MediaFilter implements Filter {
                 }
             }
             if (userId == null) {
-                ((HttpServletResponse) response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                response.getWriter().println("Not authorized");
+                httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED);
                 return;
             }
 
@@ -68,19 +68,18 @@ public class MediaFilter implements Filter {
                 if (device != null) {
                     Context.getPermissionsManager().checkDevice(userId, device.getId());
                 } else {
-                    ((HttpServletResponse) response).setStatus(HttpServletResponse.SC_NOT_FOUND);
-                    response.getWriter().println("Device not found");
+                    httpResponse.sendError(HttpServletResponse.SC_NOT_FOUND);
                     return;
                 }
             }
 
             chain.doFilter(request, response);
         } catch (SecurityException e) {
-            ((HttpServletResponse) response).setStatus(HttpServletResponse.SC_FORBIDDEN);
-            response.getWriter().println(Log.exceptionStack(e));
+            httpResponse.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            httpResponse.getWriter().println(Log.exceptionStack(e));
         } catch (SQLException e) {
-            ((HttpServletResponse) response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
-            response.getWriter().println(Log.exceptionStack(e));
+            httpResponse.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            httpResponse.getWriter().println(Log.exceptionStack(e));
         }
     }
 

--- a/src/org/traccar/protocol/Gt06ProtocolDecoder.java
+++ b/src/org/traccar/protocol/Gt06ProtocolDecoder.java
@@ -704,7 +704,8 @@ public class Gt06ProtocolDecoder extends BaseProtocolDecoder {
                 sendPhotoRequest(channel, pictureId);
             } else {
                 Device device = Context.getDeviceManager().getById(deviceSession.getDeviceId());
-                Context.getMediaManager().writeFile(device.getUniqueId(), photo, "jpg");
+                position.set(
+                        Position.KEY_IMAGE, Context.getMediaManager().writeFile(device.getUniqueId(), photo, "jpg"));
                 photos.remove(pictureId);
             }
 


### PR DESCRIPTION
There is a switch `media.dirAllowed` to allow access directories. Admin can enumerate root directory, users only device directories they have access.

![image](https://user-images.githubusercontent.com/5688080/35671023-f405215c-075b-11e8-870d-415f10adbe3b.png)

- Added `DefaultServlet` to serve folder with media files as static content
- Added filter to check access to device

fix #3688 

More comments in code...