### PR TITLE
Add user objects to Event forward payload

### DIFF
--- a/src/org/traccar/database/NotificationManager.java
+++ b/src/org/traccar/database/NotificationManager.java
@@ -73,9 +73,16 @@ public class NotificationManager extends ExtendedObjectManager<Notification> {
 
         long deviceId = event.getDeviceId();
         Set<Long> users = Context.getPermissionsManager().getDeviceUsers(deviceId);
+        Set<Long> usersToForward = null;
+        if (Context.getEventForwarder() != null) {
+            usersToForward = new HashSet<>();
+        }
         for (long userId : users) {
             if (event.getGeofenceId() == 0 || Context.getGeofenceManager() != null
                     && Context.getGeofenceManager().checkItemPermission(userId, event.getGeofenceId())) {
+                if (usersToForward != null) {
+                    usersToForward.add(userId);
+                }
                 boolean sentWeb = false;
                 boolean sentMail = false;
                 boolean sentSms = Context.getSmppManager() == null;
@@ -102,7 +109,7 @@ public class NotificationManager extends ExtendedObjectManager<Notification> {
             }
         }
         if (Context.getEventForwarder() != null) {
-            Context.getEventForwarder().forwardEvent(event, position);
+            Context.getEventForwarder().forwardEvent(event, position, usersToForward);
         }
     }
 

--- a/src/org/traccar/notification/EventForwarder.java
+++ b/src/org/traccar/notification/EventForwarder.java
@@ -30,6 +30,8 @@ import org.traccar.model.Position;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+
 import com.ning.http.client.FluentCaseInsensitiveStringsMap;
 
 public abstract class EventForwarder {
@@ -46,8 +48,9 @@ public abstract class EventForwarder {
     private static final String KEY_EVENT = "event";
     private static final String KEY_GEOFENCE = "geofence";
     private static final String KEY_DEVICE = "device";
+    private static final String KEY_USERS = "users";
 
-    public final void forwardEvent(Event event, Position position) {
+    public final void forwardEvent(Event event, Position position, Set<Long> users) {
 
         BoundRequestBuilder requestBuilder = Context.getAsyncHttpClient().preparePost(url);
         requestBuilder.setBodyEncoding(StandardCharsets.UTF_8.name());
@@ -60,7 +63,7 @@ public abstract class EventForwarder {
             requestBuilder.setHeaders(params);
         }
 
-        setContent(event, position, requestBuilder);
+        setContent(event, position, users, requestBuilder);
         requestBuilder.execute();
     }
 
@@ -79,7 +82,7 @@ public abstract class EventForwarder {
         return paramsMap;
     }
 
-    protected String prepareJsonPayload(Event event, Position position) {
+    protected String prepareJsonPayload(Event event, Position position, Set<Long> users) {
         Map<String, Object> data = new HashMap<>();
         data.put(KEY_EVENT, event);
         if (position != null) {
@@ -95,6 +98,7 @@ public abstract class EventForwarder {
                 data.put(KEY_GEOFENCE, geofence);
             }
         }
+        data.put(KEY_USERS, Context.getUsersManager().getItems(users));
         try {
             return Context.getObjectMapper().writeValueAsString(data);
         } catch (JsonProcessingException e) {
@@ -104,6 +108,7 @@ public abstract class EventForwarder {
     }
 
     protected abstract String getContentType();
-    protected abstract void setContent(Event event, Position position, BoundRequestBuilder requestBuilder);
+    protected abstract void setContent(
+            Event event, Position position, Set<Long> users, BoundRequestBuilder requestBuilder);
 
 }

--- a/src/org/traccar/notification/JsonTypeEventForwarder.java
+++ b/src/org/traccar/notification/JsonTypeEventForwarder.java
@@ -1,5 +1,7 @@
 package org.traccar.notification;
 
+import java.util.Set;
+
 import org.traccar.model.Event;
 import org.traccar.model.Position;
 
@@ -13,8 +15,8 @@ public class JsonTypeEventForwarder extends EventForwarder {
     }
 
     @Override
-    protected void setContent(Event event, Position position, BoundRequestBuilder requestBuilder) {
-        requestBuilder.setBody(prepareJsonPayload(event, position));
+    protected void setContent(Event event, Position position, Set<Long> users, BoundRequestBuilder requestBuilder) {
+        requestBuilder.setBody(prepareJsonPayload(event, position, users));
     }
 
 }

--- a/src/org/traccar/notification/MultiPartEventForwarder.java
+++ b/src/org/traccar/notification/MultiPartEventForwarder.java
@@ -3,6 +3,7 @@ package org.traccar.notification;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.Map.Entry;
 
 import org.traccar.Context;
@@ -28,7 +29,7 @@ public class MultiPartEventForwarder extends EventForwarder {
     }
 
     @Override
-    protected void setContent(Event event, Position position, BoundRequestBuilder requestBuilder) {
+    protected void setContent(Event event, Position position, Set<Long> users, BoundRequestBuilder requestBuilder) {
 
         if (additionalParams != null && !additionalParams.isEmpty()) {
             Map<String, List<String>> paramsToAdd = splitIntoKeyValues(additionalParams, "=");
@@ -41,6 +42,6 @@ public class MultiPartEventForwarder extends EventForwarder {
             }
         }
         requestBuilder.addBodyPart(new StringPart(payloadParamName,
-                prepareJsonPayload(event, position), "application/json", StandardCharsets.UTF_8));
+                prepareJsonPayload(event, position, users), "application/json", StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
This change will allow to make traccar integration a bit more simpler 
The set of users is the same as traccar uses to notify about forwarded Event.

fix #3814 