### PR TITLE
Cycle in group hierarchy bug fix while editing Groups

### DIFF
--- a/src/org/traccar/database/GroupsManager.java
+++ b/src/org/traccar/database/GroupsManager.java
@@ -78,7 +78,8 @@ public class GroupsManager extends BaseObjectManager<Group> implements Managable
     @Override
     public void updateItem(Group group) throws SQLException {
         checkGroupCycles(group);
-        super.updateItem(group);
+        getDataManager().updateObject(group);
+        super.updateCachedItem(group);
     }
 
     @Override

--- a/src/org/traccar/database/GroupsManager.java
+++ b/src/org/traccar/database/GroupsManager.java
@@ -78,14 +78,7 @@ public class GroupsManager extends BaseObjectManager<Group> implements Managable
     @Override
     public void updateItem(Group group) throws SQLException {
         checkGroupCycles(group);
-        getDataManager().updateObject(group);
-        super.updateCachedItem(group);
-    }
-
-    @Override
-    protected void updateCachedItem(Group group) {
-        checkGroupCycles(group);
-        super.updateCachedItem(group);
+        super.updateItem(group);
     }
 
     @Override

--- a/src/org/traccar/database/GroupsManager.java
+++ b/src/org/traccar/database/GroupsManager.java
@@ -76,6 +76,12 @@ public class GroupsManager extends BaseObjectManager<Group> implements Managable
     }
 
     @Override
+    public void updateItem(Group group) throws SQLException {
+        checkGroupCycles(group);
+        super.updateItem(group);
+    }
+
+    @Override
     protected void updateCachedItem(Group group) {
         checkGroupCycles(group);
         super.updateCachedItem(group);


### PR DESCRIPTION
Cycle in group hierarchy check only works during cache update but not checking at the time of entry updation into the DB.