### PR TITLE
To use formatted address directly instead of creating address.

### DIFF
--- a/src/org/traccar/geocoder/Address.java
+++ b/src/org/traccar/geocoder/Address.java
@@ -97,4 +97,14 @@ public class Address {
         this.house = house;
     }
 
+    private String formattedAddress;
+
+    public String getFormattedAddress() {
+        return formattedAddress;
+    }
+
+    public void setFormattedAddress(String formattedAddress) {
+        this.formattedAddress = formattedAddress;
+    }
+
 }

--- a/src/org/traccar/geocoder/AddressFormat.java
+++ b/src/org/traccar/geocoder/AddressFormat.java
@@ -66,6 +66,7 @@ public class AddressFormat extends Format {
         result = replace(result, "%u", address.getSuburb());
         result = replace(result, "%r", address.getStreet());
         result = replace(result, "%h", address.getHouse());
+        result = replace(result, "%f", address.getFormattedAddress());
 
         result = result.replaceAll("^[, ]*", "");
 

--- a/src/org/traccar/geocoder/BingMapsGeocoder.java
+++ b/src/org/traccar/geocoder/BingMapsGeocoder.java
@@ -51,6 +51,9 @@ public class BingMapsGeocoder extends JsonGeocoder {
                 if (location.containsKey("postalCode")) {
                     address.setPostcode(location.getString("postalCode"));
                 }
+                if (location.containsKey("formattedAddress")) {
+                    address.setFormattedAddress(location.getString("formattedAddress"));
+                }
                 return address;
             }
         }

--- a/src/org/traccar/geocoder/GeocodeFarmGeocoder.java
+++ b/src/org/traccar/geocoder/GeocodeFarmGeocoder.java
@@ -41,23 +41,27 @@ public class GeocodeFarmGeocoder extends JsonGeocoder {
         JsonObject result = json
                 .getJsonObject("geocoding_results")
                 .getJsonArray("RESULTS")
-                .getJsonObject(0)
-                .getJsonObject("ADDRESS");
+                .getJsonObject(0);
 
-        if (result.containsKey("street_number")) {
-            address.setStreet(result.getString("street_number"));
+        JsonObject resultAddress = result.getJsonObject("ADDRESS");
+
+        if (result.containsKey("formatted_address")) {
+            address.setFormattedAddress(result.getString("formatted_address"));
         }
-        if (result.containsKey("street_name")) {
-            address.setStreet(result.getString("street_name"));
+        if (resultAddress.containsKey("street_number")) {
+            address.setStreet(resultAddress.getString("street_number"));
         }
-        if (result.containsKey("locality")) {
-            address.setSettlement(result.getString("locality"));
+        if (resultAddress.containsKey("street_name")) {
+            address.setStreet(resultAddress.getString("street_name"));
         }
-        if (result.containsKey("admin_1")) {
-            address.setState(result.getString("admin_1"));
+        if (resultAddress.containsKey("locality")) {
+            address.setSettlement(resultAddress.getString("locality"));
         }
-        if (result.containsKey("country")) {
-            address.setCountry(result.getString("country"));
+        if (resultAddress.containsKey("admin_1")) {
+            address.setState(resultAddress.getString("admin_1"));
+        }
+        if (resultAddress.containsKey("country")) {
+            address.setCountry(resultAddress.getString("country"));
         }
 
         return address;

--- a/src/org/traccar/geocoder/GisgraphyGeocoder.java
+++ b/src/org/traccar/geocoder/GisgraphyGeocoder.java
@@ -45,6 +45,9 @@ public class GisgraphyGeocoder extends JsonGeocoder {
         if (result.containsKey("countryCode")) {
             address.setCountry(result.getString("countryCode"));
         }
+        if (result.containsKey("formatedFull")) {
+            address.setFormattedAddress(result.getString("formatedFull"));
+        }
 
         return address;
     }

--- a/src/org/traccar/geocoder/GoogleGeocoder.java
+++ b/src/org/traccar/geocoder/GoogleGeocoder.java
@@ -46,6 +46,10 @@ public class GoogleGeocoder extends JsonGeocoder {
             JsonObject result = (JsonObject) results.get(0);
             JsonArray components = result.getJsonArray("address_components");
 
+            if (result.containsKey("formatted_address")) {
+                address.setFormattedAddress(result.getString("formatted_address"));
+            }
+
             for (JsonObject component : components.getValuesAs(JsonObject.class)) {
 
                 String value = component.getString("short_name");

--- a/src/org/traccar/geocoder/NominatimGeocoder.java
+++ b/src/org/traccar/geocoder/NominatimGeocoder.java
@@ -44,6 +44,11 @@ public class NominatimGeocoder extends JsonGeocoder {
         if (result != null) {
             Address address = new Address();
 
+
+            if (json.containsKey("display_name")) {
+                address.setFormattedAddress(json.getString("display_name"));
+            }
+
             if (result.containsKey("house_number")) {
                 address.setHouse(result.getString("house_number"));
             }

--- a/src/org/traccar/geocoder/OpenCageGeocoder.java
+++ b/src/org/traccar/geocoder/OpenCageGeocoder.java
@@ -33,6 +33,9 @@ public class OpenCageGeocoder extends JsonGeocoder {
             if (location != null) {
                 Address address = new Address();
 
+                if (result.getJsonObject(0).containsKey("formatted")) {
+                    address.setFormattedAddress(result.getJsonObject(0).getString("formatted"));
+                }
                 if (location.containsKey("building")) {
                     address.setHouse(location.getString("building"));
                 }


### PR DESCRIPTION
Most of the reverse geocoder api's provide formatted address with all the details.
This change can help users to use formatted address. As Nominatim address are not proper in address details, this can help to use formatted address directly.

Nominatim Sample:
```json
{
    "place_id": "439734",
    "licence": "Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright",
    "osm_type": "way",
    "osm_id": "77643464",
    "lat": "28.6454569",
    "lon": "77.0690221",
    **"display_name": "Vikaspuri, West Delhi, Delhi, 110041, India",**
    "address": {
        "city_district": "Vikaspuri",
        "county": "West Delhi",
        "state": "Delhi",
        "postcode": "110041",
        "country": "India",
        "country_code": "in"
    },
    "namedetails": {},
    "boundingbox": [
        "28.6348108",
        "28.649576",
        "77.0606304",
        "77.0833674"
    ]
}
```
Gisgraphy:
```json
{
    "numFound": 1,
    "QTime": 5,
    "attributions": "http://www.gisgraphy.com/attributions.html",
    "result": [
        {
            "id": 155037642,
            "lng": 77.08337099196132,
            "lat": 28.643237603566753,
            "streetName": "Outer Ring Road",
            "zipCode": "110003",
            "city": "New Delhi",
            "state": "Delhi",
            "countryCode": "IN",
            "geocodingLevel": "STREET",
            "distance": 854.6305702252499,
            "adm1Name": "Delhi",
            **"formatedFull": "Outer Ring Road, New Delhi, Delhi,  (110003), India",**
            "formatedPostal": "Outer Ring Road, New Delhi 110003",
            "surface": "asphalt",
            "azimuthStart": 334,
            "azimuthEnd": 35,
            "length": 2580.944740079,
            "oneWay": true,
            "sourceId": 263456933
        }
    ]
}
```