### PR TITLE
Unified Device timezone handling

### DIFF
--- a/src/org/traccar/BaseProtocolDecoder.java
+++ b/src/org/traccar/BaseProtocolDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 - 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2012 - 2018 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TimeZone;
 import java.sql.SQLException;
 
 public abstract class BaseProtocolDecoder extends ExtendedObjectDecoder {
@@ -79,6 +80,25 @@ public abstract class BaseProtocolDecoder extends ExtendedObjectDecoder {
             default:
                 return value;
         }
+    }
+
+    protected TimeZone getTimeZone(long deviceId) {
+        TimeZone result = TimeZone.getTimeZone("UTC");
+        String timeZoneName = null;
+        if (Context.getDeviceManager() != null) {
+            timeZoneName = Context.getDeviceManager().lookupAttributeString(
+                    deviceId, "decoder.timezone", null, true);
+        }
+        if (timeZoneName != null) {
+            result = TimeZone.getTimeZone(timeZoneName);
+        } else {
+            int timeZoneOffset = Context.getConfig().getInteger(getProtocolName() + ".timezone", 0);
+            if (timeZoneOffset != 0) {
+                result.setRawOffset(timeZoneOffset * 1000);
+                Log.warning("Config parameter " + getProtocolName() + ".timezone is deprecated");
+            }
+        }
+        return result;
     }
 
     private DeviceSession channelDeviceSession; // connection-based protocols

--- a/src/org/traccar/DeviceSession.java
+++ b/src/org/traccar/DeviceSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2016 - 2018 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 package org.traccar;
 
+import java.util.TimeZone;
+
 public class DeviceSession {
 
     private final long deviceId;
@@ -25,6 +27,16 @@ public class DeviceSession {
 
     public long getDeviceId() {
         return deviceId;
+    }
+
+    private TimeZone timeZone;
+
+    public void setTimeZone(TimeZone timeZone) {
+        this.timeZone = timeZone;
+    }
+
+    public TimeZone getTimeZone() {
+        return timeZone;
     }
 
 }

--- a/src/org/traccar/WebDataHandler.java
+++ b/src/org/traccar/WebDataHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 - 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2015 - 2018 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -148,9 +148,7 @@ public class WebDataHandler extends BaseDataHandler {
         Map<String, Object> data = new HashMap<>();
         Device device = Context.getIdentityManager().getById(position.getDeviceId());
 
-        if (position != null) {
-            data.put(KEY_POSITION, position);
-        }
+        data.put(KEY_POSITION, position);
 
         if (device != null) {
             data.put(KEY_DEVICE, device);

--- a/src/org/traccar/notification/EventForwarder.java
+++ b/src/org/traccar/notification/EventForwarder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Anton Tananaev (anton@traccar.org)
+ * Copyright 2016 - 2018 Anton Tananaev (anton@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,11 +85,9 @@ public abstract class EventForwarder {
         if (position != null) {
             data.put(KEY_POSITION, position);
         }
-        if (event.getDeviceId() != 0) {
-            Device device = Context.getIdentityManager().getById(event.getDeviceId());
-            if (device != null) {
-                data.put(KEY_DEVICE, device);
-            }
+        Device device = Context.getIdentityManager().getById(event.getDeviceId());
+        if (device != null) {
+            data.put(KEY_DEVICE, device);
         }
         if (event.getGeofenceId() != 0) {
             Geofence geofence = Context.getGeofenceManager().getById(event.getGeofenceId());


### PR DESCRIPTION
Added `timeZone` field to `DeviceSession`
- It might be initialized once on login message and used in all next packets
- It might be initialized once on device session creation to not lookup all tree on every position. But to apply timezone changes device has to reconnect.

Also removed unnecessary checks in forwarders

fix #3572 