### PR TITLE
Add support for long SMS sending

### DIFF
--- a/src/org/traccar/smpp/SmppClient.java
+++ b/src/org/traccar/smpp/SmppClient.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2017 Anton Tananaev (anton@traccar.org)
- * Copyright 2017 Andrey Kunitsyn (andrey@traccar.org)
+ * Copyright 2017 - 2018 Anton Tananaev (anton@traccar.org)
+ * Copyright 2017 - 2018 Andrey Kunitsyn (andrey@traccar.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import com.cloudhopper.smpp.impl.DefaultSmppClient;
 import com.cloudhopper.smpp.impl.DefaultSmppSessionHandler;
 import com.cloudhopper.smpp.pdu.SubmitSm;
 import com.cloudhopper.smpp.pdu.SubmitSmResp;
+import com.cloudhopper.smpp.tlv.Tlv;
 import com.cloudhopper.smpp.type.Address;
 import com.cloudhopper.smpp.type.RecoverablePduException;
 import com.cloudhopper.smpp.type.SmppChannelException;
@@ -222,7 +223,13 @@ public class SmppClient {
             if (requestDlr) {
                 submit.setRegisteredDelivery(SmppConstants.REGISTERED_DELIVERY_SMSC_RECEIPT_REQUESTED);
             }
-            submit.setShortMessage(textBytes);
+
+            if (textBytes != null && textBytes.length > 255) {
+                submit.addOptionalParameter(new Tlv(SmppConstants.TAG_MESSAGE_PAYLOAD, textBytes, "message_payload"));
+            } else {
+                submit.setShortMessage(textBytes);
+            }
+
             submit.setSourceAddress(command ? new Address(commandSourceTon, commandSourceNpi, commandSourceAddress)
                     : new Address(sourceTon, sourceNpi, sourceAddress));
             submit.setDestAddress(new Address(destTon, destNpi, destAddress));


### PR DESCRIPTION
Send long messages as "message_payload". It should be supported by most current SMSCs.
Implementing true "MultiSubmitSm" will over-complicate code and I believe really not necessary nowadays.

Tested with my kannel test smpp.

fix #3818 